### PR TITLE
Update CAM_Convection_YOG to cesm3_0_alpha09e (CAM cam6_4_186)

### DIFF
--- a/CAM_Convection_YOG/README.md
+++ b/CAM_Convection_YOG/README.md
@@ -21,20 +21,23 @@ FTorch_CAM_integration/
 │       ├── yog_intr.F90
 │       ├── nn_interface_CAM.F90
 │       ├── nn_convection_flux.F90
-│       └── nn_cf_net.F90
+│       ├── nn_cf_net.F90
+│       └── SAM_consts.F90
 │
 ├── libraries/
 │   └── FTorch/
+│       ├── CMakeLists.txt
+│       ├── buildlib
 │       └── FTorch_cesm_interface.F90   # Wrapper for FTorch model calls
 │
+├── bld/
+│   └── namelist_files/
+│       ├── namelist_defaults_cam.xml
+│       └── namelist_definition.xml
+│
 ├── docs/
-│   ├── build_instructions.md
-│   └── troubleshooting.md
+│   └── build_instructions.md
 │
-├── examples/
-│   └── user_nl_cam
-│
-├── MODEL_CARD.md
 └── README.md
 
 ```
@@ -43,7 +46,8 @@ FTorch_CAM_integration/
 
 ## Prerequisites
 
-- CESM 3.0 (tested with `cesm3_0_alpha07f`)
+- CESM 3.0 (tested with `cesm3_0_alpha07f`; files in this folder are currently
+  from `cesm3_0_alpha09e`, base CAM tag `cam6_4_186`)
 - FTorch (Fortran interface to PyTorch)
 
 ## Overview of Integration
@@ -326,6 +330,66 @@ Add to your CESM namelist file:
    - Grid spacing information
 
 
+
+## Porting to a New CESM Tag
+
+`physpkg.F90` changes frequently upstream, so the YOG hook's insertion point may
+need a manual merge when moving to a newer CAM tag. Example from the
+`cam6_4_126` → `cam6_4_186` port: upstream removed a dead `rice`
+(reserved-ice) energy-check variable in the exact spot the YOG call was
+inserted (commit `d071951d "Remove rice from physpkg"`). The fix was to drop
+the `rice` lines (they were always zero, a no-op) and keep only the
+YOG-relevant block:
+
+```fortran
+flx_cnd(:ncol) = prec_dp(:ncol) + rliq(:ncol)
+if (yog_scheme=='on') then
+    call t_startf('yog_nn')
+    call yog_tend(ztodt, state, ptend, pbuf, cam_in%landfrac)
+    call physics_update(state, ptend, ztodt, tend)
+    call t_stopf('yog_nn')
+    flx_cnd(:ncol) = prec_dp(:ncol)
+    call check_energy_cam_chng(state, tend, "yog_nn", nstep, ztodt, zero, flx_cnd, zero, flx_heat)
+end if
+call check_energy_cam_chng(state, tend, "convect_deep", nstep, ztodt, zero, flx_cnd, snow_dp, zero)
+```
+
+Diff the target tag's `physpkg.F90` against the version here to find the
+current equivalent location if this exact context no longer matches.
+
+## Build Gotchas (found porting to `cesm3_0_alpha09e` on Derecho)
+
+- **`USE_FTORCH` defaults to `FALSE`.** Set it explicitly before building:
+  `./xmlchange USE_FTORCH=TRUE`, then `./case.build --clean-all && ./case.build`
+  (any `env_build.xml` change requires a clean rebuild).
+- **Nested FTorch submodule may not auto-initialize.** `libraries/FTorch/src`
+  (the actual Cambridge-ICCS FTorch checkout, nested inside the `FTorch`
+  submodule) can end up empty or with a dangling gitlink depending on how the
+  CESM checkout was created. Fix with `git submodule update --init src` from
+  inside `libraries/FTorch` (delete and reclone `src` first if it already has
+  a broken/dangling `.git` file pointing at a missing `.git/modules` path).
+- **CMake/Catamount shared-library build failure**, seen after Derecho's
+  default module stack moved from `24.12` to `25.10` (newer CMake, ~3.31 vs
+  ~3.26): FTorch's `find_package(Torch)` fails with
+  `ADD_LIBRARY called with SHARED option but the target platform does not
+  support dynamic linking`, because CIME's `Tools/Makefile` sets
+  `-DCMAKE_SYSTEM_NAME=Catamount` for Cray builds, and newer CMake enforces
+  that platform's "no shared libraries" rule even for `IMPORTED SHARED`
+  targets referencing an already-built `libtorch_cpu.so`. Fixed in
+  `libraries/FTorch/buildlib` by appending `-DCMAKE_SYSTEM_NAME=Linux` to
+  `USER_CMAKE_OPTS` (it's placed after CIME's own `-DCMAKE_SYSTEM_NAME=Catamount`
+  on the cmake command line, so it wins) — scoped to FTorch's own build only,
+  no other component is affected. Not yet reported upstream to
+  `ESCOMP/FTorch_interface`; other users hitting this on the current Derecho
+  stack should expect the same failure.
+- **`yog_lat_max` defaults to 30°** (tropical-only, matching the NN's SAM
+  training domain). A prior test that forced it to 90° (global, no
+  restriction) crashed CLUBB around simulated day 26 — the NN extrapolates
+  badly at high latitude/cold columns. Leave this at the code default unless
+  deliberately testing that failure mode.
+
+Tested with a 1-day `F2000climo`/`f09_f09_mg17` smoke test on Derecho —
+scheme initializes, runs, and completes cleanly.
 
 ## References
 

--- a/CAM_Convection_YOG/bld/namelist_files/namelist_defaults_cam.xml
+++ b/CAM_Convection_YOG/bld/namelist_files/namelist_defaults_cam.xml
@@ -25,6 +25,8 @@
 <dtime dyn="se"    hgrid="ne0np4CONUS.ne30x8">225</dtime>
 <dtime dyn="se"    hgrid="ne0np4.ARCTIC.ne30x4">450</dtime>
 <dtime dyn="se"    hgrid="ne0np4.ARCTICGRIS.ne30x8">225</dtime>
+<dtime dyn="se"    hgrid="ne0np4.POLARCAP.ne30x4">450</dtime>
+<dtime dyn="se"    hgrid="ne0np4.NATL.ne30x8">225</dtime>
 
 <dtime dyn="mpas"                  >1800</dtime>
 
@@ -37,6 +39,7 @@
 <ncdata nlev="58" analytic_ic="1" >atm/cam/inic/cam_vcoords_L58_c250227.nc</ncdata>
 
 <!-- Vertical/Horizontal coordinates only - MPAS initial files for analytic cases-->
+<ncdata hgrid="mpasa120" nlev="26" analytic_ic="1" >atm/cam/inic/mpas/mpasa120_L26_notopo_coords_c251105.nc</ncdata>
 <ncdata hgrid="mpasa480" nlev="32" analytic_ic="1" >atm/cam/inic/mpas/mpasa480_L32_notopo_coords_c240507.nc</ncdata>
 <ncdata hgrid="mpasa120" nlev="32" analytic_ic="1" >atm/cam/inic/mpas/mpasa120_L32_notopo_coords_c240507.nc</ncdata>
 <ncdata hgrid="mpasa60"  nlev="32" analytic_ic="1" >atm/cam/inic/mpas/mpasa60_L32_notopo_coords_c240507.nc</ncdata>
@@ -61,10 +64,10 @@
 <ncdata hgrid="10x15" nlev="30" aquaplanet="1"     >atm/cam/inic/fv/aqua_0000-01-01_10x15_L30_c170103.nc</ncdata>
 <ncdata hgrid="10x15" nlev="30" chem="trop_mozart" >atm/cam/inic/fv/camchemi_0012-01-01_10x15_L30_c081104.nc</ncdata>
 <ncdata hgrid="10x15" nlev="30" chem="trop_strat_mam4_vbs" >atm/cam/inic/fv/trop_strat_mam3_chem_2000-01-01_10x15_L30_c121015.nc</ncdata>
-<ncdata hgrid="10x15" nlev="30" chem="trop_strat_mam5_vbs" >atm/cam/inic/fv/trop_strat_mam3_chem_2000-01-01_10x15_L30_c121015.nc</ncdata>
+<ncdata hgrid="10x15" nlev="30" chem="trop_strat_mam5_t1s1" >atm/cam/inic/fv/trop_strat_mam3_chem_2000-01-01_10x15_L30_c121015.nc</ncdata>
 <ncdata hgrid="10x15" nlev="32"                    >atm/cam/inic/fv/cami-mam4_0000-01-01_10x15_L32_c170914.nc</ncdata>
 <ncdata hgrid="10x15" nlev="32" aquaplanet="1"     >atm/cam/inic/fv/aqua_0000-01-01_10x15_L32_c170103.nc</ncdata>
-<ncdata hgrid="10x15" nlev="32" chem="trop_strat_mam5_vbs">atm/cam/inic/fv/FC2000mam5_f10_0002-01-01_c221214.nc</ncdata>
+<ncdata hgrid="10x15" nlev="32" chem="trop_strat_mam5_t1s1">atm/cam/inic/fv/FC2000mam5_f10_0002-01-01_c221214.nc</ncdata>
 <ncdata hgrid="10x15" nlev="32" carma="trop_strat_soa5"   >atm/cam/inic/fv/carma_trop_strat_2000_10x15_spinup01.cam.i.0002-01-01-00000_c211027.nc</ncdata>
 <ncdata hgrid="10x15" nlev="32" carma="trop_strat_soa5" aquaplanet="1">atm/cam/inic/fv/aqua_carma_trop_strat_10x15_spinup01.cam.i.0002-01-01-00000_c211027.nc</ncdata>
 <ncdata hgrid="10x15" nlev="66"                    >atm/waccm/ic/cami_2000-01-01_10x15_L66_c041121.nc</ncdata>
@@ -78,7 +81,7 @@
 <ncdata hgrid="4x5" nlev="30"                      >atm/cam/inic/fv/cami_0000-01-01_4x5_L30_c090108.nc</ncdata>
 <ncdata hgrid="4x5" nlev="30" chem="trop_mozart"   >atm/cam/inic/fv/camchemi_0012-01-01_4x5_L30_c081104.nc</ncdata>
 <ncdata hgrid="4x5" nlev="30" chem="trop_strat_mam4_vbs" >atm/cam/inic/fv/trop_strat_mam3_chem_2000-01-01_4x5_L30_c121015.nc</ncdata>
-<ncdata hgrid="4x5" nlev="30" chem="trop_strat_mam5_vbs" >atm/cam/inic/fv/trop_strat_mam3_chem_2000-01-01_4x5_L30_c121015.nc</ncdata>
+<ncdata hgrid="4x5" nlev="30" chem="trop_strat_mam5_t1s1" >atm/cam/inic/fv/trop_strat_mam3_chem_2000-01-01_4x5_L30_c121015.nc</ncdata>
 <ncdata hgrid="4x5" nlev="66"                      >atm/waccm/ic/wa3_4x5_1950_spinup.cam2.i.1960-01-01-00000.nc</ncdata>
 <ncdata hgrid="4x5" nlev="66"  chem="waccm_ma_sulfur" >atm/waccm/ic/f40.2000.4deg.wcm.carma.sulf.004.cam2.i.0008-01-01-00000.nc</ncdata>
 <ncdata hgrid="4x5" nlev="70"                      >atm/waccm/ic/f2000.waccm-mam3_4x5_L70.cam2.i.0017-01-01.c121113.nc</ncdata>
@@ -100,7 +103,7 @@
 <ncdata hgrid="1.9x2.5" nlev="30" ic_ymd="901"     >atm/cam/inic/fv/cami_0000-09-01_1.9x2.5_L30_c070109.nc</ncdata>
 <ncdata hgrid="1.9x2.5" nlev="30" aquaplanet="1"   >atm/cam/inic/fv/aqua_0006-01-01_1.9x2.5_L30_c161020.nc</ncdata>
 <ncdata hgrid="1.9x2.5" nlev="30" chem="trop_strat_mam4_vbs" >atm/cam/inic/fv/trop_strat_mam3_chem_2000-01-01_1.9x2.5_L30_c121015.nc</ncdata>
-<ncdata hgrid="1.9x2.5" nlev="30" chem="trop_strat_mam5_vbs" >atm/cam/inic/fv/trop_strat_mam3_chem_2000-01-01_1.9x2.5_L30_c121015.nc</ncdata>
+<ncdata hgrid="1.9x2.5" nlev="30" chem="trop_strat_mam5_t1s1" >atm/cam/inic/fv/trop_strat_mam3_chem_2000-01-01_1.9x2.5_L30_c121015.nc</ncdata>
 <ncdata hgrid="1.9x2.5" nlev="30" chem="trop_mozart"                   >atm/cam/inic/fv/camchemi_0012-01-01_1.9x2.5_L30_c081104.nc</ncdata>
 <ncdata hgrid="1.9x2.5" nlev="30" chem="trop_mozart" ic_ymd="19900101" >atm/cam/inic/fv/cami-chem_1990-01-01_1.9x2.5_L30_c080215.nc</ncdata>
 <ncdata hgrid="1.9x2.5" nlev="32"                  >atm/cam/inic/fv/cami-mam3_0000-01-01_1.9x2.5_L32_c150407.nc</ncdata>
@@ -131,8 +134,8 @@
 <ncdata hgrid="0.9x1.25" nlev="32" aquaplanet="1"  >atm/cam/inic/fv/aqua_0006-01-01_0.9x1.25_L32_c161020.nc</ncdata>
 <ncdata hgrid="0.9x1.25" nlev="32" chem="trop_strat_mam4_vbs">atm/cam/inic/fv/f.e22.FC2010climo.f09_f09_mg17.cam6_2_022.001.cam.i.0016-01-01-00000_c200610.nc</ncdata>
 <ncdata hgrid="0.9x1.25" nlev="32" chem="trop_strat_mam4_ts2">atm/cam/inic/fv/f.e22.FC2010climo.f09_f09_mg17.cam6_2_022.001.cam.i.0016-01-01-00000_c200610.nc</ncdata>
-<ncdata hgrid="0.9x1.25" nlev="32" chem="trop_strat_mam5_vbs">atm/cam/inic/fv/f.e22.FC2010climo.f09_f09_mg17.cam6_2_022.001.cam.i.0016-01-01-00000_c200610.nc</ncdata>
-<ncdata hgrid="0.9x1.25" nlev="32" chem="trop_strat_mam5_ts2">atm/cam/inic/fv/f.e22.FC2010climo.f09_f09_mg17.cam6_2_022.001.cam.i.0016-01-01-00000_c200610.nc</ncdata>
+<ncdata hgrid="0.9x1.25" nlev="32" chem="trop_strat_mam5_t1s1">atm/cam/inic/fv/f.e22.FC2010climo.f09_f09_mg17.cam6_2_022.001.cam.i.0016-01-01-00000_c200610.nc</ncdata>
+<ncdata hgrid="0.9x1.25" nlev="32" chem="trop_strat_mam5_t2s1">atm/cam/inic/fv/f.e22.FC2010climo.f09_f09_mg17.cam6_2_022.001.cam.i.0016-01-01-00000_c200610.nc</ncdata>
 <ncdata hgrid="0.9x1.25" nlev="66"                 >atm/waccm/ic/cami_2000-02-01_0.9x1.25_L66_c040928.nc</ncdata>
 <ncdata hgrid="0.9x1.25" nlev="70"                 >atm/waccm/ic/FWT2000_f09_spinup01.cam.i.0001-01-02-00000_c160315.nc</ncdata>
 <ncdata hgrid="0.9x1.25" nlev="70" carma="trop_strat_soa1">atm/waccm/ic/FWmaCARMAHIST_f09_spinup01.cam.i.1980-01-01-00000_c220128.nc</ncdata>
@@ -159,7 +162,8 @@
 <ncdata hgrid="ne3np4"   nlev="32"  aquaplanet="1" >atm/cam/inic/se/cam6_QPC6_aqua_ne3pg3_mg37_L32_01-01-31_c221214.nc</ncdata>
 <ncdata hgrid="ne3np4"   nlev="58"             >atm/cam/inic/se/cam6_QPC6_topo_ne3pg3_mg37_L58_01-01-31_c221214.nc</ncdata>
 <ncdata hgrid="ne3np4"   nlev="93"             >atm/cam/inic/se/cam6_FMTHIST_ne3pg3_mg37_L93_79-02-01_c240517.nc</ncdata>
-<ncdata hgrid="ne3np4"   nlev="93" chem="trop_strat_mam5_ts4" >atm/cam/inic/se/FCts4MTHIST_ne3pg3_spinup02.cam.i.1980-01-01_c240702.nc</ncdata>
+<ncdata hgrid="ne3np4"   nlev="93" chem="trop_strat_mam5_t1s2">atm/cam/inic/se/FHISTC_MTt1s_ne3pg3_O2_spinup01.cam.i.1980-01-01_c260201.nc</ncdata>
+<ncdata hgrid="ne3np4"   nlev="93" chem="trop_strat_mam5_t4s2">atm/cam/inic/se/FHISTC_MTt1s_ne3pg3_O2_spinup01.cam.i.1980-01-01_c260201.nc</ncdata>
 
 <ncdata hgrid="ne5np4"   nlev="26"  aquaplanet="1" >atm/cam/inic/se/ape_cam4_ne5np4_L26_c170517.nc</ncdata>
 <ncdata hgrid="ne5np4"   nlev="30"                 >atm/cam/inic/homme/cami-mam3_0000-01_ne5np4_L30.140707.nc</ncdata>
@@ -181,7 +185,9 @@
 <ncdata hgrid="ne16np4"  nlev="126" waccmx="1"                                 >atm/waccm/ic/waccmx_ne16np4_126L_c200108.nc</ncdata>
 <ncdata hgrid="ne16np4"  nlev="126" waccmx="1" aquaplanet="1"                  >atm/waccm/ic/waccmx_aqua_ne16np4_126L_c191108.nc</ncdata>
 <ncdata hgrid="ne16np4"  nlev="126" waccmx="1" aquaplanet="1" ionosphere="none">atm/waccm/ic/waccmx4_neutral_aquap_ne16np4_126lev_c200827.nc</ncdata>
-<ncdata hgrid="ne16np4"  nlev="130" waccmx="1"     >atm/waccm/ic/waccmx_ne16pg3_L130_c250318.nc</ncdata>
+<ncdata hgrid="ne16np4"  nlev="130" waccmx="1"     >atm/waccm/ic/FX2000_ne16pg3_spinup01.cam.i.0002-01-01_c251215.nc</ncdata>
+<ncdata hgrid="ne16np4"  nlev="58"                 >atm/cam/inic/se/FHISTC_LTso_ne16pg3_ne16pg3_mg17.i.c260220.nc</ncdata>
+<ncdata hgrid="ne16np4"  nlev="93"                 >atm/cam/inic/se/FHISTC_MTso_ne16pg3_ne16pg3_mg17.i.c260220.nc</ncdata>
 
 <ncdata hgrid="ne30np4"  nlev="26"                 >atm/cam/inic/se/ape_topo_cam4_ne30np4_L26_c171020.nc</ncdata>
 <ncdata hgrid="ne30np4"  nlev="26"  aquaplanet="1" >atm/cam/inic/se/ape_cam4_ne30np4_L26_c170417.nc</ncdata>
@@ -191,16 +197,16 @@
 <ncdata hgrid="ne30np4"  nlev="32"  aquaplanet="1" >atm/cam/inic/se/ape_cam6_ne30np4_L32_c170509.nc</ncdata>
 <ncdata hgrid="ne30np4"  nlev="32" chem="trop_strat_mam4_vbs">atm/cam/inic/se/f.e22.FC2010climo.ne30_ne30_mg17.cam6_2_032.001.cam.i.0006-01-01-00000_c200623.nc</ncdata>
 <ncdata hgrid="ne30np4"  nlev="32" chem="trop_strat_mam4_vbs" npg="3">atm/cam/inic/se/f.e22.FC2010climo.ne30pg3_ne30pg3_mg17.cam6_2_032.001.cam.i.0007-01-01-00000_c200623.nc</ncdata>
-<ncdata hgrid="ne30np4"  nlev="32" chem="trop_strat_mam5_vbs">atm/cam/inic/se/f.e22.FC2010climo.ne30_ne30_mg17.cam6_2_032.001.cam.i.0006-01-01-00000_c200623.nc</ncdata>
-<ncdata hgrid="ne30np4"  nlev="32" chem="trop_strat_mam5_vbs" npg="3">atm/cam/inic/se/f.e22.FC2010climo.ne30pg3_ne30pg3_mg17.cam6_2_032.001.cam.i.0007-01-01-00000_c200623.nc</ncdata>
+<ncdata hgrid="ne30np4"  nlev="32" chem="trop_strat_mam5_t1s1">atm/cam/inic/se/f.e22.FC2010climo.ne30_ne30_mg17.cam6_2_032.001.cam.i.0006-01-01-00000_c200623.nc</ncdata>
+<ncdata hgrid="ne30np4"  nlev="32" chem="trop_strat_mam5_t1s1" npg="3">atm/cam/inic/se/f.e22.FC2010climo.ne30pg3_ne30pg3_mg17.cam6_2_032.001.cam.i.0007-01-01-00000_c200623.nc</ncdata>
 <ncdata hgrid="ne30np4"  nlev="32" chem="trop_strat_mam4_ts2">atm/cam/inic/se/f.e22.FC2010climo.ne30_ne30_mg17.cam6_2_032.001.cam.i.0006-01-01-00000_c200623.nc</ncdata>
-<ncdata hgrid="ne30np4"  nlev="32" chem="trop_strat_mam5_ts2">atm/cam/inic/se/f.e22.FC2010climo.ne30_ne30_mg17.cam6_2_032.001.cam.i.0006-01-01-00000_c200623.nc</ncdata>
-<ncdata hgrid="ne30np4"  nlev="58" chem="trop_strat_mam5_vbs">atm/cam/inic/se/f.e22.FCnudged.ne30_ne30_mg17.release-cesm2.2.0_spinup.2010_2020.001.cam.i.2011-01-01-00000_L58_c220310.nc</ncdata>
+<ncdata hgrid="ne30np4"  nlev="32" chem="trop_strat_mam5_t2s1">atm/cam/inic/se/f.e22.FC2010climo.ne30_ne30_mg17.cam6_2_032.001.cam.i.0006-01-01-00000_c200623.nc</ncdata>
+<ncdata hgrid="ne30np4"  nlev="58" chem="trop_strat_mam5_t1s1">atm/cam/inic/se/f.e22.FCnudged.ne30_ne30_mg17.release-cesm2.2.0_spinup.2010_2020.001.cam.i.2011-01-01-00000_L58_c220310.nc</ncdata>
 <ncdata hgrid="ne30np4"  nlev="58"                 >atm/cam/inic/se/FLT_L58_ne30pg3_IC_c220623.nc</ncdata>
-<ncdata hgrid="ne30np4"  nlev="70"                 >atm/waccm/ic/FW2000_ne30_L70_01-01-0001_c200602.nc</ncdata>
-<ncdata hgrid="ne30np4"  nlev="70" npg="3"         >atm/waccm/ic/FW2000.ne30pg3_ne30pg3_nlev70_c230906.nc</ncdata>
+<ncdata hgrid="ne30np4"  nlev="70" waccm_phys="1"  >atm/waccm/ic/FW2000.ne30pg3_ne30pg3_nlev70_c230906.nc</ncdata>
 <ncdata hgrid="ne30np4"  nlev="93"                           >atm/cam/inic/se/c153_ne30pg3_FMTHIST_x02.cam.i.1990-01-01-00000_c240618.nc</ncdata>
-<ncdata hgrid="ne30np4"  nlev="93" chem="trop_strat_mam5_vbs">atm/cam/inic/se/f.cam6_3_160.FCMT_ne30.moving_mtn.001.cam.i.1996-01-01-00000_c240618.nc</ncdata>
+<ncdata hgrid="ne30np4"  nlev="93" chem="trop_strat_mam5_t1s2">atm/cam/inic/se/FHISTC_MTt1s_ne30pg3_O2_spinup01.cam.i.1980-01-01_c260201.nc</ncdata>
+<ncdata hgrid="ne30np4"  nlev="93" chem="trop_strat_mam5_t4s2">atm/cam/inic/se/FHISTC_MTt1s_ne30pg3_O2_spinup01.cam.i.1980-01-01_c260201.nc</ncdata>
 <ncdata hgrid="ne30np4"  nlev="110"                >atm/waccm/ic/FWsc2000_ne30pg3_L110_01-01-0001_c200521.nc</ncdata>
 <ncdata hgrid="ne30np4"  nlev="130" waccmx="1"         >atm/waccm/ic/fx2000_phys-ionos-cpl_ne30_spinup01.cam.i.0002-01-01-00000_c201014.nc</ncdata>
 <ncdata hgrid="ne30np4"  nlev="130" waccmx="1" npg="3" >atm/waccm/ic/waccmx_ne30pg3_L130_c250307.nc</ncdata>
@@ -216,6 +222,8 @@
 <ncdata hgrid="ne120np4" nlev="30"  aquaplanet="1" >atm/cam/inic/se/ape_cam5_ne120np4_L30_c170419.nc</ncdata>
 <ncdata hgrid="ne120np4" nlev="32"                 >atm/cam/inic/se/F2000climo_ne120pg3_mt13_01-01-00000_c200420.nc</ncdata>
 <ncdata hgrid="ne120np4" nlev="32"  aquaplanet="1" >atm/cam/inic/se/ape_cam6_ne120np4_L32_c170908.nc</ncdata>
+<ncdata hgrid="ne120np4" nlev="58"                 >atm/cam/inic/se/betacast_ERA5ml_20100101_ne120np4_L58_c260225.nc</ncdata>
+<ncdata hgrid="ne120np4" nlev="93"                 >atm/cam/inic/se/inic/betacast_ERA5ml_20100101_ne120np4_L93_c260225.nc</ncdata>
 <ncdata hgrid="ne120np4" nlev="273" waccmx="1"     >atm/waccm/ic/fx2000_ne120pg3L273.001.cam.i.0002-01-01-00000.noBRCL_c250522.nc</ncdata>
 
 <ncdata hgrid="ne240np4" nlev="26"                 >atm/cam/inic/homme/cami_1850-01-01_ne240np4_L26_c110314.nc</ncdata>
@@ -226,12 +234,22 @@
 
 <ncdata hgrid="ne0np4CONUS.ne30x8" nlev="32" >atm/cam/inic/se/F2000climo_CONUS_30x8_mt12_mg3_01-01-00000_c200421.nc</ncdata>
 <ncdata hgrid="ne0np4CONUS.ne30x8" nlev="32" chem="trop_strat_mam4_vbs">atm/cam/inic/se/f.e22.FCnudged.ne0CONUSne30x8_ne0CONUSne30x8_mt12.cam6_2_032.002.cam.i.2013-01-01-00000_c200623.nc</ncdata>
-<ncdata hgrid="ne0np4CONUS.ne30x8" nlev="32" chem="trop_strat_mam5_vbs">atm/cam/inic/se/f.e22.FCnudged.ne0CONUSne30x8_ne0CONUSne30x8_mt12.cam6_2_032.002.cam.i.2013-01-01-00000_c200623.nc</ncdata>
+<ncdata hgrid="ne0np4CONUS.ne30x8" nlev="32" chem="trop_strat_mam5_t1s1">atm/cam/inic/se/f.e22.FCnudged.ne0CONUSne30x8_ne0CONUSne30x8_mt12.cam6_2_032.002.cam.i.2013-01-01-00000_c200623.nc</ncdata>
 <ncdata hgrid="ne0np4CONUS.ne30x8" nlev="70" >atm/waccm/ic/FW2000_CONUS_30x8_L70_01-01-0001_c200602.nc</ncdata>
 
 <ncdata hgrid="ne0np4.ARCTIC.ne30x4" nlev="32" >atm/cam/inic/se/FHIST_ARCTIC_ne30x4_mt12_1979bc-mg3_01-01-00000_c200424.nc</ncdata>
-
 <ncdata hgrid="ne0np4.ARCTICGRIS.ne30x8" nlev="32" >atm/cam/inic/se/FHIST_ARCTICGRIS_ne30x8_mt12_1979bc-mg3_01-01-00000_c200428.nc</ncdata>
+<ncdata hgrid="ne0np4.NATL.ne30x8" nlev="32" >atm/cam/inic/se/betacast_ERA5ml_20200101_NATL_L32_c250620.nc</ncdata>
+<ncdata hgrid="ne0np4CONUS.ne30x8" nlev="58" >atm/cam/inic/se/betacast_ERA5ml_20200101_CONUS_c250617.nc</ncdata>
+<ncdata hgrid="ne0np4.ARCTIC.ne30x4" nlev="58" >atm/cam/inic/se/betacast_ERA5ml_20200101_ARCTIC_c250617.nc</ncdata>
+<ncdata hgrid="ne0np4.ARCTICGRIS.ne30x8" nlev="58" >atm/cam/inic/se/betacast_ERA5ml_20200101_ARCTICGRIS_c250617.nc</ncdata>
+<ncdata hgrid="ne0np4.POLARCAP.ne30x4" nlev="58" >atm/cam/inic/se/betacast_ERA5ml_20200101_POLARCAP_c250322.nc</ncdata>
+<ncdata hgrid="ne0np4.NATL.ne30x8" nlev="58" >atm/cam/inic/se/betacast_ERA5ml_20200101_NATL_L58_c250618.nc</ncdata>
+<ncdata hgrid="ne0np4CONUS.ne30x8" nlev="93" >atm/cam/inic/se/betacast_ERA5ml_20100101_CONUS_ne30x8_L93_c260225.nc</ncdata>
+<ncdata hgrid="ne0np4.ARCTIC.ne30x4" nlev="93" >atm/cam/inic/se/betacast_ERA5ml_20100101_ARCTIC_ne30x4_L93_c260225.nc</ncdata>
+<ncdata hgrid="ne0np4.ARCTICGRIS.ne30x8" nlev="93" >atm/cam/inic/se/betacast_ERA5ml_20100101_ARCTICGRIS_ne30x8_L93_c260225.nc</ncdata>
+<ncdata hgrid="ne0np4.POLARCAP.ne30x4" nlev="93" >atm/cam/inic/se/betacast_ERA5ml_20100101_POLARCAP_ne30x4_L93_c260225.nc</ncdata>
+<ncdata hgrid="ne0np4.NATL.ne30x8" nlev="93" >atm/cam/inic/se/betacast_ERA5ml_20100101_NATL_ne30x8_L93_c260225.nc</ncdata>
 
 <!-- MPAS Initial Conditions -->
 <ncdata hgrid="mpasa480" nlev="32" >atm/cam/inic/mpas/cami_01-01-2000_00Z_mpasa480_L32_CFSR_c240508.nc</ncdata>
@@ -298,6 +316,7 @@
 <bnd_topo hgrid="C192" >atm/cam/topo/fv3_C192_nc3000_Co030_Fi001_MulG_PF_Nsw021_c200625.nc</bnd_topo>
 <bnd_topo hgrid="C384" >atm/cam/topo/fv3_C384_nc3000_Co015_Fi001_MulG_PF_nullRR_Nsw011_c200625.nc</bnd_topo>
 
+<bnd_topo hgrid="ne3np4"          >atm/cam/topo/se/ne3np4_gmted2010_modis_bedmachine_nc0540_Laplace1000_noleak_20230717.nc</bnd_topo>
 <bnd_topo hgrid="ne5np4"          >atm/cam/topo/se/ne5np4_nc3000_Co360_Fi001_MulG_PF_nullRR_Nsw064_20170515.nc</bnd_topo>
 <bnd_topo hgrid="ne16np4"         >atm/cam/topo/se/ne16np4_nc3000_Co120_Fi001_PF_nullRR_Nsw084_20171012.nc</bnd_topo>
 <bnd_topo hgrid="ne30np4"         >atm/cam/topo/se/ne30np4_gmted2010_modis_bedmachine_nc3000_Laplace0100_noleak_greenlndantarcsgh30fac2.50_20250822.nc</bnd_topo>
@@ -322,6 +341,8 @@
 <bnd_topo hgrid="ne0np4CONUS.ne30x8"       >atm/cam/topo/se/ne30x8_CONUS_nc3000_Co060_Fi001_MulG_PF_RR_Nsw042_c200428.nc</bnd_topo>
 <bnd_topo hgrid="ne0np4.ARCTIC.ne30x4"     >atm/cam/topo/se/ne30x4_ARCTIC_nc3000_Co060_Fi001_MulG_PF_RR_Nsw042_c200428.nc</bnd_topo>
 <bnd_topo hgrid="ne0np4.ARCTICGRIS.ne30x8" >atm/cam/topo/se/ne30x8_ARCTICGRIS_nc3000_Co060_Fi001_MulG_PF_RR_Nsw042_c200428.nc</bnd_topo>
+<bnd_topo hgrid="ne0np4.POLARCAP.ne30x4"   >atm/cam/topo/se/POLARCAP_gmted2010_modis_bedmachine_nc3000_Laplace0100_noleak_20250322.nc</bnd_topo>
+<bnd_topo hgrid="ne0np4.NATL.ne30x8"       >atm/cam/topo/se/NATL.ne30x8_gmted2010_modis_bedmachine_nc3000_Laplace0100_noleak_20260225.nc</bnd_topo>
 
 <bnd_topo hgrid="mpasa480" >atm/cam/topo/mpas/mpasa480_gmted2010_modis_bedmachine_nc3000_Laplace0400_noleak_20240507.nc</bnd_topo>
 <bnd_topo hgrid="mpasa120" >atm/cam/topo/mpas/mpasa120_gmted2010_modis_bedmachine_nc3000_Laplace0100_noleak_20240507.nc</bnd_topo>
@@ -356,6 +377,8 @@
 <se_mesh_file hgrid="ne0np4TESTONLY.ne5x4"    >atm/cam/coords/ne0np4EQFACE.ne5x4.g</se_mesh_file>
 <se_mesh_file hgrid="ne0np4.ARCTIC.ne30x4"    >atm/cam/coords/ne30x4_EXODUS_ARCTIC_c191009.g</se_mesh_file>
 <se_mesh_file hgrid="ne0np4.ARCTICGRIS.ne30x8">atm/cam/coords/ne30x8_EXODUS_ARCTICGRIS_c191209.g</se_mesh_file>
+<se_mesh_file hgrid="ne0np4.POLARCAP.ne30x4"  >atm/cam/coords/POLARCAP_ne30x4_EXODUS_c220531.nc</se_mesh_file>
+<se_mesh_file hgrid="ne0np4.NATL.ne30x8"      >atm/cam/coords/NATL_ne30x8_EXODUS_c201016.nc</se_mesh_file>
 
 <!-- Analytic ICs  -->
 <analytic_ic_type                   > none </analytic_ic_type>
@@ -691,7 +714,8 @@
 <!-- Time-variant chemistry surface values -->
 <bndtvghg>atm/cam/ggas/ghg_hist_1765-2005_c091218.nc</bndtvghg>
 <flbc_file>atm/waccm/lb/LBC_1765-2100_1.9x2.5_CCMI_RCP60_za_RNOCStrend_c141002.nc</flbc_file>
-<flbc_file chem="ghg_mam4">atm/waccm/lb/LBC_17500116-20150116_CMIP6_0p5degLat_c180905.nc</flbc_file>
+<flbc_file chem="ghg_mam4" phys="cam6">atm/waccm/lb/LBC_17500116-20150116_CMIP6_0p5degLat_c180905.nc</flbc_file>
+<flbc_file                 phys="cam7">atm/waccm/lb/CMIP7/LBC_17500116-20221216_CMIP7_0p5degLat_OCSupdate_c250523.nc</flbc_file>
 
 <!-- Time-variant CO2 fossil fuel emissions -->
 <co2flux_fuel_file hgrid="0.9x1.25" sim_year="1850-2015">atm/cam/ggas/emissions-cmip6_CO2_anthro_surface_175001-201512_fv_0.9x1.25_c20181011.nc</co2flux_fuel_file>
@@ -793,6 +817,7 @@
 
 <gw_top_taper>.false.</gw_top_taper>
 <gw_top_taper waccmx="1">.true.</gw_top_taper>
+
 <pgwv>32</pgwv>
 <pgwv waccmx="1">18</pgwv>
 
@@ -800,6 +825,7 @@
 
 <effgw_beres_dp                                               >0.7D0</effgw_beres_dp>
 <effgw_beres_dp model_top="lt"                                >0.15D0</effgw_beres_dp>
+<effgw_beres_dp model_top="mt"  waccm_phys="1"                >0.15D0</effgw_beres_dp>
 <effgw_beres_dp model_top="mt"                                >0.15D0</effgw_beres_dp>
 <effgw_beres_dp model_top="ht" phys="cam7"                    >0.25D0</effgw_beres_dp>
 <effgw_beres_dp model_top="xt" phys="cam7"                    >0.25D0</effgw_beres_dp>
@@ -808,20 +834,21 @@
 <effgw_beres_dp waccm_phys="1" hgrid="0.9x1.25"               >0.5D0</effgw_beres_dp>
 <effgw_beres_dp waccm_phys="1" hgrid="ne30np4"                >0.5D0</effgw_beres_dp>
 <effgw_beres_dp chem="geoschem_mam4" hgrid="0.9x1.25"         >0.5D0</effgw_beres_dp>
-<effgw_beres_dp chem="trop_strat_mam5_vbs" hgrid="0.9x1.25"   >0.5D0</effgw_beres_dp>
+<effgw_beres_dp chem="trop_strat_mam5_t1s1" hgrid="0.9x1.25"   >0.5D0</effgw_beres_dp>
 <effgw_beres_dp chem="trop_strat_mam5_vbsext" hgrid="0.9x1.25">0.5D0</effgw_beres_dp>
+<effgw_beres_dp chem="trop_strat_mam5_slh" hgrid="0.9x1.25"   >0.5D0</effgw_beres_dp>
 <effgw_beres_dp carma="trop_strat_soa1" hgrid="0.9x1.25"      >0.5D0</effgw_beres_dp>
 <effgw_beres_dp carma="trop_strat_soa5" hgrid="0.9x1.25"      >0.5D0</effgw_beres_dp>
 
 <effgw_rdg_resid                   >1.0D0</effgw_rdg_resid>
 
 <effgw_rdg_beta                    >1.0D0</effgw_rdg_beta>
-<effgw_rdg_beta model_top="lt"     >0.5D0</effgw_rdg_beta>
-<effgw_rdg_beta model_top="mt"     >0.5D0</effgw_rdg_beta>
+<effgw_rdg_beta model_top="lt"     >0.75D0</effgw_rdg_beta>
+<effgw_rdg_beta model_top="mt"     >0.75D0</effgw_rdg_beta>
 
 <effgw_rdg_beta_max                >1.0D0</effgw_rdg_beta_max>
-<effgw_rdg_beta_max model_top="lt" >0.5D0</effgw_rdg_beta_max>
-<effgw_rdg_beta_max model_top="mt" >0.5D0</effgw_rdg_beta_max>
+<effgw_rdg_beta_max model_top="lt" >0.75D0</effgw_rdg_beta_max>
+<effgw_rdg_beta_max model_top="mt" >0.75D0</effgw_rdg_beta_max>
 
 <!-- setting for gravity waves from shallow convection. -->
 <effgw_beres_sh>0.03D0</effgw_beres_sh>
@@ -835,45 +862,45 @@
 <gw_prndl     chem="geoschem_mam4">0.5d0  </gw_prndl>
 <gw_prndl     chem="trop_strat_mam4_vbs">0.5d0  </gw_prndl>
 <gw_prndl     chem="trop_strat_mam4_vbsext">0.5d0  </gw_prndl>
-<gw_prndl     chem="trop_strat_mam5_vbs">0.5d0  </gw_prndl>
+<gw_prndl     chem="trop_strat_mam5_t1s1">0.5d0  </gw_prndl>
 <gw_prndl     chem="trop_strat_mam5_vbsext">0.5d0  </gw_prndl>
+<gw_prndl     chem="trop_strat_mam4_slh">0.5d0  </gw_prndl>
+<gw_prndl     chem="trop_strat_mam5_slh">0.5d0  </gw_prndl>
 <gw_oro_south_fac                       >1.d0   </gw_oro_south_fac>
+<gw_oro_south_fac         model_top="mt">1.d0   </gw_oro_south_fac>
 <gw_oro_south_fac         waccm_phys="1">2.d0   </gw_oro_south_fac>
 <gw_oro_south_fac         model_top="ht">2.d0   </gw_oro_south_fac>
 <gw_oro_south_fac chem="geoschem_mam4">2.d0   </gw_oro_south_fac>
 <gw_oro_south_fac chem="trop_strat_mam4_vbs">2.d0   </gw_oro_south_fac>
 <gw_oro_south_fac chem="trop_strat_mam4_vbsext">2.d0   </gw_oro_south_fac>
-<gw_oro_south_fac chem="trop_strat_mam5_vbs">2.d0   </gw_oro_south_fac>
+<gw_oro_south_fac chem="trop_strat_mam4_slh">2.d0   </gw_oro_south_fac>
+<gw_oro_south_fac chem="trop_strat_mam5_slh">2.d0   </gw_oro_south_fac>
+<gw_oro_south_fac chem="trop_strat_mam5_t1s1">2.d0   </gw_oro_south_fac>
 <gw_oro_south_fac chem="trop_strat_mam5_vbsext">2.d0   </gw_oro_south_fac>
 <gw_oro_south_fac carma="trop_strat_soa1">2.D0</gw_oro_south_fac>
 <gw_oro_south_fac carma="trop_strat_soa5">2.D0</gw_oro_south_fac>
 <gw_lndscl_sgh                          >.true. </gw_lndscl_sgh>
+<gw_lndscl_sgh            model_top="mt">.true. </gw_lndscl_sgh>
 <gw_lndscl_sgh            waccm_phys="1">.false.</gw_lndscl_sgh>
 <gw_lndscl_sgh            model_top="ht">.false.</gw_lndscl_sgh>
 <gw_lndscl_sgh chem="geoschem_mam4">.false.</gw_lndscl_sgh>
 <gw_lndscl_sgh chem="trop_strat_mam4_vbs">.false.</gw_lndscl_sgh>
 <gw_lndscl_sgh chem="trop_strat_mam4_vbsext">.false.</gw_lndscl_sgh>
-<gw_lndscl_sgh chem="trop_strat_mam5_vbs">.false.</gw_lndscl_sgh>
+<gw_lndscl_sgh chem="trop_strat_mam4_slh">.false.</gw_lndscl_sgh>
+<gw_lndscl_sgh chem="trop_strat_mam5_slh">.false.</gw_lndscl_sgh>
+<gw_lndscl_sgh chem="trop_strat_mam5_t1s1">.false.</gw_lndscl_sgh>
 <gw_lndscl_sgh chem="trop_strat_mam5_vbsext">.false.</gw_lndscl_sgh>
 <gw_lndscl_sgh carma="trop_strat_soa1">.false.</gw_lndscl_sgh>
 <gw_lndscl_sgh carma="trop_strat_soa5">.false.</gw_lndscl_sgh>
-<gw_limit_tau_without_eff               >.false.</gw_limit_tau_without_eff>
-<gw_limit_tau_without_eff waccm_phys="1">.true. </gw_limit_tau_without_eff>
-<gw_limit_tau_without_eff model_top="ht">.true. </gw_limit_tau_without_eff>
-<gw_limit_tau_without_eff chem="geoschem_mam4">.true. </gw_limit_tau_without_eff>
-<gw_limit_tau_without_eff chem="trop_strat_mam4_vbs">.true. </gw_limit_tau_without_eff>
-<gw_limit_tau_without_eff chem="trop_strat_mam4_vbsext">.true. </gw_limit_tau_without_eff>
-<gw_limit_tau_without_eff chem="trop_strat_mam5_vbs">.true. </gw_limit_tau_without_eff>
-<gw_limit_tau_without_eff chem="trop_strat_mam5_vbsext">.true. </gw_limit_tau_without_eff>
-<gw_limit_tau_without_eff carma="trop_strat_soa1">.true. </gw_limit_tau_without_eff>
-<gw_limit_tau_without_eff carma="trop_strat_soa5">.true. </gw_limit_tau_without_eff>
 <gw_apply_tndmax                          >.true. </gw_apply_tndmax>
 <gw_apply_tndmax chem="geoschem_mam4"     >.false.</gw_apply_tndmax>
 <gw_apply_tndmax phys="cam7"              >.false.</gw_apply_tndmax>
 <gw_apply_tndmax            waccm_phys="1">.false.</gw_apply_tndmax>
 <gw_apply_tndmax chem="trop_strat_mam4_vbs">.false.</gw_apply_tndmax>
 <gw_apply_tndmax chem="trop_strat_mam4_vbsext">.false.</gw_apply_tndmax>
-<gw_apply_tndmax chem="trop_strat_mam5_vbs">.false.</gw_apply_tndmax>
+<gw_apply_tndmax chem="trop_strat_mam4_slh">.false.</gw_apply_tndmax>
+<gw_apply_tndmax chem="trop_strat_mam5_slh">.false.</gw_apply_tndmax>
+<gw_apply_tndmax chem="trop_strat_mam5_t1s1">.false.</gw_apply_tndmax>
 <gw_apply_tndmax chem="trop_strat_mam5_vbsext">.false.</gw_apply_tndmax>
 <gw_apply_tndmax carma="trop_strat_soa1">.false.</gw_apply_tndmax>
 <gw_apply_tndmax carma="trop_strat_soa5">.false.</gw_apply_tndmax>
@@ -893,6 +920,7 @@
 <gw_rdg_orom2min                        > 0.1d0  </gw_rdg_orom2min>
 <alpha_gw_movmtn                        > 0.01d0  </alpha_gw_movmtn>
 <effgw_movmtn_pbl                       > 1.0d0   </effgw_movmtn_pbl>
+<effgw_movmtn_pbl phys="cam7"           > 1.5d0   </effgw_movmtn_pbl>
 <movmtn_psteer                          > 65000.0d0  </movmtn_psteer>
 <movmtn_plaunch                         > 32500.0d0  </movmtn_plaunch>
 <movmtn_source                          > 1       </movmtn_source>
@@ -931,18 +959,10 @@
 <edyn_grid hgrid="0.47x0.63">320x385</edyn_grid>
 <edyn_grid hgrid="ne120np4" >320x385</edyn_grid>
 
-<!-- ESMF mesh files for physics decomposition -->
-<cam_physics_mesh hgrid="0.47x0.63">atm/cam/coords/fv0.47x0.63_esmf_c210305.nc</cam_physics_mesh>
-<cam_physics_mesh hgrid="0.9x1.25">atm/cam/coords/fv0.9x1.25_esmf_c210305.nc</cam_physics_mesh>
-<cam_physics_mesh hgrid="1.9x2.5">atm/cam/coords/fv1.9x2.5_esmf_200428.nc</cam_physics_mesh>
-<cam_physics_mesh hgrid="4x5">atm/cam/coords/fv4x5_esmf_c210305.nc</cam_physics_mesh>
-<cam_physics_mesh hgrid="ne5np4">atm/cam/coords/ne5np4_esmf_20191204.nc</cam_physics_mesh>
-<cam_physics_mesh hgrid="ne5np4" npg="3">atm/cam/coords/ne5np4.pg3_esmf_mesh_c210121.nc</cam_physics_mesh>
-<cam_physics_mesh hgrid="ne16np4">atm/cam/coords/ne16np4_esmf_c210305.nc</cam_physics_mesh>
-<cam_physics_mesh hgrid="ne16np4" npg="3">share/meshes/ne16pg3_ESMFmesh_cdf5_c20211018.nc</cam_physics_mesh>
-<cam_physics_mesh hgrid="ne30np4">atm/cam/coords/ne30np4_esmf_c210305.nc</cam_physics_mesh>
-<cam_physics_mesh hgrid="ne30np4" npg="3">atm/cam/coords/ne30pg3_esmf_20200428.nc</cam_physics_mesh>
-<cam_physics_mesh hgrid="ne120np4" npg="3">share/meshes/ne120pg3_ESMFmesh_cdf5_c20211018.nc</cam_physics_mesh>
+<!-- For ESMF regrid zonal-mean TEM diagnostics -->
+<ctem_diags_numlats>0</ctem_diags_numlats>
+<ctem_diags_numlats hgrid="ne16np4">90</ctem_diags_numlats>
+<ctem_diags_numlats hgrid="ne30np4">180</ctem_diags_numlats>
 
 <!-- For scaling lightning sources of NOx -->
 <lght_no_prd_factor                                              >1.00D0</lght_no_prd_factor>
@@ -1030,6 +1050,21 @@
 
 <so2_vrt_emis_file >atm/cam/chem/trop_mozart_aero/emis/aerocom_SO2_vertical_2000.c080807.nc</so2_vrt_emis_file>
 <so4_vrt_emis_file >atm/cam/chem/trop_mozart_aero/emis/aerocom_SO4_vertical_2000.c080807.nc</so4_vrt_emis_file>
+
+<!-- SLH chemistry emissions -->
+<c2cl4_slh_emis_file  >atm/cam/chem/emis/EMIS_SLH/flxSLH1p15/emissions_C2Cl4_NoNeg_surface_Claxton2020_flx1p15_serial_1750-2100_1.9x2.5_c251203.nc</c2cl4_slh_emis_file>
+<ch2br2_slh_emis_file >atm/cam/chem/emis/EMIS_SLH/flxSLH1p15/emissions_CH2Br2_chlorophyll_surface_Ordonez2012_flx1p15_cyclical_1750-2100_1.9x2.5_c251204.nc</ch2br2_slh_emis_file>
+<ch2brcl_slh_emis_file>atm/cam/chem/emis/EMIS_SLH/flxSLH1p15/emissions_CH2BrCl_chlorophyll_surface_Ordonez2012_flx1p15_cyclical_1750-2100_1.9x2.5_c251204.nc</ch2brcl_slh_emis_file>
+<ch2cl2_slh_emis_file >atm/cam/chem/emis/EMIS_SLH/flxSLH1p15/emissions_CH2Cl2_NoNeg_surface_Claxton2020_flx1p15_serial_1750-2100_1.9x2.5_c251203.nc</ch2cl2_slh_emis_file>
+<ch2i2_slh_emis_file  >atm/cam/chem/emis/EMIS_SLH/emissions_CH2I2_chlorophyll_surface_Ordonez2012_cyclical_1750-2100_1.9x2.5_c251204.nc</ch2i2_slh_emis_file>
+<ch2ibr_slh_emis_file >atm/cam/chem/emis/EMIS_SLH/emissions_CH2IBr_chlorophyll_surface_Ordonez2012_cyclical_1750-2100_1.9x2.5_c251204.nc</ch2ibr_slh_emis_file>
+<ch2icl_slh_emis_file >atm/cam/chem/emis/EMIS_SLH/emissions_CH2ICl_chlorophyll_surface_Ordonez2012_cyclical_1750-2100_1.9x2.5_c251204.nc</ch2icl_slh_emis_file>
+<ch3i_slh_emis_file   >atm/cam/chem/emis/EMIS_SLH/emissions_CH3I_chlorophyll_surface_Ordonez2012_cyclical_1750-2100_1.9x2.5_c251204.nc</ch3i_slh_emis_file>
+<chbr2cl_slh_emis_file>atm/cam/chem/emis/EMIS_SLH/flxSLH1p15/emissions_CHBr2Cl_chlorophyll_surface_Ordonez2012_flx1p15_cyclical_1750-2100_1.9x2.5_c251204.nc</chbr2cl_slh_emis_file>
+<chbr3_slh_emis_file  >atm/cam/chem/emis/EMIS_SLH/flxSLH1p15/emissions_CHBr3_chlorophyll_surface_Ordonez2012_flx1p15_cyclical_1750-2100_1.9x2.5_c251204.nc</chbr3_slh_emis_file>
+<chbrcl2_slh_emis_file>atm/cam/chem/emis/EMIS_SLH/flxSLH1p15/emissions_CHBrCl2_chlorophyll_surface_Ordonez2012_flx1p15_cyclical_1750-2100_1.9x2.5_c251204.nc</chbrcl2_slh_emis_file>
+<hoi_slh_emis_file    >atm/cam/chem/emis/EMIS_SLH/emissions_HOI_ocean_surface_PradosRoman2015_online_1750-2100_1.9x2.5_c251204.nc</hoi_slh_emis_file>
+<i2_slh_emis_file     >atm/cam/chem/emis/EMIS_SLH/emissions_I2_ocean_surface_PradosRoman2015_online_1750-2100_1.9x2.5_c251204.nc</i2_slh_emis_file>
 
 <!-- modal aerosol emissions -->
 <nh3_emis_file     ver="mam">atm/cam/chem/trop_mozart_aero/emis/emis_NH3_2000_c111014.nc</nh3_emis_file>
@@ -1527,13 +1562,13 @@
 <num_a2_cv_ext_file hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam4_vbs" ver="cam6">atm/cam/chem/emis/historical_ne0CONUSne30x8/emissions-cmip6_num_a2_so4_contvolcano_vertical_850-5000_ne0CONUSne30x8_c20191202.nc</num_a2_cv_ext_file>
 <so2_cv_ext_file    hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam4_vbs" ver="cam6">atm/cam/chem/emis/historical_ne0CONUSne30x8/emissions-cmip6_SO2_contvolcano_vertical_850-5000_ne0CONUSne30x8_c20191202.nc</so2_cv_ext_file>
 
-<so4_a1_an_ext_file hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_vbs" ver="cam6">atm/cam/chem/emis/CAMS_Anthro_ne0CONUSne30x8/CAMS-GLOB-ANT_Glb_ne0CONUSne30x8_so4_a1_anthro-ene_vertical_v3.1_c20191104.nc</so4_a1_an_ext_file>
-<num_a1_an_ext_file hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_vbs" ver="cam6">atm/cam/chem/emis/CAMS_Anthro_ne0CONUSne30x8/CAMS-GLOB-ANT_Glb_ne0CONUSne30x8_num_so4_a1_anthro-ene_vertical_v3.1_c20191104.nc</num_a1_an_ext_file>
-<so4_a1_cv_ext_file hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_vbs" ver="cam6">atm/cam/chem/emis/historical_ne0CONUSne30x8/emissions-cmip6_so4_a1_contvolcano_vertical_850-5000_ne0CONUSne30x8_c20191202.nc</so4_a1_cv_ext_file>
-<num_a1_cv_ext_file hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_vbs" ver="cam6">atm/cam/chem/emis/historical_ne0CONUSne30x8/emissions-cmip6_num_a1_so4_contvolcano_vertical_850-5000_ne0CONUSne30x8_c20191202.nc</num_a1_cv_ext_file>
-<so4_a2_cv_ext_file hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_vbs" ver="cam6">atm/cam/chem/emis/historical_ne0CONUSne30x8/emissions-cmip6_so4_a2_contvolcano_vertical_850-5000_ne0CONUSne30x8_c20191202.nc</so4_a2_cv_ext_file>
-<num_a2_cv_ext_file hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_vbs" ver="cam6">atm/cam/chem/emis/historical_ne0CONUSne30x8/emissions-cmip6_num_a2_so4_contvolcano_vertical_850-5000_ne0CONUSne30x8_c20191202.nc</num_a2_cv_ext_file>
-<so2_cv_ext_file    hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_vbs" ver="cam6">atm/cam/chem/emis/historical_ne0CONUSne30x8/emissions-cmip6_SO2_contvolcano_vertical_850-5000_ne0CONUSne30x8_c20191202.nc</so2_cv_ext_file>
+<so4_a1_an_ext_file hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_t1s1" ver="cam6">atm/cam/chem/emis/CAMS_Anthro_ne0CONUSne30x8/CAMS-GLOB-ANT_Glb_ne0CONUSne30x8_so4_a1_anthro-ene_vertical_v3.1_c20191104.nc</so4_a1_an_ext_file>
+<num_a1_an_ext_file hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_t1s1" ver="cam6">atm/cam/chem/emis/CAMS_Anthro_ne0CONUSne30x8/CAMS-GLOB-ANT_Glb_ne0CONUSne30x8_num_so4_a1_anthro-ene_vertical_v3.1_c20191104.nc</num_a1_an_ext_file>
+<so4_a1_cv_ext_file hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_t1s1" ver="cam6">atm/cam/chem/emis/historical_ne0CONUSne30x8/emissions-cmip6_so4_a1_contvolcano_vertical_850-5000_ne0CONUSne30x8_c20191202.nc</so4_a1_cv_ext_file>
+<num_a1_cv_ext_file hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_t1s1" ver="cam6">atm/cam/chem/emis/historical_ne0CONUSne30x8/emissions-cmip6_num_a1_so4_contvolcano_vertical_850-5000_ne0CONUSne30x8_c20191202.nc</num_a1_cv_ext_file>
+<so4_a2_cv_ext_file hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_t1s1" ver="cam6">atm/cam/chem/emis/historical_ne0CONUSne30x8/emissions-cmip6_so4_a2_contvolcano_vertical_850-5000_ne0CONUSne30x8_c20191202.nc</so4_a2_cv_ext_file>
+<num_a2_cv_ext_file hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_t1s1" ver="cam6">atm/cam/chem/emis/historical_ne0CONUSne30x8/emissions-cmip6_num_a2_so4_contvolcano_vertical_850-5000_ne0CONUSne30x8_c20191202.nc</num_a2_cv_ext_file>
+<so2_cv_ext_file    hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_t1s1" ver="cam6">atm/cam/chem/emis/historical_ne0CONUSne30x8/emissions-cmip6_SO2_contvolcano_vertical_850-5000_ne0CONUSne30x8_c20191202.nc</so2_cv_ext_file>
 
 <bc_a4_an_srf_file    hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam4_vbs" ver="cam6">atm/cam/chem/emis/CAMS_Anthro_ne0CONUSne30x8/CAMS-GLOB-ANT_Glb_ne0CONUSne30x8_anthro_surface_bc_a4_v3.1_c20191103.nc</bc_a4_an_srf_file>
 <num_a4_bc_srf_file   hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam4_vbs" ver="cam6">atm/cam/chem/emis/CAMS_Anthro_ne0CONUSne30x8/CAMS-GLOB-ANT_Glb_ne0CONUSne30x8_anthro_surface_num_bc_a4_v3.1_c20191103.nc</num_a4_bc_srf_file>
@@ -1548,18 +1583,18 @@
 <so4_a2_an_srf_file   hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam4_vbs" ver="cam6">atm/cam/chem/emis/CAMS_Anthro_ne0CONUSne30x8/CAMS-GLOB-ANT_Glb_ne0CONUSne30x8_so4_a2_anthro-res_surface_v3.1_c20191103.nc</so4_a2_an_srf_file>
 <num_a2_an_srf_file   hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam4_vbs" ver="cam6">atm/cam/chem/emis/CAMS_Anthro_ne0CONUSne30x8/CAMS-GLOB-ANT_Glb_ne0CONUSne30x8_num_so4_a2_anthro-res_surface_v3.1_c20191103.nc</num_a2_an_srf_file>
 
-<bc_a4_an_srf_file    hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_vbs" ver="cam6">atm/cam/chem/emis/CAMS_Anthro_ne0CONUSne30x8/CAMS-GLOB-ANT_Glb_ne0CONUSne30x8_anthro_surface_bc_a4_v3.1_c20191103.nc</bc_a4_an_srf_file>
-<num_a4_bc_srf_file   hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_vbs" ver="cam6">atm/cam/chem/emis/CAMS_Anthro_ne0CONUSne30x8/CAMS-GLOB-ANT_Glb_ne0CONUSne30x8_anthro_surface_num_bc_a4_v3.1_c20191103.nc</num_a4_bc_srf_file>
-<bc_a4_bb_srf_file    hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_vbs" ver="cam6">atm/cam/chem/emis/finn1.5/CONUSne30x8/emissions-finnv1.5_bc_a4_bb_surface_20100101-20171231_ne0conus_c200619.nc</bc_a4_bb_srf_file>
-<num_a4_bb_srf_file   hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_vbs" ver="cam6">atm/cam/chem/emis/finn1.5/CONUSne30x8/emissions-finnv1.5_num_bc_a4_bb_surface_20100101-20171231_ne0conus_c200619.nc</num_a4_bb_srf_file>
-<pom_a4_an_srf_file   hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_vbs" ver="cam6">atm/cam/chem/emis/CAMS_Anthro_ne0CONUSne30x8/CAMS-GLOB-ANT_Glb_ne0CONUSne30x8_anthro_surface_pom_a4_v3.1_c20191103.nc</pom_a4_an_srf_file>
-<num_a4_oc_srf_file   hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_vbs" ver="cam6">atm/cam/chem/emis/CAMS_Anthro_ne0CONUSne30x8/CAMS-GLOB-ANT_Glb_ne0CONUSne30x8_anthro_surface_num_pom_a4_v3.1_c20191103.nc</num_a4_oc_srf_file>
-<pom_a4_bb_srf_file   hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_vbs" ver="cam6">atm/cam/chem/emis/finn1.5/CONUSne30x8/emissions-finnv1.5_pom_a4_bb_surface_20100101-20171231_ne0conus_c200619.nc</pom_a4_bb_srf_file>
-<num_pom_bb_srf_file  hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_vbs" ver="cam6">atm/cam/chem/emis/finn1.5/CONUSne30x8/emissions-finnv1.5_num_pom_a4_bb_surface_20100101-20171231_ne0conus_c200619.nc</num_pom_bb_srf_file>
-<so4_a1_an_srf_file   hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_vbs" ver="cam6">atm/cam/chem/emis/CAMS_Anthro_ne0CONUSne30x8/CAMS-GLOB-ANT_Glb_ne0CONUSne30x8_so4_a1_anthro-ag-ship_surface_v3.1_c20191103.nc</so4_a1_an_srf_file>
-<num_a1_sh_srf_file   hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_vbs" ver="cam6">atm/cam/chem/emis/CAMS_Anthro_ne0CONUSne30x8/CAMS-GLOB-ANT_Glb_ne0CONUSne30x8_num_so4_a1_anthro-ag-ship_surface_v3.1_c20191103.nc</num_a1_sh_srf_file>
-<so4_a2_an_srf_file   hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_vbs" ver="cam6">atm/cam/chem/emis/CAMS_Anthro_ne0CONUSne30x8/CAMS-GLOB-ANT_Glb_ne0CONUSne30x8_so4_a2_anthro-res_surface_v3.1_c20191103.nc</so4_a2_an_srf_file>
-<num_a2_an_srf_file   hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_vbs" ver="cam6">atm/cam/chem/emis/CAMS_Anthro_ne0CONUSne30x8/CAMS-GLOB-ANT_Glb_ne0CONUSne30x8_num_so4_a2_anthro-res_surface_v3.1_c20191103.nc</num_a2_an_srf_file>
+<bc_a4_an_srf_file    hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_t1s1" ver="cam6">atm/cam/chem/emis/CAMS_Anthro_ne0CONUSne30x8/CAMS-GLOB-ANT_Glb_ne0CONUSne30x8_anthro_surface_bc_a4_v3.1_c20191103.nc</bc_a4_an_srf_file>
+<num_a4_bc_srf_file   hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_t1s1" ver="cam6">atm/cam/chem/emis/CAMS_Anthro_ne0CONUSne30x8/CAMS-GLOB-ANT_Glb_ne0CONUSne30x8_anthro_surface_num_bc_a4_v3.1_c20191103.nc</num_a4_bc_srf_file>
+<bc_a4_bb_srf_file    hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_t1s1" ver="cam6">atm/cam/chem/emis/finn1.5/CONUSne30x8/emissions-finnv1.5_bc_a4_bb_surface_20100101-20171231_ne0conus_c200619.nc</bc_a4_bb_srf_file>
+<num_a4_bb_srf_file   hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_t1s1" ver="cam6">atm/cam/chem/emis/finn1.5/CONUSne30x8/emissions-finnv1.5_num_bc_a4_bb_surface_20100101-20171231_ne0conus_c200619.nc</num_a4_bb_srf_file>
+<pom_a4_an_srf_file   hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_t1s1" ver="cam6">atm/cam/chem/emis/CAMS_Anthro_ne0CONUSne30x8/CAMS-GLOB-ANT_Glb_ne0CONUSne30x8_anthro_surface_pom_a4_v3.1_c20191103.nc</pom_a4_an_srf_file>
+<num_a4_oc_srf_file   hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_t1s1" ver="cam6">atm/cam/chem/emis/CAMS_Anthro_ne0CONUSne30x8/CAMS-GLOB-ANT_Glb_ne0CONUSne30x8_anthro_surface_num_pom_a4_v3.1_c20191103.nc</num_a4_oc_srf_file>
+<pom_a4_bb_srf_file   hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_t1s1" ver="cam6">atm/cam/chem/emis/finn1.5/CONUSne30x8/emissions-finnv1.5_pom_a4_bb_surface_20100101-20171231_ne0conus_c200619.nc</pom_a4_bb_srf_file>
+<num_pom_bb_srf_file  hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_t1s1" ver="cam6">atm/cam/chem/emis/finn1.5/CONUSne30x8/emissions-finnv1.5_num_pom_a4_bb_surface_20100101-20171231_ne0conus_c200619.nc</num_pom_bb_srf_file>
+<so4_a1_an_srf_file   hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_t1s1" ver="cam6">atm/cam/chem/emis/CAMS_Anthro_ne0CONUSne30x8/CAMS-GLOB-ANT_Glb_ne0CONUSne30x8_so4_a1_anthro-ag-ship_surface_v3.1_c20191103.nc</so4_a1_an_srf_file>
+<num_a1_sh_srf_file   hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_t1s1" ver="cam6">atm/cam/chem/emis/CAMS_Anthro_ne0CONUSne30x8/CAMS-GLOB-ANT_Glb_ne0CONUSne30x8_num_so4_a1_anthro-ag-ship_surface_v3.1_c20191103.nc</num_a1_sh_srf_file>
+<so4_a2_an_srf_file   hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_t1s1" ver="cam6">atm/cam/chem/emis/CAMS_Anthro_ne0CONUSne30x8/CAMS-GLOB-ANT_Glb_ne0CONUSne30x8_so4_a2_anthro-res_surface_v3.1_c20191103.nc</so4_a2_an_srf_file>
+<num_a2_an_srf_file   hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_t1s1" ver="cam6">atm/cam/chem/emis/CAMS_Anthro_ne0CONUSne30x8/CAMS-GLOB-ANT_Glb_ne0CONUSne30x8_num_so4_a2_anthro-res_surface_v3.1_c20191103.nc</num_a2_an_srf_file>
 
 <BENZENE_an_srf_file  hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam4_vbs" ver="cam6">atm/cam/chem/emis/CAMS_Anthro_ne0CONUSne30x8/CAMS-GLOB-ANT_Glb_ne0CONUSne30x8_anthro_surface_BENZENE_v3.1_c20191103.nc</BENZENE_an_srf_file>
 <BENZENE_bb_srf_file  hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam4_vbs" ver="cam6">atm/cam/chem/emis/finn1.5/CONUSne30x8/emissions-finnv1.5_BENZENE_bb_surface_20100101-20171231_ne0conus_c200619.nc</BENZENE_bb_srf_file>
@@ -1636,78 +1671,78 @@
 <XYLENES_an_srf_file  hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam4_vbs" ver="cam6">atm/cam/chem/emis/CAMS_Anthro_ne0CONUSne30x8/CAMS-GLOB-ANT_Glb_ne0CONUSne30x8_anthro_surface_XYLENES_v3.1_c20191103.nc</XYLENES_an_srf_file>
 <XYLENES_bb_srf_file  hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam4_vbs" ver="cam6">atm/cam/chem/emis/finn1.5/CONUSne30x8/emissions-finnv1.5_XYLENES_bb_surface_20100101-20171231_ne0conus_c200619.nc</XYLENES_bb_srf_file>
 
-<BIGALD_bb_srf_file   hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_vbs" ver="cam6">atm/cam/chem/emis/finn1.5/CONUSne30x8/emissions-finnv1.5_BIGALD_bb_surface_20100101-20171231_ne0conus_c200619.nc</BIGALD_bb_srf_file>
-<BIGALK_an_srf_file   hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_vbs" ver="cam6">atm/cam/chem/emis/CAMS_Anthro_ne0CONUSne30x8/CAMS-GLOB-ANT_Glb_ne0CONUSne30x8_anthro_surface_BIGALK_v3.1_c20191103.nc</BIGALK_an_srf_file>
-<BIGALK_bb_srf_file   hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_vbs" ver="cam6">atm/cam/chem/emis/finn1.5/CONUSne30x8/emissions-finnv1.5_BIGALK_bb_surface_20100101-20171231_ne0conus_c200619.nc</BIGALK_bb_srf_file>
-<BIGENE_an_srf_file   hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_vbs" ver="cam6">atm/cam/chem/emis/CAMS_Anthro_ne0CONUSne30x8/CAMS-GLOB-ANT_Glb_ne0CONUSne30x8_anthro_surface_BIGENE_v3.1_c20191103.nc</BIGENE_an_srf_file>
-<BIGENE_bb_srf_file   hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_vbs" ver="cam6">atm/cam/chem/emis/finn1.5/CONUSne30x8/emissions-finnv1.5_BIGENE_bb_surface_20100101-20171231_ne0conus_c200619.nc</BIGENE_bb_srf_file>
-<C2H2_an_srf_file     hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_vbs" ver="cam6">atm/cam/chem/emis/CAMS_Anthro_ne0CONUSne30x8/CAMS-GLOB-ANT_Glb_ne0CONUSne30x8_anthro_surface_C2H2_v3.1_c20191103.nc</C2H2_an_srf_file>
-<C2H2_bb_srf_file     hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_vbs" ver="cam6">atm/cam/chem/emis/finn1.5/CONUSne30x8/emissions-finnv1.5_C2H2_bb_surface_20100101-20171231_ne0conus_c200619.nc</C2H2_bb_srf_file>
-<C2H4_an_srf_file     hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_vbs" ver="cam6">atm/cam/chem/emis/CAMS_Anthro_ne0CONUSne30x8/CAMS-GLOB-ANT_Glb_ne0CONUSne30x8_anthro_surface_C2H4_v3.1_c20191103.nc</C2H4_an_srf_file>
-<C2H4_bb_srf_file     hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_vbs" ver="cam6">atm/cam/chem/emis/finn1.5/CONUSne30x8/emissions-finnv1.5_C2H4_bb_surface_20100101-20171231_ne0conus_c200619.nc</C2H4_bb_srf_file>
-<C2H4_ot_srf_file     hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_vbs" ver="cam6">atm/cam/chem/emis/historical_ne0CONUSne30x8/emissions-cmip6_C2H4_other_surface_1750_2015_historical_ne0CONUSne30x8_c20191028.nc</C2H4_ot_srf_file>
-<C2H5OH_an_srf_file   hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_vbs" ver="cam6">atm/cam/chem/emis/CAMS_Anthro_ne0CONUSne30x8/CAMS-GLOB-ANT_Glb_ne0CONUSne30x8_anthro_surface_C2H5OH_v3.1_c20191103.nc</C2H5OH_an_srf_file>
-<C2H5OH_bb_srf_file   hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_vbs" ver="cam6">atm/cam/chem/emis/finn1.5/CONUSne30x8/emissions-finnv1.5_C2H5OH_bb_surface_20100101-20171231_ne0conus_c200619.nc</C2H5OH_bb_srf_file>
-<C2H6_an_srf_file     hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_vbs" ver="cam6">atm/cam/chem/emis/CAMS_Anthro_ne0CONUSne30x8/CAMS-GLOB-ANT_Glb_ne0CONUSne30x8_anthro_surface_C2H6_v3.1_c20191103.nc</C2H6_an_srf_file>
-<C2H6_bb_srf_file     hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_vbs" ver="cam6">atm/cam/chem/emis/finn1.5/CONUSne30x8/emissions-finnv1.5_C2H6_bb_surface_20100101-20171231_ne0conus_c200619.nc</C2H6_bb_srf_file>
-<C2H6_ot_srf_file     hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_vbs" ver="cam6">atm/cam/chem/emis/historical_ne0CONUSne30x8/emissions-cmip6_C2H6_other_surface_1750_2015_historical_ne0CONUSne30x8_c20191028.nc</C2H6_ot_srf_file>
-<C3H6_an_srf_file     hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_vbs" ver="cam6">atm/cam/chem/emis/CAMS_Anthro_ne0CONUSne30x8/CAMS-GLOB-ANT_Glb_ne0CONUSne30x8_anthro_surface_C3H6_v3.1_c20191103.nc</C3H6_an_srf_file>
-<C3H6_bb_srf_file     hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_vbs" ver="cam6">atm/cam/chem/emis/finn1.5/CONUSne30x8/emissions-finnv1.5_C3H6_bb_surface_20100101-20171231_ne0conus_c200619.nc</C3H6_bb_srf_file>
-<C3H6_ot_srf_file     hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_vbs" ver="cam6">atm/cam/chem/emis/historical_ne0CONUSne30x8/emissions-cmip6_C3H6_other_surface_1750_2015_historical_ne0CONUSne30x8_c20191028.nc</C3H6_ot_srf_file>
-<C3H8_an_srf_file     hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_vbs" ver="cam6">atm/cam/chem/emis/CAMS_Anthro_ne0CONUSne30x8/CAMS-GLOB-ANT_Glb_ne0CONUSne30x8_anthro_surface_C3H8_v3.1_c20191103.nc</C3H8_an_srf_file>
-<C3H8_bb_srf_file     hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_vbs" ver="cam6">atm/cam/chem/emis/finn1.5/CONUSne30x8/emissions-finnv1.5_C3H8_bb_surface_20100101-20171231_ne0conus_c200619.nc</C3H8_bb_srf_file>
-<C3H8_ot_srf_file     hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_vbs" ver="cam6">atm/cam/chem/emis/historical_ne0CONUSne30x8/emissions-cmip6_C3H8_other_surface_1750_2015_historical_ne0CONUSne30x8_c20191028.nc</C3H8_ot_srf_file>
-<CH2O_an_srf_file     hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_vbs" ver="cam6">atm/cam/chem/emis/CAMS_Anthro_ne0CONUSne30x8/CAMS-GLOB-ANT_Glb_ne0CONUSne30x8_anthro_surface_CH2O_v3.1_c20191103.nc</CH2O_an_srf_file>
-<CH2O_bb_srf_file     hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_vbs" ver="cam6">atm/cam/chem/emis/finn1.5/CONUSne30x8/emissions-finnv1.5_CH2O_bb_surface_20100101-20171231_ne0conus_c200619.nc</CH2O_bb_srf_file>
-<CH3CHO_an_srf_file   hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_vbs" ver="cam6">atm/cam/chem/emis/CAMS_Anthro_ne0CONUSne30x8/CAMS-GLOB-ANT_Glb_ne0CONUSne30x8_anthro_surface_CH3CHO_v3.1_c20191103.nc</CH3CHO_an_srf_file>
-<CH3CHO_bb_srf_file   hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_vbs" ver="cam6">atm/cam/chem/emis/finn1.5/CONUSne30x8/emissions-finnv1.5_CH3CHO_bb_surface_20100101-20171231_ne0conus_c200619.nc</CH3CHO_bb_srf_file>
-<CH3CN_an_srf_file    hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_vbs" ver="cam6">atm/cam/chem/emis/CAMS_Anthro_ne0CONUSne30x8/CAMS-GLOB-ANT_Glb_ne0CONUSne30x8_anthro_surface_CH3CN_v3.1_c20191103.nc</CH3CN_an_srf_file>
-<CH3CN_bb_srf_file    hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_vbs" ver="cam6">atm/cam/chem/emis/finn1.5/CONUSne30x8/emissions-finnv1.5_CH3CN_bb_surface_20100101-20171231_ne0conus_c200619.nc</CH3CN_bb_srf_file>
-<CH3COCH3_an_srf_file hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_vbs" ver="cam6">atm/cam/chem/emis/CAMS_Anthro_ne0CONUSne30x8/CAMS-GLOB-ANT_Glb_ne0CONUSne30x8_anthro_surface_CH3COCH3_v3.1_c20191103.nc</CH3COCH3_an_srf_file>
-<CH3COCH3_bb_srf_file hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_vbs" ver="cam6">atm/cam/chem/emis/finn1.5/CONUSne30x8/emissions-finnv1.5_CH3COCH3_bb_surface_20100101-20171231_ne0conus_c200619.nc</CH3COCH3_bb_srf_file>
-<CH3COCHO_bb_srf_file hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_vbs" ver="cam6">atm/cam/chem/emis/finn1.5/CONUSne30x8/emissions-finnv1.5_CH3COCHO_bb_surface_20100101-20171231_ne0conus_c200619.nc</CH3COCHO_bb_srf_file>
-<CH3COOH_an_srf_file  hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_vbs" ver="cam6">atm/cam/chem/emis/CAMS_Anthro_ne0CONUSne30x8/CAMS-GLOB-ANT_Glb_ne0CONUSne30x8_anthro_surface_CH3COOH_v3.1_c20191103.nc</CH3COOH_an_srf_file>
-<CH3COOH_bb_srf_file  hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_vbs" ver="cam6">atm/cam/chem/emis/finn1.5/CONUSne30x8/emissions-finnv1.5_CH3COOH_bb_surface_20100101-20171231_ne0conus_c200619.nc</CH3COOH_bb_srf_file>
-<CH3OH_an_srf_file    hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_vbs" ver="cam6">atm/cam/chem/emis/CAMS_Anthro_ne0CONUSne30x8/CAMS-GLOB-ANT_Glb_ne0CONUSne30x8_anthro_surface_CH3OH_v3.1_c20191103.nc</CH3OH_an_srf_file>
-<CH3OH_bb_srf_file    hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_vbs" ver="cam6">atm/cam/chem/emis/finn1.5/CONUSne30x8/emissions-finnv1.5_CH3OH_bb_surface_20100101-20171231_ne0conus_c200619.nc</CH3OH_bb_srf_file>
-<CO_an_srf_file       hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_vbs" ver="cam6">atm/cam/chem/emis/CAMS_Anthro_ne0CONUSne30x8/CAMS-GLOB-ANT_Glb_ne0CONUSne30x8_anthro_surface_CO_v3.1_c20191103.nc</CO_an_srf_file>
-<CO_bb_srf_file       hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_vbs" ver="cam6">atm/cam/chem/emis/finn1.5/CONUSne30x8/emissions-finnv1.5_CO_bb_surface_20100101-20171231_ne0conus_c200619.nc</CO_bb_srf_file>
-<CO_ot_srf_file       hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_vbs" ver="cam6">atm/cam/chem/emis/historical_ne0CONUSne30x8/emissions-cmip6_CO_other_surface_1750_2015_historical_ne0CONUSne30x8_c20191028.nc</CO_ot_srf_file>
-<CRESOL_bb_srf_file   hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_vbs" ver="cam6">atm/cam/chem/emis/finn1.5/CONUSne30x8/emissions-finnv1.5_CRESOL_bb_surface_20100101-20171231_ne0conus_c200619.nc</CRESOL_bb_srf_file>
-<dms_ot_srf_file      hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_vbs" ver="cam6">atm/cam/chem/emis/historical_ne0CONUSne30x8/emissions-cmip6_DMS_other_surface_1750_2015_historical_ne0CONUSne30x8_c20191028.nc</dms_ot_srf_file>
-<GLYALD_bb_srf_file   hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_vbs" ver="cam6">atm/cam/chem/emis/finn1.5/CONUSne30x8/emissions-finnv1.5_GLYALD_bb_surface_20100101-20171231_ne0conus_c200619.nc</GLYALD_bb_srf_file>
-<HCN_an_srf_file      hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_vbs" ver="cam6">atm/cam/chem/emis/CAMS_Anthro_ne0CONUSne30x8/CAMS-GLOB-ANT_Glb_ne0CONUSne30x8_anthro_surface_HCN_v3.1_c20191103.nc</HCN_an_srf_file>
-<HCN_bb_srf_file      hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_vbs" ver="cam6">atm/cam/chem/emis/finn1.5/CONUSne30x8/emissions-finnv1.5_HCN_bb_surface_20100101-20171231_ne0conus_c200619.nc</HCN_bb_srf_file>
-<HCOOH_an_srf_file    hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_vbs" ver="cam6">atm/cam/chem/emis/CAMS_Anthro_ne0CONUSne30x8/CAMS-GLOB-ANT_Glb_ne0CONUSne30x8_anthro_surface_HCOOH_v3.1_c20191103.nc</HCOOH_an_srf_file>
-<HCOOH_bb_srf_file    hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_vbs" ver="cam6">atm/cam/chem/emis/finn1.5/CONUSne30x8/emissions-finnv1.5_HCOOH_bb_surface_20100101-20171231_ne0conus_c200619.nc</HCOOH_bb_srf_file>
-<HYAC_bb_srf_file     hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_vbs" ver="cam6">atm/cam/chem/emis/finn1.5/CONUSne30x8/emissions-finnv1.5_HYAC_bb_surface_20100101-20171231_ne0conus_c200619.nc</HYAC_bb_srf_file>
-<ISOP_an_srf_file     hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_vbs" ver="cam6">atm/cam/chem/emis/CAMS_Anthro_ne0CONUSne30x8/CAMS-GLOB-ANT_Glb_ne0CONUSne30x8_anthro_surface_ISOP_v3.1_c20191103.nc</ISOP_an_srf_file>
-<ISOP_bb_srf_file     hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_vbs" ver="cam6">atm/cam/chem/emis/finn1.5/CONUSne30x8/emissions-finnv1.5_ISOP_bb_surface_20100101-20171231_ne0conus_c200619.nc</ISOP_bb_srf_file>
-<IVOC_an_srf_file     hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_vbs" ver="cam6">atm/cam/chem/emis/CAMS_Anthro_ne0CONUSne30x8/CAMS-GLOB-ANT_Glb_ne0CONUSne30x8_anthro_surface_IVOC_v3.1_c20191103.nc</IVOC_an_srf_file>
-<IVOC_bb_srf_file     hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_vbs" ver="cam6">atm/cam/chem/emis/finn1.5/CONUSne30x8/emissions-finnv1.5_IVOC_bb_surface_20100101-20171231_ne0conus_c200619.nc</IVOC_bb_srf_file>
-<MACR_bb_srf_file     hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_vbs" ver="cam6">atm/cam/chem/emis/finn1.5/CONUSne30x8/emissions-finnv1.5_MACR_bb_surface_20100101-20171231_ne0conus_c200619.nc</MACR_bb_srf_file>
-<MEK_an_srf_file      hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_vbs" ver="cam6">atm/cam/chem/emis/CAMS_Anthro_ne0CONUSne30x8/CAMS-GLOB-ANT_Glb_ne0CONUSne30x8_anthro_surface_MEK_v3.1_c20191103.nc</MEK_an_srf_file>
-<MEK_bb_srf_file      hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_vbs" ver="cam6">atm/cam/chem/emis/finn1.5/CONUSne30x8/emissions-finnv1.5_MEK_bb_surface_20100101-20171231_ne0conus_c200619.nc</MEK_bb_srf_file>
-<MTERP_an_srf_file    hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_vbs" ver="cam6">atm/cam/chem/emis/CAMS_Anthro_ne0CONUSne30x8/CAMS-GLOB-ANT_Glb_ne0CONUSne30x8_anthro_surface_MTERP_v3.1_c20191103.nc</MTERP_an_srf_file>
-<MTERP_bb_srf_file    hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_vbs" ver="cam6">atm/cam/chem/emis/finn1.5/CONUSne30x8/emissions-finnv1.5_TERPENES_bb_surface_20100101-20171231_ne0conus_c200619.nc</MTERP_bb_srf_file>
-<MVK_bb_srf_file      hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_vbs" ver="cam6">atm/cam/chem/emis/finn1.5/CONUSne30x8/emissions-finnv1.5_MVK_bb_surface_20100101-20171231_ne0conus_c200619.nc</MVK_bb_srf_file>
-<NH3_an_srf_file      hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_vbs" ver="cam6">atm/cam/chem/emis/CAMS_Anthro_ne0CONUSne30x8/CAMS-GLOB-ANT_Glb_ne0CONUSne30x8_anthro_surface_NH3_v3.1_c20191103.nc</NH3_an_srf_file>
-<NH3_bb_srf_file      hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_vbs" ver="cam6">atm/cam/chem/emis/finn1.5/CONUSne30x8/emissions-finnv1.5_NH3_bb_surface_20100101-20171231_ne0conus_c200619.nc</NH3_bb_srf_file>
-<NH3_ot_srf_file      hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_vbs" ver="cam6">atm/cam/chem/emis/historical_ne0CONUSne30x8/emissions-cmip6_NH3_other_surface_1750_2015_historical_ne0CONUSne30x8_c20191028.nc</NH3_ot_srf_file>
-<NO_an_srf_file       hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_vbs" ver="cam6">atm/cam/chem/emis/CAMS_Anthro_ne0CONUSne30x8/CAMS-GLOB-ANT_Glb_ne0CONUSne30x8_anthro_surface_NOx_v3.1_c20191103.nc</NO_an_srf_file>
-<NO_bb_srf_file       hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_vbs" ver="cam6">atm/cam/chem/emis/finn1.5/CONUSne30x8/emissions-finnv1.5_NO_bb_surface_20100101-20171231_ne0conus_c200619.nc</NO_bb_srf_file>
-<NO_ot_srf_file       hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_vbs" ver="cam6">atm/cam/chem/emis/historical_ne0CONUSne30x8/emissions-cmip6_NO_other_surface_1750_2015_historical_ne0CONUSne30x8_c20191028.nc</NO_ot_srf_file>
-<NO2_bb_srf_file      hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_vbs" ver="cam6">atm/cam/chem/emis/finn1.5/CONUSne30x8/emissions-finnv1.5_NO2_bb_surface_20100101-20171231_ne0conus_c200619.nc</NO2_bb_srf_file>
-<so2_ag_sh_file       hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_vbs" ver="cam6">atm/cam/chem/emis/CAMS_Anthro_ne0CONUSne30x8/CAMS-GLOB-ANT_Glb_ne0CONUSne30x8_SO2_anthro-ag-ship-res_surface_v3.1_c20191103.nc</so2_ag_sh_file>
-<so2_an_srf_file      hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_vbs" ver="cam6">atm/cam/chem/emis/CAMS_Anthro_ne0CONUSne30x8/CAMS-GLOB-ANT_Glb_ne0CONUSne30x8_SO2_anthro-ene_surface_v3.1_c20191103.nc</so2_an_srf_file>
-<so2_bb_srf_file      hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_vbs" ver="cam6">atm/cam/chem/emis/finn1.5/CONUSne30x8/emissions-finnv1.5_SO2_bb_surface_20100101-20171231_ne0conus_c200619.nc</so2_bb_srf_file>
-<SOAG_an_srf_file     hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_vbs" ver="cam6">atm/cam/chem/emis/CAMS_Anthro_ne0CONUSne30x8/CAMS-GLOB-ANT_Glb_ne0CONUSne30x8_anthro_surface_SOAGx1.5_v3.1_c20191103.nc</SOAG_an_srf_file>
-<SVOC_an_srf_file     hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_vbs" ver="cam6">atm/cam/chem/emis/CAMS_Anthro_ne0CONUSne30x8/CAMS-GLOB-ANT_Glb_ne0CONUSne30x8_anthro_surface_SVOC_v3.1_c20191103.nc</SVOC_an_srf_file>
-<SVOC_bb_srf_file     hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_vbs" ver="cam6">atm/cam/chem/emis/finn1.5/CONUSne30x8/emissions-finnv1.5_SVOC_bb_surface_20100101-20171231_ne0conus_c200619.nc</SVOC_bb_srf_file>
-<TOLUENE_an_srf_file  hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_vbs" ver="cam6">atm/cam/chem/emis/CAMS_Anthro_ne0CONUSne30x8/CAMS-GLOB-ANT_Glb_ne0CONUSne30x8_anthro_surface_TOLUENE_v3.1_c20191103.nc</TOLUENE_an_srf_file>
-<TOLUENE_bb_srf_file  hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_vbs" ver="cam6">atm/cam/chem/emis/finn1.5/CONUSne30x8/emissions-finnv1.5_TOLUENE_bb_surface_20100101-20171231_ne0conus_c200619.nc</TOLUENE_bb_srf_file>
-<XYLENES_an_srf_file  hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_vbs" ver="cam6">atm/cam/chem/emis/CAMS_Anthro_ne0CONUSne30x8/CAMS-GLOB-ANT_Glb_ne0CONUSne30x8_anthro_surface_XYLENES_v3.1_c20191103.nc</XYLENES_an_srf_file>
-<XYLENES_bb_srf_file  hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_vbs" ver="cam6">atm/cam/chem/emis/finn1.5/CONUSne30x8/emissions-finnv1.5_XYLENES_bb_surface_20100101-20171231_ne0conus_c200619.nc</XYLENES_bb_srf_file>
+<BIGALD_bb_srf_file   hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_t1s1" ver="cam6">atm/cam/chem/emis/finn1.5/CONUSne30x8/emissions-finnv1.5_BIGALD_bb_surface_20100101-20171231_ne0conus_c200619.nc</BIGALD_bb_srf_file>
+<BIGALK_an_srf_file   hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_t1s1" ver="cam6">atm/cam/chem/emis/CAMS_Anthro_ne0CONUSne30x8/CAMS-GLOB-ANT_Glb_ne0CONUSne30x8_anthro_surface_BIGALK_v3.1_c20191103.nc</BIGALK_an_srf_file>
+<BIGALK_bb_srf_file   hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_t1s1" ver="cam6">atm/cam/chem/emis/finn1.5/CONUSne30x8/emissions-finnv1.5_BIGALK_bb_surface_20100101-20171231_ne0conus_c200619.nc</BIGALK_bb_srf_file>
+<BIGENE_an_srf_file   hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_t1s1" ver="cam6">atm/cam/chem/emis/CAMS_Anthro_ne0CONUSne30x8/CAMS-GLOB-ANT_Glb_ne0CONUSne30x8_anthro_surface_BIGENE_v3.1_c20191103.nc</BIGENE_an_srf_file>
+<BIGENE_bb_srf_file   hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_t1s1" ver="cam6">atm/cam/chem/emis/finn1.5/CONUSne30x8/emissions-finnv1.5_BIGENE_bb_surface_20100101-20171231_ne0conus_c200619.nc</BIGENE_bb_srf_file>
+<C2H2_an_srf_file     hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_t1s1" ver="cam6">atm/cam/chem/emis/CAMS_Anthro_ne0CONUSne30x8/CAMS-GLOB-ANT_Glb_ne0CONUSne30x8_anthro_surface_C2H2_v3.1_c20191103.nc</C2H2_an_srf_file>
+<C2H2_bb_srf_file     hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_t1s1" ver="cam6">atm/cam/chem/emis/finn1.5/CONUSne30x8/emissions-finnv1.5_C2H2_bb_surface_20100101-20171231_ne0conus_c200619.nc</C2H2_bb_srf_file>
+<C2H4_an_srf_file     hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_t1s1" ver="cam6">atm/cam/chem/emis/CAMS_Anthro_ne0CONUSne30x8/CAMS-GLOB-ANT_Glb_ne0CONUSne30x8_anthro_surface_C2H4_v3.1_c20191103.nc</C2H4_an_srf_file>
+<C2H4_bb_srf_file     hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_t1s1" ver="cam6">atm/cam/chem/emis/finn1.5/CONUSne30x8/emissions-finnv1.5_C2H4_bb_surface_20100101-20171231_ne0conus_c200619.nc</C2H4_bb_srf_file>
+<C2H4_ot_srf_file     hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_t1s1" ver="cam6">atm/cam/chem/emis/historical_ne0CONUSne30x8/emissions-cmip6_C2H4_other_surface_1750_2015_historical_ne0CONUSne30x8_c20191028.nc</C2H4_ot_srf_file>
+<C2H5OH_an_srf_file   hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_t1s1" ver="cam6">atm/cam/chem/emis/CAMS_Anthro_ne0CONUSne30x8/CAMS-GLOB-ANT_Glb_ne0CONUSne30x8_anthro_surface_C2H5OH_v3.1_c20191103.nc</C2H5OH_an_srf_file>
+<C2H5OH_bb_srf_file   hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_t1s1" ver="cam6">atm/cam/chem/emis/finn1.5/CONUSne30x8/emissions-finnv1.5_C2H5OH_bb_surface_20100101-20171231_ne0conus_c200619.nc</C2H5OH_bb_srf_file>
+<C2H6_an_srf_file     hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_t1s1" ver="cam6">atm/cam/chem/emis/CAMS_Anthro_ne0CONUSne30x8/CAMS-GLOB-ANT_Glb_ne0CONUSne30x8_anthro_surface_C2H6_v3.1_c20191103.nc</C2H6_an_srf_file>
+<C2H6_bb_srf_file     hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_t1s1" ver="cam6">atm/cam/chem/emis/finn1.5/CONUSne30x8/emissions-finnv1.5_C2H6_bb_surface_20100101-20171231_ne0conus_c200619.nc</C2H6_bb_srf_file>
+<C2H6_ot_srf_file     hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_t1s1" ver="cam6">atm/cam/chem/emis/historical_ne0CONUSne30x8/emissions-cmip6_C2H6_other_surface_1750_2015_historical_ne0CONUSne30x8_c20191028.nc</C2H6_ot_srf_file>
+<C3H6_an_srf_file     hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_t1s1" ver="cam6">atm/cam/chem/emis/CAMS_Anthro_ne0CONUSne30x8/CAMS-GLOB-ANT_Glb_ne0CONUSne30x8_anthro_surface_C3H6_v3.1_c20191103.nc</C3H6_an_srf_file>
+<C3H6_bb_srf_file     hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_t1s1" ver="cam6">atm/cam/chem/emis/finn1.5/CONUSne30x8/emissions-finnv1.5_C3H6_bb_surface_20100101-20171231_ne0conus_c200619.nc</C3H6_bb_srf_file>
+<C3H6_ot_srf_file     hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_t1s1" ver="cam6">atm/cam/chem/emis/historical_ne0CONUSne30x8/emissions-cmip6_C3H6_other_surface_1750_2015_historical_ne0CONUSne30x8_c20191028.nc</C3H6_ot_srf_file>
+<C3H8_an_srf_file     hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_t1s1" ver="cam6">atm/cam/chem/emis/CAMS_Anthro_ne0CONUSne30x8/CAMS-GLOB-ANT_Glb_ne0CONUSne30x8_anthro_surface_C3H8_v3.1_c20191103.nc</C3H8_an_srf_file>
+<C3H8_bb_srf_file     hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_t1s1" ver="cam6">atm/cam/chem/emis/finn1.5/CONUSne30x8/emissions-finnv1.5_C3H8_bb_surface_20100101-20171231_ne0conus_c200619.nc</C3H8_bb_srf_file>
+<C3H8_ot_srf_file     hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_t1s1" ver="cam6">atm/cam/chem/emis/historical_ne0CONUSne30x8/emissions-cmip6_C3H8_other_surface_1750_2015_historical_ne0CONUSne30x8_c20191028.nc</C3H8_ot_srf_file>
+<CH2O_an_srf_file     hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_t1s1" ver="cam6">atm/cam/chem/emis/CAMS_Anthro_ne0CONUSne30x8/CAMS-GLOB-ANT_Glb_ne0CONUSne30x8_anthro_surface_CH2O_v3.1_c20191103.nc</CH2O_an_srf_file>
+<CH2O_bb_srf_file     hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_t1s1" ver="cam6">atm/cam/chem/emis/finn1.5/CONUSne30x8/emissions-finnv1.5_CH2O_bb_surface_20100101-20171231_ne0conus_c200619.nc</CH2O_bb_srf_file>
+<CH3CHO_an_srf_file   hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_t1s1" ver="cam6">atm/cam/chem/emis/CAMS_Anthro_ne0CONUSne30x8/CAMS-GLOB-ANT_Glb_ne0CONUSne30x8_anthro_surface_CH3CHO_v3.1_c20191103.nc</CH3CHO_an_srf_file>
+<CH3CHO_bb_srf_file   hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_t1s1" ver="cam6">atm/cam/chem/emis/finn1.5/CONUSne30x8/emissions-finnv1.5_CH3CHO_bb_surface_20100101-20171231_ne0conus_c200619.nc</CH3CHO_bb_srf_file>
+<CH3CN_an_srf_file    hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_t1s1" ver="cam6">atm/cam/chem/emis/CAMS_Anthro_ne0CONUSne30x8/CAMS-GLOB-ANT_Glb_ne0CONUSne30x8_anthro_surface_CH3CN_v3.1_c20191103.nc</CH3CN_an_srf_file>
+<CH3CN_bb_srf_file    hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_t1s1" ver="cam6">atm/cam/chem/emis/finn1.5/CONUSne30x8/emissions-finnv1.5_CH3CN_bb_surface_20100101-20171231_ne0conus_c200619.nc</CH3CN_bb_srf_file>
+<CH3COCH3_an_srf_file hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_t1s1" ver="cam6">atm/cam/chem/emis/CAMS_Anthro_ne0CONUSne30x8/CAMS-GLOB-ANT_Glb_ne0CONUSne30x8_anthro_surface_CH3COCH3_v3.1_c20191103.nc</CH3COCH3_an_srf_file>
+<CH3COCH3_bb_srf_file hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_t1s1" ver="cam6">atm/cam/chem/emis/finn1.5/CONUSne30x8/emissions-finnv1.5_CH3COCH3_bb_surface_20100101-20171231_ne0conus_c200619.nc</CH3COCH3_bb_srf_file>
+<CH3COCHO_bb_srf_file hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_t1s1" ver="cam6">atm/cam/chem/emis/finn1.5/CONUSne30x8/emissions-finnv1.5_CH3COCHO_bb_surface_20100101-20171231_ne0conus_c200619.nc</CH3COCHO_bb_srf_file>
+<CH3COOH_an_srf_file  hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_t1s1" ver="cam6">atm/cam/chem/emis/CAMS_Anthro_ne0CONUSne30x8/CAMS-GLOB-ANT_Glb_ne0CONUSne30x8_anthro_surface_CH3COOH_v3.1_c20191103.nc</CH3COOH_an_srf_file>
+<CH3COOH_bb_srf_file  hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_t1s1" ver="cam6">atm/cam/chem/emis/finn1.5/CONUSne30x8/emissions-finnv1.5_CH3COOH_bb_surface_20100101-20171231_ne0conus_c200619.nc</CH3COOH_bb_srf_file>
+<CH3OH_an_srf_file    hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_t1s1" ver="cam6">atm/cam/chem/emis/CAMS_Anthro_ne0CONUSne30x8/CAMS-GLOB-ANT_Glb_ne0CONUSne30x8_anthro_surface_CH3OH_v3.1_c20191103.nc</CH3OH_an_srf_file>
+<CH3OH_bb_srf_file    hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_t1s1" ver="cam6">atm/cam/chem/emis/finn1.5/CONUSne30x8/emissions-finnv1.5_CH3OH_bb_surface_20100101-20171231_ne0conus_c200619.nc</CH3OH_bb_srf_file>
+<CO_an_srf_file       hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_t1s1" ver="cam6">atm/cam/chem/emis/CAMS_Anthro_ne0CONUSne30x8/CAMS-GLOB-ANT_Glb_ne0CONUSne30x8_anthro_surface_CO_v3.1_c20191103.nc</CO_an_srf_file>
+<CO_bb_srf_file       hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_t1s1" ver="cam6">atm/cam/chem/emis/finn1.5/CONUSne30x8/emissions-finnv1.5_CO_bb_surface_20100101-20171231_ne0conus_c200619.nc</CO_bb_srf_file>
+<CO_ot_srf_file       hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_t1s1" ver="cam6">atm/cam/chem/emis/historical_ne0CONUSne30x8/emissions-cmip6_CO_other_surface_1750_2015_historical_ne0CONUSne30x8_c20191028.nc</CO_ot_srf_file>
+<CRESOL_bb_srf_file   hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_t1s1" ver="cam6">atm/cam/chem/emis/finn1.5/CONUSne30x8/emissions-finnv1.5_CRESOL_bb_surface_20100101-20171231_ne0conus_c200619.nc</CRESOL_bb_srf_file>
+<dms_ot_srf_file      hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_t1s1" ver="cam6">atm/cam/chem/emis/historical_ne0CONUSne30x8/emissions-cmip6_DMS_other_surface_1750_2015_historical_ne0CONUSne30x8_c20191028.nc</dms_ot_srf_file>
+<GLYALD_bb_srf_file   hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_t1s1" ver="cam6">atm/cam/chem/emis/finn1.5/CONUSne30x8/emissions-finnv1.5_GLYALD_bb_surface_20100101-20171231_ne0conus_c200619.nc</GLYALD_bb_srf_file>
+<HCN_an_srf_file      hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_t1s1" ver="cam6">atm/cam/chem/emis/CAMS_Anthro_ne0CONUSne30x8/CAMS-GLOB-ANT_Glb_ne0CONUSne30x8_anthro_surface_HCN_v3.1_c20191103.nc</HCN_an_srf_file>
+<HCN_bb_srf_file      hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_t1s1" ver="cam6">atm/cam/chem/emis/finn1.5/CONUSne30x8/emissions-finnv1.5_HCN_bb_surface_20100101-20171231_ne0conus_c200619.nc</HCN_bb_srf_file>
+<HCOOH_an_srf_file    hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_t1s1" ver="cam6">atm/cam/chem/emis/CAMS_Anthro_ne0CONUSne30x8/CAMS-GLOB-ANT_Glb_ne0CONUSne30x8_anthro_surface_HCOOH_v3.1_c20191103.nc</HCOOH_an_srf_file>
+<HCOOH_bb_srf_file    hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_t1s1" ver="cam6">atm/cam/chem/emis/finn1.5/CONUSne30x8/emissions-finnv1.5_HCOOH_bb_surface_20100101-20171231_ne0conus_c200619.nc</HCOOH_bb_srf_file>
+<HYAC_bb_srf_file     hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_t1s1" ver="cam6">atm/cam/chem/emis/finn1.5/CONUSne30x8/emissions-finnv1.5_HYAC_bb_surface_20100101-20171231_ne0conus_c200619.nc</HYAC_bb_srf_file>
+<ISOP_an_srf_file     hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_t1s1" ver="cam6">atm/cam/chem/emis/CAMS_Anthro_ne0CONUSne30x8/CAMS-GLOB-ANT_Glb_ne0CONUSne30x8_anthro_surface_ISOP_v3.1_c20191103.nc</ISOP_an_srf_file>
+<ISOP_bb_srf_file     hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_t1s1" ver="cam6">atm/cam/chem/emis/finn1.5/CONUSne30x8/emissions-finnv1.5_ISOP_bb_surface_20100101-20171231_ne0conus_c200619.nc</ISOP_bb_srf_file>
+<IVOC_an_srf_file     hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_t1s1" ver="cam6">atm/cam/chem/emis/CAMS_Anthro_ne0CONUSne30x8/CAMS-GLOB-ANT_Glb_ne0CONUSne30x8_anthro_surface_IVOC_v3.1_c20191103.nc</IVOC_an_srf_file>
+<IVOC_bb_srf_file     hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_t1s1" ver="cam6">atm/cam/chem/emis/finn1.5/CONUSne30x8/emissions-finnv1.5_IVOC_bb_surface_20100101-20171231_ne0conus_c200619.nc</IVOC_bb_srf_file>
+<MACR_bb_srf_file     hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_t1s1" ver="cam6">atm/cam/chem/emis/finn1.5/CONUSne30x8/emissions-finnv1.5_MACR_bb_surface_20100101-20171231_ne0conus_c200619.nc</MACR_bb_srf_file>
+<MEK_an_srf_file      hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_t1s1" ver="cam6">atm/cam/chem/emis/CAMS_Anthro_ne0CONUSne30x8/CAMS-GLOB-ANT_Glb_ne0CONUSne30x8_anthro_surface_MEK_v3.1_c20191103.nc</MEK_an_srf_file>
+<MEK_bb_srf_file      hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_t1s1" ver="cam6">atm/cam/chem/emis/finn1.5/CONUSne30x8/emissions-finnv1.5_MEK_bb_surface_20100101-20171231_ne0conus_c200619.nc</MEK_bb_srf_file>
+<MTERP_an_srf_file    hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_t1s1" ver="cam6">atm/cam/chem/emis/CAMS_Anthro_ne0CONUSne30x8/CAMS-GLOB-ANT_Glb_ne0CONUSne30x8_anthro_surface_MTERP_v3.1_c20191103.nc</MTERP_an_srf_file>
+<MTERP_bb_srf_file    hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_t1s1" ver="cam6">atm/cam/chem/emis/finn1.5/CONUSne30x8/emissions-finnv1.5_TERPENES_bb_surface_20100101-20171231_ne0conus_c200619.nc</MTERP_bb_srf_file>
+<MVK_bb_srf_file      hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_t1s1" ver="cam6">atm/cam/chem/emis/finn1.5/CONUSne30x8/emissions-finnv1.5_MVK_bb_surface_20100101-20171231_ne0conus_c200619.nc</MVK_bb_srf_file>
+<NH3_an_srf_file      hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_t1s1" ver="cam6">atm/cam/chem/emis/CAMS_Anthro_ne0CONUSne30x8/CAMS-GLOB-ANT_Glb_ne0CONUSne30x8_anthro_surface_NH3_v3.1_c20191103.nc</NH3_an_srf_file>
+<NH3_bb_srf_file      hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_t1s1" ver="cam6">atm/cam/chem/emis/finn1.5/CONUSne30x8/emissions-finnv1.5_NH3_bb_surface_20100101-20171231_ne0conus_c200619.nc</NH3_bb_srf_file>
+<NH3_ot_srf_file      hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_t1s1" ver="cam6">atm/cam/chem/emis/historical_ne0CONUSne30x8/emissions-cmip6_NH3_other_surface_1750_2015_historical_ne0CONUSne30x8_c20191028.nc</NH3_ot_srf_file>
+<NO_an_srf_file       hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_t1s1" ver="cam6">atm/cam/chem/emis/CAMS_Anthro_ne0CONUSne30x8/CAMS-GLOB-ANT_Glb_ne0CONUSne30x8_anthro_surface_NOx_v3.1_c20191103.nc</NO_an_srf_file>
+<NO_bb_srf_file       hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_t1s1" ver="cam6">atm/cam/chem/emis/finn1.5/CONUSne30x8/emissions-finnv1.5_NO_bb_surface_20100101-20171231_ne0conus_c200619.nc</NO_bb_srf_file>
+<NO_ot_srf_file       hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_t1s1" ver="cam6">atm/cam/chem/emis/historical_ne0CONUSne30x8/emissions-cmip6_NO_other_surface_1750_2015_historical_ne0CONUSne30x8_c20191028.nc</NO_ot_srf_file>
+<NO2_bb_srf_file      hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_t1s1" ver="cam6">atm/cam/chem/emis/finn1.5/CONUSne30x8/emissions-finnv1.5_NO2_bb_surface_20100101-20171231_ne0conus_c200619.nc</NO2_bb_srf_file>
+<so2_ag_sh_file       hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_t1s1" ver="cam6">atm/cam/chem/emis/CAMS_Anthro_ne0CONUSne30x8/CAMS-GLOB-ANT_Glb_ne0CONUSne30x8_SO2_anthro-ag-ship-res_surface_v3.1_c20191103.nc</so2_ag_sh_file>
+<so2_an_srf_file      hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_t1s1" ver="cam6">atm/cam/chem/emis/CAMS_Anthro_ne0CONUSne30x8/CAMS-GLOB-ANT_Glb_ne0CONUSne30x8_SO2_anthro-ene_surface_v3.1_c20191103.nc</so2_an_srf_file>
+<so2_bb_srf_file      hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_t1s1" ver="cam6">atm/cam/chem/emis/finn1.5/CONUSne30x8/emissions-finnv1.5_SO2_bb_surface_20100101-20171231_ne0conus_c200619.nc</so2_bb_srf_file>
+<SOAG_an_srf_file     hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_t1s1" ver="cam6">atm/cam/chem/emis/CAMS_Anthro_ne0CONUSne30x8/CAMS-GLOB-ANT_Glb_ne0CONUSne30x8_anthro_surface_SOAGx1.5_v3.1_c20191103.nc</SOAG_an_srf_file>
+<SVOC_an_srf_file     hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_t1s1" ver="cam6">atm/cam/chem/emis/CAMS_Anthro_ne0CONUSne30x8/CAMS-GLOB-ANT_Glb_ne0CONUSne30x8_anthro_surface_SVOC_v3.1_c20191103.nc</SVOC_an_srf_file>
+<SVOC_bb_srf_file     hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_t1s1" ver="cam6">atm/cam/chem/emis/finn1.5/CONUSne30x8/emissions-finnv1.5_SVOC_bb_surface_20100101-20171231_ne0conus_c200619.nc</SVOC_bb_srf_file>
+<TOLUENE_an_srf_file  hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_t1s1" ver="cam6">atm/cam/chem/emis/CAMS_Anthro_ne0CONUSne30x8/CAMS-GLOB-ANT_Glb_ne0CONUSne30x8_anthro_surface_TOLUENE_v3.1_c20191103.nc</TOLUENE_an_srf_file>
+<TOLUENE_bb_srf_file  hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_t1s1" ver="cam6">atm/cam/chem/emis/finn1.5/CONUSne30x8/emissions-finnv1.5_TOLUENE_bb_surface_20100101-20171231_ne0conus_c200619.nc</TOLUENE_bb_srf_file>
+<XYLENES_an_srf_file  hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_t1s1" ver="cam6">atm/cam/chem/emis/CAMS_Anthro_ne0CONUSne30x8/CAMS-GLOB-ANT_Glb_ne0CONUSne30x8_anthro_surface_XYLENES_v3.1_c20191103.nc</XYLENES_an_srf_file>
+<XYLENES_bb_srf_file  hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_t1s1" ver="cam6">atm/cam/chem/emis/finn1.5/CONUSne30x8/emissions-finnv1.5_XYLENES_bb_surface_20100101-20171231_ne0conus_c200619.nc</XYLENES_bb_srf_file>
 
 <!-- SCAM CMIP emissions - lightweight set of emissions files for single column -->
 
@@ -2022,6 +2057,8 @@
 <drydep_srf_file hgrid="ne0np4CONUS.ne30x8"      >atm/cam/chem/trop_mam/atmsrf_ne0np4conus30x8_161116.nc</drydep_srf_file>
 <drydep_srf_file hgrid="ne0np4.ARCTIC.ne30x4"    >atm/cam/chem/trop_mam/atmsrf_ne30x4_ARCTIC_191011.nc</drydep_srf_file>
 <drydep_srf_file hgrid="ne0np4.ARCTICGRIS.ne30x8">atm/cam/chem/trop_mam/atmsrf_ne30x8_ARCTICGRIS_191212.nc</drydep_srf_file>
+<drydep_srf_file hgrid="ne0np4.POLARCAP.ne30x4"  >atm/cam/chem/trop_mam/atmsrf_POLARCAP_250322.nc</drydep_srf_file>
+<drydep_srf_file hgrid="ne0np4.NATL.ne30x8"      >atm/cam/chem/trop_mam/atmsrf_ne0np4.NATL.ne30x8_201109.nc</drydep_srf_file>
 
 <drydep_srf_file hgrid="C24">atm/cam/chem/trop_mam/atmsrf_C24_c200625.nc</drydep_srf_file>
 <drydep_srf_file hgrid="C48">atm/cam/chem/trop_mam/atmsrf_C48_c200625.nc</drydep_srf_file>
@@ -2045,8 +2082,10 @@
 
 <!-- photolysis inputs -->
 <xs_coef_file>atm/waccm/phot/effxstex.txt</xs_coef_file>
-<xs_short_file>atm/waccm/phot/xs_short_c221005mm.nc</xs_short_file>
-<xs_long_file >atm/waccm/phot/temp_prs_GT200nm_c221005mm.nc</xs_long_file>
+<xs_short_file>atm/waccm/phot/xs_short_c221005mm_slh_c250930.nc</xs_short_file>
+<xs_long_file >atm/waccm/phot/temp_prs_GT200nm_c221005mm_slh_c250930.nc</xs_long_file>
+<xs_short_file phys="cam7">atm/waccm/phot/xs_short_c250124mm.nc</xs_short_file>
+<xs_long_file  phys="cam7">atm/waccm/phot/temp_prs_GT200nm_c250124mm.nc</xs_long_file>
 <rsf_file     >atm/waccm/phot/RSF_GT200nm_v3.0_c080811.nc</rsf_file>
 <exo_coldens_file>atm/cam/chem/trop_mozart/phot/exo_coldens.nc</exo_coldens_file>
 
@@ -2058,6 +2097,13 @@
 </ubc_specifier>
 <ubc_specifier ver="waccmsc">
   'T->MSIS','Q->2.d-8vmr','CH4->2.d-10vmr'
+</ubc_specifier>
+<!-- WACCM7 -- do not include water vapor for now -->
+<ubc_specifier ver="waccm7chem">
+  'T->MSIS','CH4->2.d-10vmr','F->1.0D-15mmr','HF->1.0D-15mmr','H->MSIS','N->MSIS','O->MSIS','O2->MSIS','H2->TGCM','NO->SNOE'
+</ubc_specifier>
+<ubc_specifier ver="waccm7sc">
+  'T->MSIS','CH4->2.d-10vmr'
 </ubc_specifier>
 
 <!-- Boundary data for Tropopheric Chemistry -->
@@ -2073,7 +2119,7 @@
 <stream_ndep_mesh_filename>share/meshes/fv0.9x1.25_141008_polemod_ESMFmesh.nc</stream_ndep_mesh_filename>
 
 <stream_ndep_data_filename >lnd/clm2/ndepdata/fndep_clm_hist_b.e21.BWHIST.f09_g17.CMIP6-historical-WACCM.ensmean_1849-2015_monthly_0.9x1.25_c180926.nc</stream_ndep_data_filename>
-<stream_ndep_data_filename sim_year="1850">lnd/clm2/ndepdata/fndep_clm_WACCM6_CMIP6piControl001_y21-50avg_1850monthly_0.95x1.25_c180802.nc</stream_ndep_data_filename>
+<stream_ndep_data_filename sim_year="1850">atm/cam/chem/trop_strat_mam5_ts4_aero_spinup/ndep/fndep_clm_B1850C_MT4s.1850monthly.ne30_c251220.nc</stream_ndep_data_filename>
 
 <!-- Turbulent Mountain Stress -->
 <do_tms                                                     > .false. </do_tms>
@@ -2098,6 +2144,9 @@
 <do_iss phys="cam6"      > .true.  </do_iss>
 <do_iss phys="cam7"      > .true.  </do_iss>
 
+<!-- Sponge layer vertical diffusion factor -->
+<diff_sponge_fac               > 0.0D0 </diff_sponge_fac>
+
 <!-- Use convective water in radiation calculation -->
 <conv_water_in_rad                  > 0 </conv_water_in_rad>
 <conv_water_in_rad phys="cam5"      > 1 </conv_water_in_rad>
@@ -2121,6 +2170,7 @@
 <clubb_timestep                                   > 300.0D0 </clubb_timestep>
 <clubb_rnevap_effic                               > 1.0D0   </clubb_rnevap_effic>
 <clubb_do_icesuper                                > .false. </clubb_do_icesuper>
+<clubb_l_ascending_grid                           > .false. </clubb_l_ascending_grid>
 
 
 <!-- Lscale_from_tau set by clubb_opts config option -->
@@ -2162,6 +2212,7 @@
 <clubb_c_K1                                       > 0.75    </clubb_c_K1>
 <clubb_c_K10                                      > 0.5     </clubb_c_K10>
 <clubb_c_K10h                                     > 0.3     </clubb_c_K10h>
+<clubb_c_K10h phys="cam7"                         > 0.280   </clubb_c_K10h>
 <clubb_c_K2                                       > 0.125   </clubb_c_K2>
 <clubb_c_K8                                       > 1.25    </clubb_c_K8>
 <clubb_c_K9                                       > 0.25    </clubb_c_K9>
@@ -2181,9 +2232,13 @@
 <clubb_gamma_coef hgrid="1.9x2.5" phys="cam6"     > 0.280   </clubb_gamma_coef>
 <clubb_gamma_coefb                                > 0.32    </clubb_gamma_coefb>
 <clubb_gamma_coefb phys="cam7"                    > 0.3     </clubb_gamma_coefb>
+<clubb_grid_adapt_in_time_method                  > 0       </clubb_grid_adapt_in_time_method>
+<clubb_fill_holes_type                            > 2       </clubb_fill_holes_type>
+<clubb_grid_remap_method                          > 1       </clubb_grid_remap_method>
 <clubb_ipdf_call_placement                        > 2       </clubb_ipdf_call_placement>
 <clubb_lambda0_stability_coef                     > 0.04    </clubb_lambda0_stability_coef>
 <clubb_lmin_coef                                  > 0.1     </clubb_lmin_coef>
+<clubb_l_add_dycore_grid                          > .false. </clubb_l_add_dycore_grid>
 <clubb_l_brunt_vaisala_freq_moist                 > .false. </clubb_l_brunt_vaisala_freq_moist>
 <clubb_l_C2_cloud_frac                            > .false. </clubb_l_C2_cloud_frac>
 <clubb_l_calc_thlp2_rad                           > .true.  </clubb_l_calc_thlp2_rad>
@@ -2216,6 +2271,8 @@
 <clubb_l_partial_upwind_wp3                       > .false. </clubb_l_partial_upwind_wp3>
 <clubb_l_predict_upwp_vpwp                        > .false. </clubb_l_predict_upwp_vpwp>
 <clubb_l_predict_upwp_vpwp phys="cam7"            > .true.  </clubb_l_predict_upwp_vpwp>
+<clubb_l_ho_nontrad_coriolis                      > .false. </clubb_l_ho_nontrad_coriolis>
+<clubb_l_ho_trad_coriolis                         > .false. </clubb_l_ho_trad_coriolis>
 <clubb_l_prescribed_avg_deltaz                    > .false. </clubb_l_prescribed_avg_deltaz>
 <clubb_l_rcm_supersat_adj                         > .false. </clubb_l_rcm_supersat_adj>
 <clubb_l_rtm_nudge                                > .false. </clubb_l_rtm_nudge>
@@ -2352,6 +2409,7 @@
 
 <micro_mg_accre_enhan_fact                  >  1.D0    </micro_mg_accre_enhan_fact>
 <micro_mg_accre_enhan_fact microphys="mg2"  >  1.D0    </micro_mg_accre_enhan_fact>
+<micro_mg_accre_enhan_fact phys="cam7"      >  0.731D0    </micro_mg_accre_enhan_fact>
 
 <micro_mg_autocon_fact                  >  0.01D0    </micro_mg_autocon_fact>
 <micro_mg_autocon_fact microphys="mg2"  >  0.01D0    </micro_mg_autocon_fact>
@@ -2359,8 +2417,9 @@
 <micro_mg_autocon_nd_exp                  >  -1.1D0    </micro_mg_autocon_nd_exp>
 <micro_mg_autocon_nd_exp microphys="mg2"  >  -1.1D0    </micro_mg_autocon_nd_exp>
 
-<micro_mg_autocon_lwp_exp                  >  2.47D0    </micro_mg_autocon_lwp_exp>
-<micro_mg_autocon_lwp_exp microphys="mg2"  >  2.47D0    </micro_mg_autocon_lwp_exp>
+<micro_mg_autocon_lwp_exp                 >  2.47D0    </micro_mg_autocon_lwp_exp>
+<micro_mg_autocon_lwp_exp microphys="mg2" >  2.47D0    </micro_mg_autocon_lwp_exp>
+<micro_mg_autocon_lwp_exp phys="cam7"     >  2.37D0    </micro_mg_autocon_lwp_exp>
 
 <microp_aero_bulk_scale                  >  2.D0    </microp_aero_bulk_scale>
 
@@ -2368,8 +2427,10 @@
 <microp_aero_npccn_scale microphys="mg2"  >  1.D0    </microp_aero_npccn_scale>
 
 <microp_aero_wsub_scale                  >  1.D0     </microp_aero_wsub_scale>
+<microp_aero_wsub_scale phys="cam7"      >  0.9D0     </microp_aero_wsub_scale>
 
 <microp_aero_wsubi_scale                  >  1.D0    </microp_aero_wsubi_scale>
+<microp_aero_wsubi_scale phys="cam7"      >  1.5D0    </microp_aero_wsubi_scale>
 
 <microp_aero_wsub_min                  >  0.2D0    </microp_aero_wsub_min>
 <microp_aero_wsub_min phys="cam7"      >  0.1D0    </microp_aero_wsub_min>
@@ -2383,6 +2444,7 @@
 <micro_mg_homog_size  microphys="mg2"  >  25.D-6    </micro_mg_homog_size>
 
 <micro_mg_vtrmi_factor                  >  1.D0    </micro_mg_vtrmi_factor>
+<micro_mg_vtrmi_factor phys="cam7"      >  1.39D0    </micro_mg_vtrmi_factor>
 <micro_mg_vtrms_factor                  >  1.D0    </micro_mg_vtrms_factor>
 
 <micro_mg_effi_factor                  >  1.D0    </micro_mg_effi_factor>
@@ -2409,7 +2471,7 @@
 <cld_macmic_num_steps microphys="mg2" clubb_sgs="1" dtime="600" > 1 </cld_macmic_num_steps>
 <cld_macmic_num_steps microphys="mg2" clubb_sgs="1" dtime="300" > 1 </cld_macmic_num_steps>
 <cld_macmic_num_steps microphys="mg3" clubb_sgs="1"> 3 </cld_macmic_num_steps>
-<!-- hi-res and var-res support for ne120, ARCTIC, ARCTCIGRIS, CONUS -->
+<!-- hi-res and var-res support for ne120, ARCTIC, ARCTICGRIS, POLARCAP, CONUS, NATL -->
 <cld_macmic_num_steps microphys="mg2" clubb_sgs="1" dtime="450" > 2 </cld_macmic_num_steps>
 <cld_macmic_num_steps microphys="mg2" clubb_sgs="1" dtime="225" > 1 </cld_macmic_num_steps>
 <cld_macmic_num_steps microphys="mg3" clubb_sgs="1" dtime="450" > 2 </cld_macmic_num_steps>
@@ -2497,55 +2559,47 @@
 <molec_diff_bot_press> 50.D0 </molec_diff_bot_press>
 
 <!-- dust emission tuning factor -->
+<!-- NOTE: by default cam7 uses dust_emis_method=Leung_2023, otherwise dust_emis_method = Zender_2003 -->
+<!-- if, e.g., one uses cam6 but selects Leung_2023, dust_emis_fact will need to be rechanged -->
 <dust_emis_fact                                                         >0.37D0</dust_emis_fact>
 <dust_emis_fact                            phys="cam5"                  >0.35D0</dust_emis_fact>
 <dust_emis_fact          hgrid="0.47x0.63" phys="cam5"                  >0.45D0</dust_emis_fact>
 <dust_emis_fact          hgrid="0.23x0.31" phys="cam5"                  >0.45D0</dust_emis_fact>
-<dust_emis_fact                            phys="cam6"                  >0.35D0</dust_emis_fact>
-<dust_emis_fact                            phys="cam7"                  >2.30D0</dust_emis_fact>
-<dust_emis_fact                            phys="cam6"      silhs="1"   >0.30D0</dust_emis_fact>
-<dust_emis_fact                            phys="cam7"      silhs="1"   >2.30D0</dust_emis_fact>
-<dust_emis_fact          hgrid="0.47x0.63" phys="cam6"                  >0.45D0</dust_emis_fact>
-<dust_emis_fact          hgrid="0.47x0.63" phys="cam7"                  >2.30D0</dust_emis_fact>
-<dust_emis_fact          hgrid="0.23x0.31" phys="cam6"                  >0.45D0</dust_emis_fact>
-<dust_emis_fact          hgrid="0.23x0.31" phys="cam7"                  >2.30D0</dust_emis_fact>
+<dust_emis_fact                            phys="cam6"                  >0.88D0</dust_emis_fact>
+<dust_emis_fact                            phys="cam7"                  >3.20D0</dust_emis_fact>
+<dust_emis_fact                            phys="cam6"      silhs="1"   >0.75D0</dust_emis_fact>
+<dust_emis_fact                            phys="cam7"      silhs="1"   >4.00D0</dust_emis_fact>
+<dust_emis_fact          hgrid="0.47x0.63" phys="cam6"                  >1.13D0</dust_emis_fact>
+<dust_emis_fact          hgrid="0.47x0.63" phys="cam7"                  >4.00D0</dust_emis_fact>
+<dust_emis_fact          hgrid="0.23x0.31" phys="cam6"                  >1.13D0</dust_emis_fact>
+<dust_emis_fact          hgrid="0.23x0.31" phys="cam7"                  >4.00D0</dust_emis_fact>
 
 <dust_emis_fact dyn="se"                   phys="cam5"                    >0.55D0</dust_emis_fact>
 <dust_emis_fact dyn="fv"                   phys="cam5"   clubb_sgs="1"    >0.22D0</dust_emis_fact>
-<dust_emis_fact dyn="se"                   phys="cam6"                    >0.70D0</dust_emis_fact>
-<dust_emis_fact dyn="se"                   phys="cam7"                    >2.30D0</dust_emis_fact>
-<dust_emis_fact dyn="mpas"                 phys="cam7"                    >2.30D0</dust_emis_fact>
-<dust_emis_fact dyn="se" hgrid="ne30np4"   phys="cam6"             chem="trop_strat_mam4_vbs">0.8D0</dust_emis_fact>
-<dust_emis_fact dyn="se" hgrid="ne30np4"   phys="cam7"             chem="trop_strat_mam4_vbs">2.30D0</dust_emis_fact>
-<dust_emis_fact dyn="se" hgrid="ne0np4CONUS.ne30x8" phys="cam6"    chem="trop_strat_mam4_vbs">0.8D0</dust_emis_fact>
-<dust_emis_fact dyn="se" hgrid="ne0np4CONUS.ne30x8" phys="cam7"    chem="trop_strat_mam4_vbs">2.30D0</dust_emis_fact>
-<dust_emis_fact dyn="se" hgrid="ne30np4"   phys="cam6"             chem="trop_strat_mam4_ts1">0.8D0</dust_emis_fact>
-<dust_emis_fact dyn="se" hgrid="ne30np4"   phys="cam7"             chem="trop_strat_mam4_ts1">2.30D0</dust_emis_fact>
-<dust_emis_fact dyn="se" hgrid="ne0np4CONUS.ne30x8" phys="cam6"    chem="trop_strat_mam4_tst">0.8D0</dust_emis_fact>
-<dust_emis_fact dyn="se" hgrid="ne0np4CONUS.ne30x8" phys="cam7"    chem="trop_strat_mam4_tst">2.30D0</dust_emis_fact>
-<dust_emis_fact dyn="se" hgrid="ne30np4"   phys="cam6"             chem="trop_strat_mam5_vbs">0.8D0</dust_emis_fact>
-<dust_emis_fact dyn="se" hgrid="ne30np4"   phys="cam7"             chem="trop_strat_mam5_vbs">2.30D0</dust_emis_fact>
-<dust_emis_fact dyn="se" hgrid="ne0np4CONUS.ne30x8" phys="cam6"    chem="trop_strat_mam5_vbs">0.8D0</dust_emis_fact>
-<dust_emis_fact dyn="se" hgrid="ne0np4CONUS.ne30x8" phys="cam7"    chem="trop_strat_mam5_vbs">2.30D0</dust_emis_fact>
-<dust_emis_fact dyn="se" hgrid="ne30np4"   phys="cam6"             chem="trop_strat_mam5_ts1">0.8D0</dust_emis_fact>
-<dust_emis_fact dyn="se" hgrid="ne30np4"   phys="cam7"             chem="trop_strat_mam5_ts1">2.30D0</dust_emis_fact>
-<dust_emis_fact dyn="se" hgrid="ne0np4CONUS.ne30x8" phys="cam6"    chem="trop_strat_mam5_tst">0.8D0</dust_emis_fact>
-<dust_emis_fact dyn="se" hgrid="ne0np4CONUS.ne30x8" phys="cam7"    chem="trop_strat_mam5_tst">2.30D0</dust_emis_fact>
-<dust_emis_fact dyn="se" hgrid="ne30np4"   phys="cam6"             waccm_phys="1">0.8D0</dust_emis_fact>
-<dust_emis_fact dyn="se" hgrid="ne30np4"   phys="cam7"             waccm_phys="1">2.30D0</dust_emis_fact>
-<dust_emis_fact dyn="se" hgrid="ne0np4CONUS.ne30x8" phys="cam6"    waccm_phys="1">0.8D0</dust_emis_fact>
-<dust_emis_fact dyn="se" hgrid="ne0np4CONUS.ne30x8" phys="cam7"    waccm_phys="1">2.30D0</dust_emis_fact>
-<dust_emis_fact dyn="fv"                   phys="cam6"                    >0.70D0</dust_emis_fact>
-<dust_emis_fact dyn="fv"                   phys="cam7"                    >2.300D0</dust_emis_fact>
+<dust_emis_fact dyn="se"                   phys="cam6"                    >1.75D0</dust_emis_fact>
+<dust_emis_fact dyn="se"                   phys="cam7"                    >3.20D0</dust_emis_fact>
+<dust_emis_fact dyn="mpas"                 phys="cam7"                    >3.20D0</dust_emis_fact>
+<dust_emis_fact dyn="se" hgrid="ne30np4"   phys="cam6"                    >2.0D0</dust_emis_fact>
+<dust_emis_fact dyn="se" hgrid="ne30np4"   phys="cam7"                    >3.2D0</dust_emis_fact>
+<dust_emis_fact dyn="se" hgrid="ne0np4CONUS.ne30x8" phys="cam6"    chem="trop_strat_mam4_vbs">2.0D0</dust_emis_fact>
+<dust_emis_fact dyn="se" hgrid="ne0np4CONUS.ne30x8" phys="cam7"    chem="trop_strat_mam4_vbs">4.0D0</dust_emis_fact>
+<dust_emis_fact dyn="se" hgrid="ne0np4CONUS.ne30x8" phys="cam6"    chem="trop_strat_mam5_t1s1">2.0D0</dust_emis_fact>
+<dust_emis_fact dyn="se" hgrid="ne0np4CONUS.ne30x8" phys="cam7"    chem="trop_strat_mam5_t1s1">4.0D0</dust_emis_fact>
+<dust_emis_fact dyn="se" hgrid="ne30np4"   phys="cam6"             waccm_phys="1">2.0D0</dust_emis_fact>
+<dust_emis_fact dyn="se" hgrid="ne30np4"   phys="cam7"             waccm_phys="1">3.2D0</dust_emis_fact>
+<dust_emis_fact dyn="se" hgrid="ne0np4CONUS.ne30x8" phys="cam6"    waccm_phys="1">2.0D0</dust_emis_fact>
+<dust_emis_fact dyn="se" hgrid="ne0np4CONUS.ne30x8" phys="cam7"    waccm_phys="1">4.0D0</dust_emis_fact>
+<dust_emis_fact dyn="fv"                   phys="cam6"                    >1.75D0</dust_emis_fact>
+<dust_emis_fact dyn="fv"                   phys="cam7"                    >3.2D0</dust_emis_fact>
 
-<dust_emis_fact hgrid="1.9x2.5"                   phys="cam6"    ver="chem">0.26D0</dust_emis_fact>
-<dust_emis_fact hgrid="1.9x2.5"                   phys="cam7"    ver="chem">2.30D0</dust_emis_fact>
-<dust_emis_fact hgrid="0.9x1.25"                  phys="cam6"    ver="chem">0.7D0</dust_emis_fact>
-<dust_emis_fact hgrid="0.9x1.25"                  phys="cam7"    ver="chem">2.30D0</dust_emis_fact>
-<dust_emis_fact hgrid="1.9x2.5"   offline_dyn="1" phys="cam6"    ver="chem">0.24D0</dust_emis_fact>
-<dust_emis_fact hgrid="1.9x2.5"   offline_dyn="1" phys="cam7"    ver="chem">2.30D0</dust_emis_fact>
-<dust_emis_fact hgrid="0.47x0.63" offline_dyn="1" phys="cam6"    ver="chem">0.9D0</dust_emis_fact>
-<dust_emis_fact hgrid="0.47x0.63" offline_dyn="1" phys="cam7"    ver="chem">2.30D0</dust_emis_fact>
+<dust_emis_fact hgrid="1.9x2.5"                   phys="cam6"    ver="chem">0.65D0</dust_emis_fact>
+<dust_emis_fact hgrid="1.9x2.5"                   phys="cam7"    ver="chem">4.0D0</dust_emis_fact>
+<dust_emis_fact hgrid="0.9x1.25"                  phys="cam6"    ver="chem">1.75D0</dust_emis_fact>
+<dust_emis_fact hgrid="0.9x1.25"                  phys="cam7"    ver="chem">4.0D0</dust_emis_fact>
+<dust_emis_fact hgrid="1.9x2.5"   offline_dyn="1" phys="cam6"    ver="chem">0.6D0</dust_emis_fact>
+<dust_emis_fact hgrid="1.9x2.5"   offline_dyn="1" phys="cam7"    ver="chem">4.0D0</dust_emis_fact>
+<dust_emis_fact hgrid="0.47x0.63" offline_dyn="1" phys="cam6"    ver="chem">2.25D0</dust_emis_fact>
+<dust_emis_fact hgrid="0.47x0.63" offline_dyn="1" phys="cam7"    ver="chem">4.0D0</dust_emis_fact>
 
 <!-- dust emissions method -->
 <dust_emis_method>              Zender_2003</dust_emis_method>
@@ -2558,7 +2612,7 @@
 <seasalt_emis_scale ver="mam7"                                           >1.62D0</seasalt_emis_scale>
 <seasalt_emis_scale ver="strat"                                          >0.90D0</seasalt_emis_scale>
 <seasalt_emis_scale ver="strat" clubb_sgs="1"                            >1.00D0</seasalt_emis_scale>
-<seasalt_emis_scale ver="strat" clubb_sgs="1" phys="cam7"                >1.50D0</seasalt_emis_scale>
+<seasalt_emis_scale ver="strat" clubb_sgs="1" phys="cam7"                >1.55D0</seasalt_emis_scale>
 <seasalt_emis_scale ver="strat" clubb_sgs="1" hgrid="1.9x2.5" phys="cam6">1.10D0</seasalt_emis_scale>
 <seasalt_emis_scale ver="strat" clubb_sgs="1" silhs="1"                  >0.60D0</seasalt_emis_scale>
 
@@ -2710,7 +2764,7 @@
 <cldfrc_dp1                                                           > 0.14D0 </cldfrc_dp1>
 <cldfrc_dp1             phys="cam5"                                   > 0.10D0 </cldfrc_dp1>
 <cldfrc_dp1             phys="cam6"                                   > 0.10D0 </cldfrc_dp1>
-<cldfrc_dp1             phys="cam7"                                   > 0.05D0 </cldfrc_dp1>
+<cldfrc_dp1             phys="cam7"                                   > 0.129D0 </cldfrc_dp1>
 <cldfrc_dp1 dyn="fv"    phys="cam4"                                   > 0.10D0 </cldfrc_dp1>
 <cldfrc_dp1 dyn="se"    phys="cam4"                                   > 0.10D0 </cldfrc_dp1>
 
@@ -2838,7 +2892,7 @@
 <zmconv_c0_lnd                   hgrid="ne120np4" phys="cam7"         > 0.0035D0 </zmconv_c0_lnd>
 <zmconv_c0_lnd                   hgrid="C384"     phys="cam7"         > 0.0035D0 </zmconv_c0_lnd>
 <zmconv_c0_lnd  microphys="mg2"  clubb_sgs="1"    phys="cam7"         > 0.0075D0 </zmconv_c0_lnd>
-<zmconv_c0_lnd  microphys="mg3"  clubb_sgs="1"    phys="cam7"         > 0.0075D0 </zmconv_c0_lnd>
+<zmconv_c0_lnd  microphys="mg3"  clubb_sgs="1"    phys="cam7"         > 0.00549D0 </zmconv_c0_lnd>
 <zmconv_c0_lnd  dyn="fv"                          phys="cam4"         > 0.0035D0 </zmconv_c0_lnd>
 <zmconv_c0_lnd  dyn="se"                          phys="cam4"         > 0.0035D0 </zmconv_c0_lnd>
 
@@ -2872,7 +2926,7 @@
 <zmconv_num_cin                                       phys="cam7"     > 1       </zmconv_num_cin>
 
 <zmconv_dmpdz                                                         > -1.0E-3 </zmconv_dmpdz>
-<zmconv_tiedke_add                                                    > 0.5     </zmconv_tiedke_add>
+<zmconv_tiedtke_add                                                    > 0.5     </zmconv_tiedtke_add>
 <zmconv_capelmt                                                       > 70.0    </zmconv_capelmt>
 <zmconv_tau                                                           > 3600.0    </zmconv_tau>
 
@@ -2958,7 +3012,7 @@
 <scm_relax_tau_top_sec           scam="1"                  > 172800.D0  </scm_relax_tau_top_sec>
 
 
-<!-- IOP SCAM defaults (The Single Column Atmosphere Model Version 6 (SCAM6), J. Adv. Model. Earth Sy., 11, 1381–1401, https://doi.org/10.1029/2018MS001578-->
+<!-- IOP SCAM defaults (The Single Column Atmosphere Model Version 6 (SCAM6), J. Adv. Model. Earth Sy., 11, 1381-1401, https://doi.org/10.1029/2018MS001578-->
 
 <!-- IOP ARM95/ARM Southern Great Plains/lat:36/lon:263/Jul 1995/18d/M. Zhang et al. (2016)/Land convection -->
 <ncdata             hgrid="ne3np4"    nlev="32"       scam_iop="arm95"     >atm/cam/inic/se/CESM2.F2000climo.ne3np4.cam.i.0003-06-01-00000.nc</ncdata>
@@ -3059,6 +3113,7 @@
 <history_eddy>                 .false.  </history_eddy>
 <history_budget>               .false.  </history_budget>
 <history_waccm>                .false.  </history_waccm>
+<history_waccm waccm_phys="1" model_top="mt">.false.</history_waccm>
 <history_waccm waccm_phys="1"> .true.   </history_waccm>
 <history_waccmx>               .false.  </history_waccmx>
 <history_waccmx waccmx="1">    .true.   </history_waccmx>
@@ -3194,35 +3249,54 @@
 <se_hypervis_scaling se_refined_mesh="1" hypervis_type="tensor" >3.22D0 </se_hypervis_scaling>
 
 <se_hypervis_subcycle                                                           > 3 </se_hypervis_subcycle>
+<se_hypervis_subcycle  waccm_phys="1"  model_top="mt"                           > 3 </se_hypervis_subcycle>
 <se_hypervis_subcycle  waccm_phys="1"                                           > 2 </se_hypervis_subcycle>
-<se_hypervis_subcycle  hgrid="ne16np4"                                          > 4 </se_hypervis_subcycle>
+<se_hypervis_subcycle  hgrid="ne16np4"                                          > 3 </se_hypervis_subcycle>
+<se_hypervis_subcycle  hgrid="ne16np4"  model_top="lt"                          > 1 </se_hypervis_subcycle>
 <se_hypervis_subcycle  hgrid="ne16np4"  waccm_phys="1"            model_top="none"> 10 </se_hypervis_subcycle>
 <se_hypervis_subcycle  hgrid="ne16np4"  waccm_phys="1" waccmx="0" model_top="none"> 9 </se_hypervis_subcycle>
 <se_hypervis_subcycle  hgrid="ne30np4"  waccm_phys="1" waccmx="0" model_top="none"> 8 </se_hypervis_subcycle>
 <se_hypervis_subcycle  hgrid="ne30np4"  waccm_phys="1" waccmx="1" model_top="none"> 5 </se_hypervis_subcycle>
 <se_hypervis_subcycle  hgrid="ne30np4"  model_top="lt"                          > 2 </se_hypervis_subcycle>
 <se_hypervis_subcycle  hgrid="ne30np4"  model_top="mt"                          > 3 </se_hypervis_subcycle>
-<se_hypervis_subcycle  se_refined_mesh="1"                                      > 3 </se_hypervis_subcycle>
+<se_hypervis_subcycle  hgrid="ne0np4.ARCTIC.ne30x4"                             > 2  </se_hypervis_subcycle>
+<se_hypervis_subcycle  hgrid="ne0np4.POLARCAP.ne30x4"                           > 2  </se_hypervis_subcycle>
+<se_hypervis_subcycle  hgrid="ne0np4CONUS.ne30x8"                               > 1  </se_hypervis_subcycle>
+<se_hypervis_subcycle  hgrid="ne0np4.ARCTICGRIS.ne30x8"                         > 1  </se_hypervis_subcycle>
+<se_hypervis_subcycle  hgrid="ne0np4.NATL.ne30x8"                               > 1  </se_hypervis_subcycle>
 <se_hypervis_subcycle  hgrid="ne0np4CONUS.ne30x8" waccm_phys="1"                > 1 </se_hypervis_subcycle>
 <se_hypervis_subcycle  hgrid="ne16np4" model_top="ht"                           > 18</se_hypervis_subcycle>
 <se_hypervis_subcycle  hgrid="ne16np4" model_top="xt"                           > 18</se_hypervis_subcycle>
 <se_hypervis_subcycle  hgrid="ne30np4" model_top="ht"                           > 18</se_hypervis_subcycle>
 <se_hypervis_subcycle  hgrid="ne30np4" model_top="xt"                           > 18</se_hypervis_subcycle>
 <se_hypervis_subcycle  waccmx="1" hgrid="ne120np4" nlev="273"                   > 30</se_hypervis_subcycle>
+<se_hypervis_subcycle  hgrid="ne120np4"  model_top="mt"                         > 2 </se_hypervis_subcycle>
 
-<se_hypervis_subcycle_sponge                                           > 1  </se_hypervis_subcycle_sponge>
-<se_hypervis_subcycle_sponge hgrid="ne30np4"  model_top="mt"           > 3  </se_hypervis_subcycle_sponge>
-<se_hypervis_subcycle_sponge hgrid="ne16np4"  waccm_phys="1" waccmx="0"> 2  </se_hypervis_subcycle_sponge>
-<se_hypervis_subcycle_sponge hgrid="ne30np4"  waccm_phys="1" waccmx="0"> 4  </se_hypervis_subcycle_sponge>
-<se_hypervis_subcycle_sponge waccmx="1"                                > 20 </se_hypervis_subcycle_sponge>
-<se_hypervis_subcycle_sponge hgrid="ne30np4" waccmx="1" model_top="none"> 60 </se_hypervis_subcycle_sponge>
-<se_hypervis_subcycle_sponge hgrid="ne120np4"                          > 4  </se_hypervis_subcycle_sponge>
-<se_hypervis_subcycle_sponge se_refined_mesh="1"                       > 2  </se_hypervis_subcycle_sponge>
-<se_hypervis_subcycle_sponge hgrid="ne0np4CONUS.ne30x8" waccm_phys="1" > 4  </se_hypervis_subcycle_sponge>
-<se_hypervis_subcycle_sponge hgrid="ne16np4" model_top="ht"            > 2  </se_hypervis_subcycle_sponge>
-<se_hypervis_subcycle_sponge hgrid="ne30np4" model_top="ht"            > 4  </se_hypervis_subcycle_sponge>
-<se_hypervis_subcycle_sponge hgrid="ne30np4" model_top="xt"            > 40 </se_hypervis_subcycle_sponge>
-<se_hypervis_subcycle_sponge waccmx="1" hgrid="ne120np4" nlev="273"    > 180</se_hypervis_subcycle_sponge>
+<se_hypervis_subcycle_sponge                                                 > 1  </se_hypervis_subcycle_sponge>
+<se_hypervis_subcycle_sponge hgrid="ne30np4"  model_top="mt"                 > 3  </se_hypervis_subcycle_sponge>
+<se_hypervis_subcycle_sponge hgrid="ne30np4" model_top="mt" waccm_phys="1"   > 3  </se_hypervis_subcycle_sponge>
+<se_hypervis_subcycle_sponge hgrid="ne16np4"  waccm_phys="1" waccmx="0"      > 2  </se_hypervis_subcycle_sponge>
+<se_hypervis_subcycle_sponge hgrid="ne30np4"  waccm_phys="1" waccmx="0"      > 4  </se_hypervis_subcycle_sponge>
+<se_hypervis_subcycle_sponge waccmx="1"                                      > 20 </se_hypervis_subcycle_sponge>
+<se_hypervis_subcycle_sponge hgrid="ne30np4" waccmx="1" model_top="none"     > 60 </se_hypervis_subcycle_sponge>
+<se_hypervis_subcycle_sponge hgrid="ne120np4"                                > 4  </se_hypervis_subcycle_sponge>
+<se_hypervis_subcycle_sponge hgrid="ne0np4.ARCTIC.ne30x4"                    > 2  </se_hypervis_subcycle_sponge>
+<se_hypervis_subcycle_sponge hgrid="ne0np4.POLARCAP.ne30x4"                  > 2  </se_hypervis_subcycle_sponge>
+<se_hypervis_subcycle_sponge hgrid="ne0np4CONUS.ne30x8"                      > 5  </se_hypervis_subcycle_sponge>
+<se_hypervis_subcycle_sponge hgrid="ne0np4.ARCTICGRIS.ne30x8"                > 5  </se_hypervis_subcycle_sponge>
+<se_hypervis_subcycle_sponge hgrid="ne0np4.NATL.ne30x8"                      > 5  </se_hypervis_subcycle_sponge>
+<se_hypervis_subcycle_sponge hgrid="ne0np4CONUS.ne30x8" waccm_phys="1"       > 4  </se_hypervis_subcycle_sponge>
+<se_hypervis_subcycle_sponge hgrid="ne16np4" model_top="ht"                  > 2  </se_hypervis_subcycle_sponge>
+<se_hypervis_subcycle_sponge hgrid="ne30np4" model_top="ht"                  > 4  </se_hypervis_subcycle_sponge>
+<se_hypervis_subcycle_sponge hgrid="ne30np4" model_top="xt"                  > 40 </se_hypervis_subcycle_sponge>
+<se_hypervis_subcycle_sponge waccmx="1" hgrid="ne120np4" nlev="273"          > 180</se_hypervis_subcycle_sponge>
+<se_hypervis_subcycle_sponge hgrid="ne120np4"  model_top="mt"                > 10 </se_hypervis_subcycle_sponge>
+<se_hypervis_subcycle_sponge hgrid="ne0np4.ARCTIC.ne30x4" model_top="mt"     > 3  </se_hypervis_subcycle_sponge>
+<se_hypervis_subcycle_sponge hgrid="ne0np4.POLARCAP.ne30x4" model_top="mt"   > 3  </se_hypervis_subcycle_sponge>
+<se_hypervis_subcycle_sponge hgrid="ne0np4CONUS.ne30x8" model_top="mt"       > 6  </se_hypervis_subcycle_sponge>
+<se_hypervis_subcycle_sponge hgrid="ne0np4.ARCTICGRIS.ne30x8" model_top="mt" > 6  </se_hypervis_subcycle_sponge>
+<se_hypervis_subcycle_sponge hgrid="ne0np4.NATL.ne30x8" model_top="mt"       > 6  </se_hypervis_subcycle_sponge>
+
 
 <se_hypervis_subcycle_q>1                 </se_hypervis_subcycle_q>
 <se_hypervis_subcycle_q hgrid="ne16np4">2 </se_hypervis_subcycle_q>
@@ -3236,16 +3310,16 @@
 <se_max_hypervis_courant se_refined_mesh="1" hypervis_type="scalar" > 1.9 </se_max_hypervis_courant>
 
 <se_nu>-1</se_nu>
-<se_nu hgrid="ne16np4" waccm_phys="1" waccmx="0">6.e15</se_nu>
-<se_nu hgrid="ne16np4" model_top="ht"           >6.e15</se_nu>
+<se_nu hgrid="ne16np4">6.e15</se_nu>
 <se_nu waccmx="1">5.e15</se_nu>
 
 <se_nu_div> -1 </se_nu_div>
-<se_nu_div hgrid="ne16np4" waccm_phys="1" waccmx="0">6.e15</se_nu_div>
-<se_nu_div hgrid="ne16np4" model_top="ht"           >6.e15</se_nu_div>
+<se_nu_div hgrid="ne16np4">6.e15</se_nu_div>
 <se_nu_div waccmx="1"> 10.e15 </se_nu_div>
 
 <se_nu_p>-1 </se_nu_p>
+<se_nu_p hgrid="ne16np4">6.e15</se_nu_p>
+<se_nu_p waccmx="1">5.e15</se_nu_p>
 
 <se_nu_top                                   > 1.25e5 </se_nu_top>
 <se_nu_top waccmx="1"                        > 1.0e6 </se_nu_top>
@@ -3263,6 +3337,7 @@
 <se_sponge_del4_nu_div_fac model_top="ht"                           > 7.5 </se_sponge_del4_nu_div_fac>
 <se_sponge_del4_nu_div_fac hgrid="ne120np4" nlev="273" waccmx="1"   > 5.0 </se_sponge_del4_nu_div_fac>
 <se_sponge_del4_lev       > -1 </se_sponge_del4_lev>
+<se_sponge_del4_lev waccm_phys="1" model_top="mt"> -1 </se_sponge_del4_lev>
 <se_sponge_del4_lev waccm_phys="1"> 30 </se_sponge_del4_lev>
 <se_sponge_del4_lev model_top="ht"> 30 </se_sponge_del4_lev>
 <se_sponge_del4_lev model_top="xt"> 30 </se_sponge_del4_lev>
@@ -3276,32 +3351,49 @@
 <se_refined_mesh hgrid="ne0np4TESTONLY.ne5x4" > .true. </se_refined_mesh>
 <se_refined_mesh hgrid="ne0np4.ARCTIC.ne30x4" > .true. </se_refined_mesh>
 <se_refined_mesh hgrid="ne0np4.ARCTICGRIS.ne30x8" > .true. </se_refined_mesh>
+<se_refined_mesh hgrid="ne0np4.POLARCAP.ne30x4" > .true. </se_refined_mesh>
+<se_refined_mesh hgrid="ne0np4.NATL.ne30x8" > .true. </se_refined_mesh>
 
 <se_nsplit>                   2 </se_nsplit>
 <se_nsplit hgrid="ne16np4" >  1 </se_nsplit>
 
-<se_nsplit hgrid="ne5np4"   waccm_phys="1"                >  3  </se_nsplit>
-<se_nsplit hgrid="ne16np4"  waccmx="1" model_top="none"   >  3  </se_nsplit>
-<se_nsplit hgrid="ne16np4"  waccm_phys="1" model_top="none"> 2  </se_nsplit>
-<se_nsplit hgrid="ne16np4"  model_top="ht"                >  3  </se_nsplit>
-<se_nsplit hgrid="ne16np4"  model_top="xt"                >  3  </se_nsplit>
+<se_nsplit hgrid="ne5np4"   waccm_phys="1"                 > 3 </se_nsplit>
+<se_nsplit hgrid="ne16np4"  waccmx="1" model_top="none"    > 3 </se_nsplit>
+<se_nsplit hgrid="ne16np4"  waccm_phys="1" model_top="none"> 2 </se_nsplit>
+<se_nsplit hgrid="ne16np4"  model_top="ht"                 > 3 </se_nsplit>
+<se_nsplit hgrid="ne16np4"  model_top="xt"                 > 3 </se_nsplit>
 <se_nsplit hgrid="ne30np4" waccm_phys="1" waccmx="1" model_top="none">  4  </se_nsplit>
-<se_nsplit hgrid="ne30np4"                                >  2  </se_nsplit>
-<se_nsplit hgrid="ne30np4"  waccm_phys="1" model_top="none"> 4  </se_nsplit>
-<se_nsplit hgrid="ne30np4"  model_top="ht"                >  4  </se_nsplit>
-<se_nsplit hgrid="ne30np4"  model_top="xt"                >  5  </se_nsplit>
-<se_nsplit hgrid="ne0np4CONUS.ne30x8" waccm_phys="1"      > 10  </se_nsplit>
+<se_nsplit hgrid="ne30np4"                                 > 2 </se_nsplit>
+<se_nsplit hgrid="ne30np4"  waccm_phys="1" model_top="none"> 4 </se_nsplit>
+<se_nsplit hgrid="ne30np4"  model_top="ht"                 > 4 </se_nsplit>
+<se_nsplit hgrid="ne30np4"  model_top="xt"                 > 5 </se_nsplit>
+<se_nsplit hgrid="ne0np4.ARCTIC.ne30x4"                    > 3 </se_nsplit>
+<se_nsplit hgrid="ne0np4.POLARCAP.ne30x4"                  > 3 </se_nsplit>
+<se_nsplit hgrid="ne0np4CONUS.ne30x8"                      > 3 </se_nsplit>
+<se_nsplit hgrid="ne0np4.ARCTICGRIS.ne30x8"                > 3 </se_nsplit>
+<se_nsplit hgrid="ne0np4.NATL.ne30x8"                      > 3 </se_nsplit>
+<se_nsplit hgrid="ne0np4CONUS.ne30x8" waccm_phys="1"       > 10 </se_nsplit>
+<se_nsplit hgrid="ne0np4TESTONLY.ne5x4"                    > 7 </se_nsplit>
+<se_nsplit waccmx="1" hgrid="ne120np4" nlev="273"          > 10 </se_nsplit>
+<se_nsplit hgrid="ne120np4"  model_top="mt"                > 8 </se_nsplit>
+<se_nsplit hgrid="ne0np4CONUS.ne30x8" model_top="mt"       > 4 </se_nsplit>
+<se_nsplit hgrid="ne0np4.ARCTICGRIS.ne30x8" model_top="mt" > 4 </se_nsplit>
+<se_nsplit hgrid="ne0np4.NATL.ne30x8" model_top="mt"       > 4 </se_nsplit>
 
-<se_nsplit hgrid="ne0np4TESTONLY.ne5x4"> 7 </se_nsplit>
-<se_nsplit waccmx="1" hgrid="ne120np4" nlev="273" > 10 </se_nsplit>
-
-<se_rsplit                                          > 3 </se_rsplit>
-<se_rsplit waccm_phys="1" waccmx="0"                > 2 </se_rsplit>
-<se_rsplit model_top="ht"                           > 2 </se_rsplit>
-<se_rsplit waccmx="1"                               > 4 </se_rsplit>
-<se_rsplit hgrid="ne16np4" waccmx="1" model_top="none"> 2 </se_rsplit>
-<se_rsplit hgrid="ne0np4CONUS.ne30x8" waccm_phys="1"> 3 </se_rsplit>
-<se_rsplit waccmx="1" hgrid="ne120np4" nlev="273"   > 5 </se_rsplit>
+<se_rsplit                                                 > 3 </se_rsplit>
+<se_rsplit waccm_phys="1" model_top="mt"                   > 3 </se_rsplit>
+<se_rsplit waccm_phys="1" waccmx="0"                       > 2 </se_rsplit>
+<se_rsplit model_top="ht"                                  > 2 </se_rsplit>
+<se_rsplit waccmx="1"                                      > 4 </se_rsplit>
+<se_rsplit hgrid="ne16np4" waccmx="1" model_top="none"     > 2 </se_rsplit>
+<se_rsplit hgrid="ne0np4CONUS.ne30x8" waccm_phys="1"       > 3 </se_rsplit>
+<se_rsplit waccmx="1" hgrid="ne120np4" nlev="273"          > 5 </se_rsplit>
+<se_rsplit hgrid="ne120np4"  model_top="mt"                > 3 </se_rsplit>
+<se_rsplit hgrid="ne0np4.ARCTIC.ne30x4" model_top="mt"     > 6 </se_rsplit>
+<se_rsplit hgrid="ne0np4.POLARCAP.ne30x4" model_top="mt"   > 6 </se_rsplit>
+<se_rsplit hgrid="ne0np4CONUS.ne30x8" model_top="mt"       > 5 </se_rsplit>
+<se_rsplit hgrid="ne0np4.ARCTICGRIS.ne30x8" model_top="mt" > 5 </se_rsplit>
+<se_rsplit hgrid="ne0np4.NATL.ne30x8" model_top="mt"       > 5 </se_rsplit>
 
 <se_fvm_supercycling>-1</se_fvm_supercycling>
 <se_fvm_supercycling_jet>-1</se_fvm_supercycling_jet>
@@ -3378,8 +3470,6 @@
 <mpas_coef_3rd_order          > 1.0D0 </mpas_coef_3rd_order>
 <mpas_smagorinsky_coef        > 0.125D0 </mpas_smagorinsky_coef>
 <mpas_mix_full                > .true. </mpas_mix_full>
-<mpas_epssm                   > 0.1D0 </mpas_epssm>
-<mpas_epssm hgrid="mpasa120" waccm_phys="1"> 0.5D0 </mpas_epssm>
 <mpas_smdiv                   > 0.1D0 </mpas_smdiv>
 <mpas_apvm_upwinding          > 0.5D0 </mpas_apvm_upwinding>
 <mpas_apvm_upwinding hgrid="mpasa120" waccm_phys="1"> 0.0D0 </mpas_apvm_upwinding>
@@ -3393,6 +3483,11 @@
 <mpas_rayleigh_damp_u         > .true. </mpas_rayleigh_damp_u>
 <mpas_rayleigh_damp_u_timescale_days> 5.0 </mpas_rayleigh_damp_u_timescale_days>
 <mpas_number_rayleigh_damp_u_levels> 5 </mpas_number_rayleigh_damp_u_levels>
+<mpas_epssm_minimum> 0.1D0 </mpas_epssm_minimum>
+<mpas_epssm_maximum> 0.1D0 </mpas_epssm_maximum>
+<mpas_epssm_maximum hgrid="mpasa120" waccm_phys="1"> 0.5D0 </mpas_epssm_maximum>
+<mpas_epssm_transition_bottom_z> 30000.0D0 </mpas_epssm_transition_bottom_z>
+<mpas_epssm_transition_top_z> 50000.0D0 </mpas_epssm_transition_top_z>
 <mpas_apply_lbcs> .false. </mpas_apply_lbcs>
 <mpas_jedi_da> .false. </mpas_jedi_da>
 <mpas_block_decomp_file_prefix hgrid="mpasa480">atm/cam/inic/mpas/mpasa480.graph.info.part.</mpas_block_decomp_file_prefix>
@@ -3407,6 +3502,9 @@
 <mpas_print_global_minmax_vel  > .false. </mpas_print_global_minmax_vel>
 <mpas_print_detailed_minmax_vel> .false. </mpas_print_detailed_minmax_vel>
 <mpas_print_global_minmax_sca  > .false. </mpas_print_global_minmax_sca>
+
+<mpas_halo_exch_method> mpas_halo </mpas_halo_exch_method>
+<mpas_gpu_aware_mpi> .false. </mpas_gpu_aware_mpi>
 
 <!-- ================================================================== -->
 <!-- Chemistry Rates Diagnostics                                        -->
@@ -3430,7 +3528,7 @@
   'SolIonRate_Tot = jeuv_1 + jeuv_2 + jeuv_3 + jeuv_4 + jeuv_5 + jeuv_6 + jeuv_7 + jeuv_8 + jeuv_9 + jeuv_10 + jeuv_11 + ',
                    'jeuv_14 + jeuv_15 + jeuv_16 + jeuv_17 + jeuv_18 + jeuv_19 + jeuv_20 + jeuv_21 + jeuv_22 + jeuv_23',
 </rxn_rate_sums>
-<rxn_rate_sums chem="trop_strat_mam5_ts2">
+<rxn_rate_sums chem="trop_strat_mam5_t2s1">
     'O3_Prod = NO_HO2 + CH3O2_NO + HOCH2OO_NO + C2H5O2_NO + CH3CO3_NO + EO2_NO + C3H7O2_NO + PO2_NO + ',
                'RO2_NO + ENEO2_NO + MACRO2_NOa + jhonitr + ',
                'MCO3_NO + MEKO2_NO + ALKO2_NO + jalknit + ACBZO2_NO + BENZO2_NO + BZOO_NO + ',
@@ -3541,7 +3639,7 @@
               'APIN_O3 + BPIN_O3 + LIMON_O3 + MYRC_O3 + ',
               'ISOPN1D_O3 + ISOPN4D_O3 + ISOPNOOHD_O3 + NC4CHO_O3 + TERPF1_O3 + TERPF2_O3'
 </rxn_rate_sums>
-<rxn_rate_sums chem="trop_strat_mam5_ts4">
+<rxn_rate_sums chem="trop_strat_mam5_t4s2">
   'O3_Prod = NO_HO2 + CH3O2_NO + C2H5O2_NO + CH3CO3_NO + EO2_NO + C3H7O2_NO + PO2_NO + RO2_NO + ',
            ' MACRO2_NOa + MCO3_NO + .92*ISOPO2_NO + ISOPNO3_NO + XO2_NO + jnoa + jonitr + NOA_OH ',
            'O3_Loss = O1D_H2O + OH_O3 + HO2_O3 + C2H4_O3 + C3H6_O3 + ISOP_O3 + MVK_O3 + MACR_O3 + TERP_O3 + S_O3 + SO_O3',
@@ -3569,6 +3667,11 @@
   'Ox_Loss = 2.0*O_O3 + O1D_H2O + HO2_O + HO2_O3 + OH_O + OH_O3 + H_O3 + 2.0*NO2_O + 2.0*jno3_b + 2.0*CLO_O + 2.0*jcl2o2 + ',
            ' 2.0*CLO_CLOa + 2.0*CLO_CLOb + 2.0*BRO_CLOb + 2.0*BRO_CLOc + 2.0*BRO_BRO + 2.0*BRO_O + CLO_HO2 + BRO_HO2 + C2H4_O3 + ',
            ' C3H6_O3 + ISOP_O3 + MVK_O3 + MACR_O3 + TERP_O3 + S_O3 + SO_O3'
+</rxn_rate_sums>
+<rxn_rate_sums chem="waccm_t4ma_mam5">
+  'O3S_Loss = 2.0*O_O3 + O1D_H2O + HO2_O3 + OH_O3 + H_O3 + 2.0*NO2_O + 2.0*jno3_b + 2.0*CLO_O + 2.0*jcl2o2 + 2.0*CLO_CLOa + ',
+            ' 2.0*CLO_CLOb + 2.0*BRO_CLOb + 2.0*BRO_CLOc + 2.0*BRO_BRO + 2.0*BRO_O + CLO_HO2 + BRO_HO2 + S_O3 + SO_O3 + ',
+            ' C2H4_O3 + C3H6_O3 + ISOP_O3 + MVK_O3 + MACR_O3 + TERP_O3'
 </rxn_rate_sums>
 <rxn_rate_sums>
   'O3_Prod = NO_HO2 + CH3O2_NO + HOCH2OO_NO + C2H5O2_NO + CH3CO3_NO + EO2_NO + C3H7O2_NO + PO2_NO + RO2_NO + ENEO2_NO + ',

--- a/CAM_Convection_YOG/bld/namelist_files/namelist_definition.xml
+++ b/CAM_Convection_YOG/bld/namelist_files/namelist_definition.xml
@@ -1270,13 +1270,6 @@ In the low-top model, this helps to conserve momentum and produce a QBO.
 Default: set by build-namelist.
 </entry>
 
-<entry id="gw_limit_tau_without_eff" type="logical" category="gw_drag"
-       group="gw_drag_nl" valid_values="" >
-Apply limiters to tau before applying the efficiency factor, rather than
-afterward.
-Default: set by build-namelist
-</entry>
-
 <entry id="gw_apply_tndmax" type="logical" category="gw_drag"
        group="gw_drag_nl" valid_values="" >
 Apply limiter on maximum wind tendency from stress divergence in gravity wave drag scheme.
@@ -1533,7 +1526,7 @@ Default: set by build-namelist.
 
 <entry id="gw_rdg_do_adjust_tauoro" type="logical" category="gw_rdg"
        group="gw_rdg_nl" valid_values="" >
-If true, then adujust tauoro
+If true, then adjust tauoro
 Default: set by build-namelist.
 </entry>
 
@@ -1575,7 +1568,7 @@ Default: set by build-namelist.
 
 <entry id="gw_rdg_Fr_c" type="real"  category="gw_rdg"
        group="gw_rdg_nl" valid_values="" >
-Critical inverse4 Froude number
+Critical inverse Froude number
 Default: set by build-namelist.
 </entry>
 
@@ -2346,7 +2339,7 @@ COSP will not run unless this is set to .true. in the namelist!
 Turn on the desired simulators using lXXX_sim namelist vars
 If no specific simulators are specified, all of the simulators
 are run on all columns and all output is saved. (useful for testing).
-COSP is available with CAM4, CAM5 and CAM6 physics.
+COSP is available with CAM4, CAM5, CAM6 and CAM7 physics.
 This default logical is set in cospsimulator_intr.F90.
 Default: FALSE
 </entry>
@@ -2461,6 +2454,15 @@ will be saved.
 Default: FALSE
 </entry>
 
+<entry id="cosp_lrttov_sim" type="logical"  category="cosp"
+       group="cospsimulator_nl" valid_values="">
+If true, RTTOV simulator will be run and output
+will be saved according to the appropriate RTTOV
+instrument namelist files in "rttov_instrument_namelists".
+
+Default: FALSE
+</entry>
+
 <!-- COSP input control parameters -->
 
 <entry id="cosp_ncolumns" type="integer"  category="cosp"
@@ -2468,6 +2470,168 @@ Default: FALSE
 Number of subcolumns in SCOPS
 This default logical is set in cospsimulator_intr.F90
 Default: 50
+</entry>
+
+<entry id="cosp_rttov_Ninstruments" type="integer"  category="cosp"
+       group="cospsimulator_nl" valid_values="">
+Number of RTTOV instruments to simulate.
+This default logical is set in cospsimulator_intr.F90
+Default: 0
+</entry>
+    
+<entry id="cosp_rttov_instrument_namelists" type="char*256(50)"  category="cosp"
+       group="cospsimulator_nl" valid_values="" >
+List of RTTOV instrument namelist files to read when running RTTOV in COSP.
+File paths are read relative to the case run directory 
+(e.g. /glade/derecho/scratch/$USER/$CASENAME/run/) if an absolute path is not provided (recommended). Each namelist file
+contains information specifying the simulated instrument, channels, and
+outputs. Templates and instructions can be found in src/physics/cosp2/COSP-RTTOV_examples/.
+Default: none
+</entry>
+
+<!-- Swathing input control parameters. -->
+<entry id="cosp_N_SWATHS_ISCCP" type="integer*10"  category="cosp"
+       group="cospsimulator_nl" valid_values="" >
+Number of satellite sampling swaths used to mask COSP ISCCP data.
+Default: none
+</entry>
+
+<entry id="cosp_N_SWATHS_MISR" type="integer*10"  category="cosp"
+       group="cospsimulator_nl" valid_values="" >
+Number of satellite sampling swaths used to mask COSP MISR data.
+Default: none
+</entry>
+
+<entry id="cosp_N_SWATHS_MODIS" type="integer*10"  category="cosp"
+       group="cospsimulator_nl" valid_values="" >
+Number of satellite sampling swaths used to mask COSP MODIS data.
+Default: none
+</entry>
+
+<entry id="cosp_N_SWATHS_CSCAL" type="integer*10"  category="cosp"
+       group="cospsimulator_nl" valid_values="" >
+Number of satellite sampling swaths used to mask COSP CloudSat-CALIPSO data.
+Default: none
+</entry>
+
+<entry id="cosp_N_SWATHS_PARASOL" type="integer*10"  category="cosp"
+       group="cospsimulator_nl" valid_values="" >
+Number of satellite sampling swaths used to mask COSP PARASOL data.
+Default: none
+</entry>
+
+<entry id="cosp_N_SWATHS_ATLID" type="integer*10"  category="cosp"
+       group="cospsimulator_nl" valid_values="" >
+Number of satellite sampling swaths used to mask COSP ATLID data.
+Default: none
+</entry>
+
+<entry id="cosp_SWATH_LOCALTIMES_ISCCP" type="real*10"  category="cosp"
+       group="cospsimulator_nl" valid_values="" >
+Swath localtimes (hours) for masking COSP ISCCP data. The sampling 
+"local time" refers to a linear shift from UTC as a function of a 
+gridcell’s longitude (t_local = t_UTC − longitude * 24/360).
+Default: none
+</entry>
+
+<entry id="cosp_SWATH_LOCALTIMES_MISR" type="real*10"  category="cosp"
+       group="cospsimulator_nl" valid_values="" >
+Swath localtimes (hours) for masking COSP MISR data. The sampling 
+"local time" refers to a linear shift from UTC as a function of a 
+gridcell’s longitude (t_local = t_UTC − longitude * 24/360).
+Default: none
+</entry>
+
+<entry id="cosp_SWATH_LOCALTIMES_MODIS" type="real*10"  category="cosp"
+       group="cospsimulator_nl" valid_values="" >
+Swath localtimes (hours) for masking COSP MODIS data. The sampling 
+"local time" refers to a linear shift from UTC as a function of a 
+gridcell’s longitude (t_local = t_UTC − longitude * 24/360).
+Default: none
+</entry>
+
+<entry id="cosp_SWATH_LOCALTIMES_CSCAL" type="real*10"  category="cosp"
+       group="cospsimulator_nl" valid_values="" >
+Swath localtimes (hours) for masking COSP CloudSat-CALIPSO data. The  
+sampling "local time" refers to a linear shift from UTC as a function of a 
+gridcell’s longitude (t_local = t_UTC − longitude * 24/360).
+Default: none
+</entry>
+
+<entry id="cosp_SWATH_LOCALTIMES_PARASOL" type="real*10"  category="cosp"
+       group="cospsimulator_nl" valid_values="" >
+Swath localtimes (hours) for masking COSP PARASOL data. The sampling 
+"local time" refers to a linear shift from UTC as a function of a 
+gridcell’s longitude (t_local = t_UTC − longitude * 24/360).
+Default: none
+</entry>
+
+<entry id="cosp_SWATH_LOCALTIMES_ATLID" type="real*10"  category="cosp"
+       group="cospsimulator_nl" valid_values="" >
+Swath localtimes (hours) for masking COSP ATLID data. The sampling 
+"local time" refers to a linear shift from UTC as a function of a 
+gridcell’s longitude (t_local = t_UTC − longitude * 24/360).
+Default: none
+</entry>
+
+<entry id="cosp_SWATH_WIDTHS_ISCCP" type="real*10"  category="cosp"
+       group="cospsimulator_nl" valid_values="" >
+Swath widths (kilometers) for masking COSP ISCCP data. The "swath width"
+determines the spatial region around each local time that is simulated. 
+Supplying a swath width in units of distance rather than radians produces
+a larger sampling density at higher latitudes that is consistent with
+observations.
+Default: none
+</entry>
+
+<entry id="cosp_SWATH_WIDTHS_MISR" type="real*10"  category="cosp"
+       group="cospsimulator_nl" valid_values="" >
+Swath widths (kilometers) for masking COSP MISR data. The "swath width"
+determines the spatial region around each local time that is simulated. 
+Supplying a swath width in units of distance rather than radians produces
+a larger sampling density at higher latitudes that is consistent with
+observations.
+Default: none
+</entry>
+
+<entry id="cosp_SWATH_WIDTHS_MODIS" type="real*10"  category="cosp"
+       group="cospsimulator_nl" valid_values="" >
+Swath widths (kilometers) for masking COSP MODIS data. The "swath width"
+determines the spatial region around each local time that is simulated. 
+Supplying a swath width in units of distance rather than radians produces
+a larger sampling density at higher latitudes that is consistent with
+observations.
+Default: none
+</entry>
+
+<entry id="cosp_SWATH_WIDTHS_CSCAL" type="real*10"  category="cosp"
+       group="cospsimulator_nl" valid_values="" >
+Swath widths (kilometers) for masking COSP CSCAL data. The "swath width"
+determines the spatial region around each local time that is simulated. 
+Supplying a swath width in units of distance rather than radians produces
+a larger sampling density at higher latitudes that is consistent with
+observations.
+Default: none
+</entry>
+
+<entry id="cosp_SWATH_WIDTHS_PARASOL" type="real*10"  category="cosp"
+       group="cospsimulator_nl" valid_values="" >
+Swath widths (kilometers) for masking COSP PARASOL data. The "swath width"
+determines the spatial region around each local time that is simulated. 
+Supplying a swath width in units of distance rather than radians produces
+a larger sampling density at higher latitudes that is consistent with
+observations.
+Default: none
+</entry>
+
+<entry id="cosp_SWATH_WIDTHS_ATLID" type="real*10"  category="cosp"
+       group="cospsimulator_nl" valid_values="" >
+Swath widths (kilometers) for masking COSP ATLID data. The "swath width"
+determines the spatial region around each local time that is simulated. 
+Supplying a swath width in units of distance rather than radians produces
+a larger sampling density at higher latitudes that is consistent with
+observations.
+Default: none
 </entry>
 
 <!-- COSP output parameters -->
@@ -2583,7 +2747,7 @@ Default: .true., except for carma=cirrus and carma=carma_dust
        group="micro_mg_nl" valid_values="" >
 Version number for MG microphysics.  This value is set automatically based
 on settings in configure and passed to build-namelist
-Default: 1 for CAM5 and 2 for CAM6
+Default: 1 for CAM5, 2 for CAM6 and 3 for CAM7
 </entry>
 
 <entry id="micro_mg_sub_version" type="integer" category="microphys"
@@ -2956,7 +3120,7 @@ Default: 0.05
 <entry id="use_preexisting_ice" type="logical" category="microphys"
        group="nucleate_ice_nl" valid_values="" >
 Switch to turn on treatment of pre-existing ice in the ice nucleation code.
-Default: .false., except .true. for CAM6
+Default: .false., except .true. for CAM6 and CAM7
 </entry>
 
 <entry id="hist_preexisting_ice" type="logical" category="microphys"
@@ -2987,7 +3151,7 @@ Default: set by build-namelist
 Switch to determine whether ice nucleation happens using the incloud (true) or
 the gridbox average (false) relative humidity.  When true, it is assumed that
 the incloud relative humidity for nucleation is 1.
-Default: .true., except .false. for CAM6
+Default: .true., except .false. for CAM6 and CAM7
 </entry>
 
 <entry id="nucleate_ice_strat" type="real" category="microphys"
@@ -3043,7 +3207,7 @@ Default: .true.
 <entry id="cldfrc_ice" type="logical" category="cldfrc"
        group="cldfrc_nl" valid_values="" >
 Switch for ice cloud fraction calculation.
-Default: .true. for CAM5 and CAM6, otherwise .false.
+Default: .true. for CAM5, CAM6 and CAM7, otherwise .false.
 </entry>
 
 <entry id="cldfrc_rhminl" type="real" category="cldfrc"
@@ -3055,7 +3219,7 @@ Default: set by build-namelist
 <entry id="cldfrc_rhminl_adj_land" type="real" category="conv"
        group="cldfrc_nl" valid_values="" >
 Adjustment to rhminl for land without snow cover.
-Default: 0.0 for CAM6;
+Default: 0.0 for CAM6 and CAM7;
          all others =&gt; 0.10
 </entry>
 
@@ -3098,13 +3262,13 @@ Default: set by build-namelist
 <entry id="cldfrc_premib" type="real" category="conv"
        group="cldfrc_nl" valid_values="" >
 Bottom height (Pa) for mid-level liquid stratus fraction.
-Default: 700.e2 for CAM5 and CAM6; all others=&gt; 750.e2
+Default: 700.e2 for CAM5, CAM6 and CAM7; all others=&gt; 750.e2
 </entry>
 
 <entry id="cldfrc_iceopt" type="integer" category="conv"
        group="cldfrc_nl" valid_values="" >
 Scheme for ice cloud fraction: 1=wang &amp; sassen, 2=schiller (iciwc),
-3=wood &amp; field, 4=Wilson (based on smith), 5=modified slingo (ssat &amp; empyt cloud)
+3=wood &amp; field, 4=Wilson (based on smith), 5=modified slingo (ssat &amp; empty cloud)
 Default: set by build-namelist
 </entry>
 
@@ -3140,7 +3304,7 @@ Default: set by build-namelist
 
 <entry id="cldfrc2m_qist_min" type="real" category="conv"
        group="cldfrc2m_nl" valid_values="" >
-Minimum in-stratus IWC constraint [ kg/kg ]
+Minimum in-stratus IWC constraint greater than 0 [ kg/kg ]
 Default: set by build-namelist
 </entry>
 
@@ -3154,7 +3318,7 @@ Default: set by build-namelist
        group="cldfrc2m_nl" valid_values="" >
 Use cloud fraction to determine whether to do growth of ice clouds below
 RHice of 1 down to RHice = rhmini.
-Default: .true. for CAM6; all others =&gt; .false.
+Default: .true. for CAM6 and CAM7; all others =&gt; .false.
 </entry>
 
 <entry id="cldfrc2m_do_avg_aist_algs" type="logical" category="conv"
@@ -3203,7 +3367,7 @@ Default: set by build-namelist
 <entry id="zmconv_num_cin" type="integer" category="conv"
        group="zmconv_nl" valid_values="" >
 The number of negative buoyancy regions that are allowed before the convection top and CAPE calculations are completed.
-Default: =&gt; 1 for CAM6;
+Default: =&gt; 1 for CAM6 and CAM7;
          =&gt; 5 for all other
 </entry>
 
@@ -3213,7 +3377,7 @@ Tunable entrainment rate in ZM deep convection scheme in units of (m-1).
 Default: -1.0e-3 m-1
 </entry>
 
-<entry id="zmconv_tiedke_add" type="real" category="conv"
+<entry id="zmconv_tiedtke_add" type="real" category="conv"
        group="zmconv_nl" valid_values="" >
 Tunable parcel temperature perturbation in ZM deep convection scheme in units of (K).
 Default: 0.5K perturbation
@@ -3624,12 +3788,12 @@ Default: 100.e3 (hPa)
 <entry id="eddy_moist_entrain_a2l" type="real" category="pbl"
        group="eddy_diff_nl" valid_values="" >
 Moist entrainment enhancement parameter.
-Default: set by build-namelist
+Default: 30.D0
 </entry>
 
 <entry id="kv_top_pressure" type="real" category="pbl"
        group="eddy_diff_nl" valid_values="" >
-Pressure (Pa) that defined the upper atmosphere for adjustment of
+Pressure (Pa) that defines the upper atmosphere for adjustment of
 eddy diffusivities from diag_TKE using kv_top_scale.
 Default: 0.
 </entry>
@@ -3661,6 +3825,37 @@ diffusion solver routine.
 Default: set by build-namelist
 </entry>
 
+<entry id="diff_sponge_fac" type="real" category="pbl"
+       group="vert_diff_nl" valid_values="" >
+Factor to add sponge layer vertical diffusion of zonal and meridional components
+of the wind verctor (following the profile for del2 damping in the spectral-element dycore).
+
+Sponge layer interface coefficients for model tops above ptop=1E-3Pa (e.g. WACCM):
+
+        kvm_sponge(1) = 2.e5*diff_sponge_fac
+        kvm_sponge(2) = 2.e5*diff_sponge_fac
+        kvm_sponge(3) = 1.5e5*diff_sponge_fac
+        kvm_sponge(4) = 1.0e5*diff_sponge_fac
+        kvm_sponge(5) = 0.5e5*diff_sponge_fac
+        kvm_sponge(6) = 0.1e5*diff_sponge_fac
+
+Else:
+
+	kvm_sponge(1) = 2.e4*diff_sponge_fac
+        kvm_sponge(2) = 2.e4*diff_sponge_fac
+        kvm_sponge(3) = 0.4e*diff_sponge_fac
+        kvm_sponge(4) = 0.1e4*diff_sponge_fac
+
+Vertical diffusion in configurations with model tops below ~80km
+(e.g., LT and MT) is only recommended for spin-up with diff_sponge_fac=1.
+For higher tops diff_sponge_fac=1 can improve model stability in general.
+
+A too large diff_sponge_fac value can lead to "stove pipes" in the
+the zonally averaged zonal wind in the sponge layer.
+
+Default: 0.0
+</entry>
+
 <!-- CLUBB PBL Diff nl -->
 
 <entry id="clubb_cloudtop_cooling" type="logical"  category="pblrad"
@@ -3677,6 +3872,13 @@ Include effects of precip evaporation on turbulent moments
        group="clubbpbl_diff_nl" valid_values="" >
 Switch for CLUBB_ADV parameter that turns on advection of CLUBB pdf moments by
 the dynamics core. Very experimental.
+</entry>
+
+<entry id="clubb_l_ascending_grid" type="logical" category="pblrad"
+       group="clubbpbl_diff_nl" valid_values="" >
+Causes advance_clubb_core to run in ascending mode, where the surface is at k=1, which is opposite
+of the descending cam grid. This is mainly a testing/debugging option - it requires an expensive 
+data flipping step and should not change answers significantly.
 </entry>
 
 <!-- Clubb timestep -->
@@ -3947,6 +4149,32 @@ Gaussian PDF, and also decreases the difference between the means of w from
 each Gaussian.
 </entry>
 
+<entry id="clubb_grid_adapt_in_time_method" type="integer" category="pblrad"
+       group="clubb_params_nl" valid_values="0,1" >
+Specifier for method to construct a grid density function to adapt grid to.
+Valid values: 0 (no grid adaptation), 1 (use Lscale and wp2)
+</entry>
+
+<entry id="clubb_fill_holes_type" type="integer" category="pblrad"
+       group="clubb_params_nl" valid_values="0,1,2,3,4,5,6" >
+Selects which algorithm the fill_holes routine uses to correct 
+below threshold values in field solutions.
+0: off - Skip the mass conservative hole filling step, rely on blunt clipping
+1: global - Fast but minimally local, most methods use this as a fallback step
+2: sliding_window - Expensive but highly local when possible, falls back to global fill if needed
+3: widening_windows - Slightly parallelizable, local when possible, falls back to global if needed
+4: smart_window - Uses hueristics to determine ranges to fill, fast and highly local when possible, falls back to global if needed
+5: smart_window_smooth - Same as smart_window, but with experimental smoothing features that slightly increases cost, NO GLOBAL FALLBACK
+6: parallel_fill - Highly local when possible, completely parallelizable but computationally wasteful, falls back to global if needed
+See CLUBB_core/model_flags.F90 or CLUBB_core/fill_holes.F90 for more detail.
+</entry>
+
+<entry id="clubb_grid_remap_method" type="integer" category="pblrad"
+       group="clubb_params_nl" valid_values="1" >
+Specifier for method to remap values from one grid to another.
+Valid values: 1 (ullrich remapping)
+</entry>
+
 <entry id="clubb_iiPDF_type" type="integer" category="pblrad"
        group="clubb_params_nl" valid_values="1,2,3,4,5,6,7" >
 Selected option for the two-component normal (double Gaussian) PDF type to use for the w, rt,
@@ -3971,6 +4199,11 @@ Intensity of stability correction applied to C1 and C6
 Coefficient used to determine the minimum allowable value of CLUBB's length
 scale (Lscale) in a grid-spacing dependent formula.  Increasing the value of
 clubb_lmin_coef increases the minimum allowable value for length scale.
+</entry>
+
+<entry id="clubb_l_add_dycore_grid" type="logical" category="pblrad"
+       group="clubb_params_nl" valid_values="" >
+Flag to remap values from the dycore grid.
 </entry>
 
 <entry id="clubb_l_brunt_vaisala_freq_moist" type="logical" category="pblrad"
@@ -4152,6 +4385,18 @@ in terms of wp3(t+1). (Requires ADG1 PDF and l_standard_term_ta=true).
 Flag to predict horizontal momentum fluxes upwp and vpwp along with mean
 horizontal winds um and vm.  When this flag is turned off, upwp and vpwp are
 calculated by down-gradient diffusion.
+</entry>
+
+<entry id="clubb_l_ho_nontrad_coriolis" type="logical" category="pblrad"
+       group="clubb_params_nl" valid_values="" >
+Flag to implement the nontraditional Coriolis terms in the 
+prognostic equations of w'w', u'w', and u'u.
+</entry>
+
+<entry id="clubb_l_ho_trad_coriolis" type="logical" category="pblrad"
+       group="clubb_params_nl" valid_values="" >
+Flag to implement the traditional Coriolis terms in the
+prognostic equations of v'w' and u'w'.
 </entry>
 
 <entry id="clubb_l_prescribed_avg_deltaz" type="logical" category="pblrad"
@@ -4414,6 +4659,15 @@ Absolute path to the neural net weights used for the YOG deep convection scheme.
 <entry id="SAM_sounding" type="char*132" input_pathname="abs" category="conv"
        group="yog_params_nl" valid_values="" >
 Absolute path to the SAM sounding profile used for the YOG deep convection scheme.
+</entry>
+
+<entry id="yog_lat_max" type="real" category="conv"
+       group="yog_params_nl" valid_values="" >
+Maximum absolute latitude (degrees) at which the YOG deep convection scheme
+is applied. The YOG neural net was trained on tropical SAM data; outside
+this latitude band its tendencies are zeroed and the standard ZM deep
+convection scheme (which always runs) is left unmodified.
+Default: 30.0
 </entry>
 
 <!-- CARMA Sectional Microphysics -->
@@ -5163,7 +5417,7 @@ Default: TRUE
 <!-- Physics control -->
 
 <entry id="cam_physpkg" type="char*16" category="build"
-       group="phys_ctl_nl" valid_values="cam4,cam5,cam6,adiabatic,held_suarez,kessler,frierson" >
+       group="phys_ctl_nl" valid_values="cam4,cam5,cam6,cam7,adiabatic,held_suarez,kessler,frierson" >
 Name of the CAM physics package.  N.B. this variable may not be set by
 the user.  It is set by build-namelist via information in the configure
 cache file to be consistent with how CAM was built.
@@ -5180,10 +5434,12 @@ Default: set by build-namelist
 
 <entry id="cam_chempkg" type="char*32" category="build" group="phys_ctl_nl"
        valid_values="none,ghg_mam4,terminator,trop_mam3,trop_mam4,trop_mam7,trop_mozart,trop_strat_mam4_ts2,
-		     trop_strat_mam4_vbs,trop_strat_mam4_vbsext,trop_strat_mam5_ts2,trop_strat_mam5_vbs,
-		     trop_strat_mam5_vbsext,waccm_ma,waccm_mad,waccm_ma_sulfur,waccm_sc,waccm_sc_mam4,
-		     waccm_mad_mam4,waccm_ma_mam4,waccm_tsmlt_mam4,waccm_tsmlt_mam4_vbsext,waccm_mad_mam5,
-		     waccm_ma_mam5,waccm_tsmlt_mam5,waccm_tsmlt_mam5_vbsext,geoschem">
+                     trop_strat_mam4_vbs,trop_strat_mam4_vbsext,trop_strat_mam4_slh,trop_strat_mam5_slh,
+                     trop_strat_mam5_t1s1,trop_strat_mam5_t1s2,trop_strat_mam5_t2s1,trop_strat_mam5_t4s2,
+                     trop_strat_mam5_vbsext,trop_strat_noaero,waccm_ma,waccm_mad,waccm_ma_sulfur,waccm_sc,
+                     waccm_sc_mam4,waccm_mad_mam4,waccm_ma_mam4,waccm_tsmlt_mam4,waccm_tsmlt_mam4_vbsext,
+                     waccm_tsmlt_mam4_slh,waccm_tsmlt_mam5_slh,waccm_mad_mam5,waccm_ma_mam5,waccm_tsmlt_mam5,
+                     waccm_tsmlt_mam5_vbsext,waccm_t4ma_mam5,waccm_ma_noaero,geoschem_mam4">
 Name of the CAM chemistry package.  N.B. this variable may not be set by
 the user.  It is set by build-namelist via information in the configure
 cache file to be consistent with how CAM was built.
@@ -6323,6 +6579,51 @@ Default: NEU
        group="wetdep_inparm" valid_values="" >
 List of gas-phase species that undergo wet deposition via the wet deposition scheme.
 Default: NONE
+</entry>
+
+<entry id="gas_wetdep_ice_uptake_list" type="char*16(1000)" category="cam_chem"
+       group="wetdep_inparm" valid_values="" >
+List of gas-phase species that undergo ice scavenging in the NEU
+wet deposition scheme.
+Default: set by build-namelist
+</entry>
+
+<!-- Short-Lived Halogen (SLH) Namelist Definitions -->
+
+<entry id="SSAdehal_ScalingFactor" type="real" category="cam_chem"
+       group="slh_nl" valid_values="" >
+Scaling-factor for SLH dehalogenation reaction (XONO2,XNO2,HOX) on Sea-Salt Aerosols.
+Default: set by build-namelist
+</entry>
+
+<entry id="SSAhno3_ScalingFactor" type="real" category="cam_chem"
+       group="slh_nl" valid_values="" >
+Scaling-factor for SLH acid displacement reaction (HNO3-->HCl) on Sea-Salt Aerosols.
+Default: set by build-namelist
+</entry>
+
+<entry id="SSAn2o5_ScalingFactor" type="real" category="cam_chem"
+       group="slh_nl" valid_values="" >
+Scaling-factor for SLH dinitrogen pentoxide reaction (N2O5-->HNO3+CLNO2) on Sea-Salt Aerosols
+Default: set by build-namelist.
+</entry>
+
+<entry id="LIQfraprx_ScalingFactor_I" type="real" category="cam_chem"
+       group="slh_nl" valid_values="" >
+Scaling-factor for SLH washout (Iodine) on liquid droplets based on Free-Regime Approx.
+Default: set by build-namelist
+</entry>
+
+<entry id="ICEfraprx_ScalingFactor_I" type="real" category="cam_chem"
+       group="slh_nl" valid_values="" >
+Scaling-factor for SLH washout (Iodine) on ice crystals based on Free-Regime Approx.
+Default: set by build-namelist
+</entry>
+
+<entry id="ICEfraprx_ScalingFactor_Br" type="real" category="cam_chem"
+       group="slh_nl" valid_values="" >
+Scaling-factor for SLH washout (Bromine) on ice crystals based on Free-Regime Approx.
+Default: set by build-namelist
 </entry>
 
 <entry id="modal_accum_coarse_exch" type="logical" category="cam_chem"
@@ -7703,6 +8004,17 @@ Maximum zenith angle (degrees) used for photolysis.
 Default: set by build-namelist.
 </entry>
 
+<entry id="tuvx_config_path" type="char*256" input_pathname="abs" category="chemistry"
+       group="tuvx_opts" valid_values="" >
+Filepath of TUV-X configuration specification.
+Default: NONE
+</entry>
+
+<entry id="tuvx_active" type="logical" category="chemistry"
+       group="tuvx_opts" valid_values="" >
+Switch to turn on TUV-X photolysis.
+Default: FALSE
+</entry>
 
 <!-- Namelist read by seq_drydep_mod and shared by CAM and CLM -->
 
@@ -8023,6 +8335,13 @@ Default: FALSE
        group="radheat_nl" valid_values="" >
 Call ALI-ARMS every X timesteps
 Default: 1
+</entry>
+
+<entry id="nlte_use_extco2" type="logical" category="waccm_phys"
+       group="radheat_nl" valid_values="" >
+If TRUE, then use the extended CO2 scheme of Lopez-Puertas et al. 2024 as an alernative method of computing non-LTE
+CO2 cooling rates in the upper atmosphere. (DOI:10.5194/gmd-17-4401-2024)
+Default: FALSE
 </entry>
 
 <entry id="qbo_cyclic" type="logical" category="waccm_phys"
@@ -8695,8 +9014,8 @@ Default: 120000.0
 
 <entry id="mpas_visc4_2dsmag" type="real" category="mpas"
        group="nhyd_model" valid_values="">
-Scaling coefficient of delta_x^3 to obtain Del^4 diffusion coefficient in
-MPAS dycore.
+Coefficient multiplied by delta x^3 to obtain Del^4 physical hyperviscosity
+in MPAS dycore.
 Default: 0.05
 </entry>
 
@@ -8787,13 +9106,6 @@ MPAS dycore.
 Default: TRUE
 </entry>
 
-<entry id="mpas_epssm" type="real" category="mpas"
-       group="nhyd_model" valid_values="">
-Off-centering parameter for the vertically implicit acoustic integration in
-MPAS dycore
-Default: 0.1
-</entry>
-
 <entry id="mpas_smdiv" type="real" category="mpas"
        group="nhyd_model" valid_values="">
 3-d divergence damping coefficient in MPAS dycore.
@@ -8869,6 +9181,32 @@ damping linearly ramps to zero by layer number from the top
 Default: 3
 </entry>
 
+<entry id="mpas_epssm_minimum" type="real" category="mpas"
+       group="damping" valid_values="real values between 0 and 1">
+Value of epssm, the off-centering parameter for the vertically implicit acoustic integration,
+below transition zone.
+Default: 0.1
+</entry>
+
+<entry id="mpas_epssm_maximum" type="real" category="mpas"
+       group="damping" valid_values="real values between 0 and 1">
+Value of epssm, the off-centering parameter for the vertically implicit acoustic integration,
+above transition zone.
+Default: 0.5
+</entry>
+
+<entry id="mpas_epssm_transition_bottom_z" type="real" category="mpas"
+       group="damping" valid_values="positive real values">
+Height (in meters) above MSL for the bottom of transition zone for epssm.
+Default: 30000.0
+</entry>
+
+<entry id="mpas_epssm_transition_top_z" type="real" category="mpas"
+       group="damping" valid_values="positive real values">
+Height (in meters) above MSL for the top of transition zone for epssm.
+Default: 50000.0
+</entry>
+
 <entry id="mpas_apply_lbcs" type="logical" category="mpas"
        group="limited_area" valid_values="">
 Whether to apply lateral boundary conditions
@@ -8919,6 +9257,18 @@ dycore.
 Default: FALSE
 </entry>
 
+<entry id="mpas_halo_exch_method" type="char*512" category="mpas"
+       group="development" valid_values="mpas_dmpar,mpas_halo">
+Method to use for exchanging halos in MPAS dycore.
+Default: mpas_halo
+</entry>
+
+<entry id="mpas_gpu_aware_mpi" type="logical" category="mpas"
+       group="development" valid_values=".false.,.true.">
+Whether to use GPU-aware MPI for halo exchanges in MPAS dycore. GPU-aware MPI
+is only implemented for mpas_halo_exch_method = mpas_halo.
+Default: FALSE
+</entry>
 
 <!-- Dycore testing  -->
 

--- a/CAM_Convection_YOG/docs/build_instructions.md
+++ b/CAM_Convection_YOG/docs/build_instructions.md
@@ -1,11 +1,46 @@
 # Build Instructions (Summary)
-- Clone CESM3_0_alpha07f.
-- Copy these modified CAM files into components/atm/cam/src/physics/cam/.
-- Ensure FTorch library interface is located in libraries/FTorch directory
-- Add namelist entries in namelist_definition.xml.
--  Rebuild CAM and run your case.
 
-./case.setup
-./preview_namelists
-./case.build --clean-all
-./case.build
+Tested against `cesm3_0_alpha09e` (CAM `cam6_4_186`) on Derecho. Originally
+built against `cesm3_0_alpha07f` — see the "Porting to a New CESM Tag" and
+"Build Gotchas" sections in the main README for what changed between tags.
+
+1. Clone/checkout CESM3 (with submodules, e.g. via `git-fleximod update`).
+2. Copy the files under `src/cam/` in this folder into
+   `components/cam/src/physics/cam/` in your checkout (new files:
+   `SAM_consts.F90`, `nn_cf_net.F90`, `nn_convection_flux.F90`,
+   `nn_interface_cam.F90`, `yog_intr.F90`; modified: `phys_control.F90`,
+   `physpkg.F90` — the latter needs a manual merge if your CAM tag has
+   diverged from `cam6_4_186`, see README).
+3. Copy `libraries/FTorch/{CMakeLists.txt,FTorch_cesm_interface.F90,buildlib}`
+   from this folder into your checkout's `libraries/FTorch/`.
+4. Confirm the nested FTorch submodule is actually populated:
+   `ls libraries/FTorch/src` should show real files (`CMakeLists.txt`, `src/`,
+   etc.), not an empty directory. If empty: `cd libraries/FTorch && git
+   submodule update --init src`.
+5. Copy `bld/namelist_files/{namelist_defaults_cam.xml,namelist_definition.xml}`
+   from this folder into `components/cam/bld/namelist_files/` (or manually
+   apply the YOG-related `<entry>` additions if your tag's files have
+   otherwise diverged).
+6. Create your case as usual, then:
+   ```
+   ./xmlchange USE_FTORCH=TRUE
+   ./case.setup
+   ./preview_namelists
+   ./case.build --clean-all
+   ./case.build
+   ```
+7. In `user_nl_cam`, set:
+   ```
+   yog_scheme = 'on'
+   yog_nn_weights = '/path/to/model_weights.pt'
+   yog_nn_scale   = '/path/to/scaling_metadata.nc'
+   SAM_sounding   = '/path/to/sam_sounding.nc'
+   ```
+   (`yog_lat_max` defaults to 30° — only override this deliberately, see
+   README "Build Gotchas").
+
+If `case.build` fails on FTorch with a CMake `ADD_LIBRARY ... SHARED ...
+does not support dynamic linking` error, see the Catamount/CMake note in the
+README — the fix is already applied in `libraries/FTorch/buildlib` above,
+but if you're merging against a different FTorch version, you may need to
+reapply it.

--- a/CAM_Convection_YOG/libraries/FTorch/buildlib
+++ b/CAM_Convection_YOG/libraries/FTorch/buildlib
@@ -82,7 +82,11 @@ def buildlib(bldroot, installpath, case):
     else:
         use_ftorch = "OFF"
 
-    cmake_opts = '"-DCMAKE_PREFIX_PATH={} -DTORCH_LIBRARY={} -DUSE_FTORCH={} "'.format(torch_dir, torch_library, use_ftorch)
+    # Override the Catamount cross-compile target CIME sets by default: it disables
+    # CMake's shared-library support, which breaks find_package(Torch)'s protobuf/
+    # utf8_range IMPORTED SHARED targets under newer libtorch builds. Placed after
+    # the base -DCMAKE_SYSTEM_NAME=Catamount on the cmake command line so this wins.
+    cmake_opts = '"-DCMAKE_PREFIX_PATH={} -DTORCH_LIBRARY={} -DUSE_FTORCH={} -DCMAKE_SYSTEM_NAME=Linux "'.format(torch_dir, torch_library, use_ftorch)
 
     gmake_vars = (
         "CASEROOT={caseroot} COMP_NAME=FTorch "

--- a/CAM_Convection_YOG/src/cam/SAM_consts.F90
+++ b/CAM_Convection_YOG/src/cam/SAM_consts.F90
@@ -1,0 +1,129 @@
+module SAM_consts_mod
+  !! Physical constants from the SAM Model required for variable conversions
+  
+  use netcdf
+
+  implicit none
+  public
+
+  ! From params.f90 in SAM
+  ! These are constants used in equations as part of the parameterisation.
+  ! Since the net is trained with them they should be left as defined here, rather than
+  ! forced to match the external model
+
+  ! Physical Constants:
+
+  != unit (m / s^2)
+  real(8), parameter :: ggr = 9.81
+      !! Gravity acceleration, m/s2
+
+  != unit J / kg :: lcond, lsub, lfus
+  real(8), parameter :: lfus = 0.3336e+06
+      !! Latent heat of fusion
+  real(8), parameter :: lcond = 2.5104e+06
+      !! Latent heat of condensation
+  real(8), parameter :: lsub = 2.8440e+06
+      !! Latent heat of sublimation, J/kg
+
+  != unit (J / kg) / K :: cp
+  real(8), parameter :: cp = 1004.
+      !! Specific heat of air
+  
+  ! unit K :: fac_cond, fac_fus, fac_sub
+  real(8), parameter :: fac_cond = lcond/cp
+      !!
+  real(8), parameter :: fac_fus = lfus/cp
+      !!
+  real(8), parameter :: fac_sub = lsub/cp
+      !!
+
+  ! Temperatures limits for various hydrometeors
+  != unit K :: tprmin
+  real(8), parameter :: tprmin = 268.16
+      !! Minimum temperature for rain
+  
+  != unit K :: tprmax
+  real(8), parameter :: tprmax = 283.16
+      !! Maximum temperature for snow+graupel, K
+  
+  != unit K :: tbgmin
+  real(8), parameter :: tbgmin = 253.16
+      !! Minimum temperature for cloud water.
+  
+  != unit K :: tbgmin
+  real(8), parameter :: tbgmax = 273.16
+      !! Maximum temperature for cloud ice, K
+
+  != unit K :: tbgmin
+  real(8), parameter :: tgrmin = 223.16
+      !! Maximum temperature for snow, K
+
+  != unit K :: tbgmin
+  real(8), parameter :: tgrmax = 283.16
+      !! Maximum temperature for graupel, K
+
+  ! Misc. microphysics variables
+  ! != unit 1 / K :: a_pr
+  real(8), parameter :: a_pr = 1./(tprmax-tprmin)
+      !! Misc. microphysics variables
+  
+  != unit 1 / K :: a_bg
+  real(8), parameter :: a_bg = 1./(tbgmax-tbgmin)
+      !! Misc. microphysics variables
+
+  real(8), parameter :: an = 1./(tbgmax-tbgmin)
+  real(8), parameter :: bn = tbgmin * an
+  real(8), parameter :: ap = 1./(tprmax-tprmin)
+  real(8), parameter :: bp = tprmin * ap
+  real(8), parameter :: fac1 = fac_cond+(1+bp)*fac_fus
+  real(8), parameter :: fac2 = fac_fus*ap
+  real(8), parameter :: ag = 1./(tgrmax-tgrmin)
+
+  ! ---------------------------
+  ! SAM Grid Variables
+  ! ---------------------------
+  integer, parameter :: input_ver_dim = 49 ! XL XL XL
+      !! The number of cells in a SAM atmospheric column on which the neural net was trained
+  
+  ! Outputs from NN are supplied at lowest 30 half-model levels for sedimentation fluxes,
+  ! and at 29 levels for fluxes (as flux at bottom boundary is zero).
+  integer, parameter :: nrf = 49 ! XL XL XL 
+      !! number of vertical levels the NN uses
+  integer, parameter :: nrfq = nrf - 1
+      !! number of vertical levels the NN uses when boundary condition is set to 0
+
+  real(8), parameter :: dt_sam = 24.0
+      !! SAM timestep in seconds
+
+!---------------------------------------------------------------------
+! Functions and Subroutines
+
+contains
+
+  != unit 1 :: omegan
+  real(8) function omegan(tabs)
+      != unit K :: tabs
+      real(8), intent(in) :: tabs
+          !! Absolute temperature
+
+      omegan = max(0., min(1., (tabs-tbgmin)*a_bg))
+
+      return
+
+  end function omegan
+
+
+  subroutine check(err_status)
+  !! Check error status after netcdf call and print message for
+  !! error codes.
+
+  integer, intent(in) :: err_status
+    !! error status from nf90 function
+
+  if(err_status /= nf90_noerr) then
+     write(*, *) trim(nf90_strerror(err_status))
+  end if
+
+  end subroutine check
+
+end module SAM_consts_mod

--- a/CAM_Convection_YOG/src/cam/nn_cf_net.F90
+++ b/CAM_Convection_YOG/src/cam/nn_cf_net.F90
@@ -125,8 +125,11 @@ contains
         deallocate(out_data)
 
         ! Clean up tensors
-        call torch_delete(in_tensor)
-        call torch_delete(out_tensor)
+        !call torch_delete(in_tensor)
+        !call torch_delete(out_tensor)
+
+        call torch_delete(in_tensor(1))
+        call torch_delete(out_tensor(1))
     end subroutine net_forward
 
     subroutine nn_cf_net_init(nn_filename, metadata_filename, n_inputs, n_outputs, nrf, model_ftorch, iulog, errstring)
@@ -223,10 +226,15 @@ contains
         n_lev = nrf
 
         ! Allocate and set sizes of the feature groups
+        ! All 5 output groups (t_rad_rest_tend, t_flux_adv, q_flux_adv,
+        ! q_tend_auto, q_sed_flux) are full nrf size for this model --
+        ! unlike the older reference model, t_flux_adv/q_flux_adv are NOT
+        ! reduced by 1 here (the surface-boundary zero is applied
+        ! explicitly in nn_convection_flux.F90 instead). n_features_out=5
+        ! groups x n_lev=49 = 245 = N_out, confirmed against the metadata file.
         if (allocated(feature_out_sizes)) deallocate(feature_out_sizes)
         allocate(feature_out_sizes(n_features_out))
-        feature_out_sizes(:)   = n_lev
-        feature_out_sizes(2:3) = n_lev-1
+        feature_out_sizes(:) = n_lev
 
     end subroutine nn_cf_net_init
 
@@ -261,6 +269,7 @@ contains
 
         if(err_status /= nf90_noerr) then
              write(*, *) trim(nf90_strerror(err_status))
+             stop 'nn_cf_net_mod: fatal netCDF error, aborting'
         end if
 
     end subroutine check

--- a/CAM_Convection_YOG/src/cam/nn_convection_flux.F90
+++ b/CAM_Convection_YOG/src/cam/nn_convection_flux.F90
@@ -8,8 +8,10 @@ module nn_convection_flux_mod
 ! Libraries to use
 use nn_cf_net_mod, only: nn_cf_net_init, net_forward !nn_cf_net_finalize
 use SAM_consts_mod, only: fac_cond, fac_fus, tprmin, a_pr, input_ver_dim, &
-                          nrf, nrfq
+                          nrf, nrfq, ggr
+use cam_logfile,    only: iulog
 use FTorch_cesm_interface, only: torch_model
+
 implicit none
 private
 
@@ -25,12 +27,15 @@ public  nn_convection_flux, nn_convection_flux_init, nn_convection_flux_finalize
 
 ! Neural Net parameters used throughout module
 
-integer :: n_inputs, n_outputs, n_h1, n_h2, n_h3, n_h4, n_features_out, n_lev
+integer :: n_inputs, n_outputs
     !! Length of input/output vector to the NN
+
 type(torch_model) :: model_ftorch
+    !! FTorch handle for the loaded TorchScript model
+
 logical :: do_init=.true.
     !! model initialisation is yet to be performed
-integer, allocatable :: feature_out_sizes(:)
+
 
 !---------------------------------------------------------------------
 ! Functions and Subroutines
@@ -44,28 +49,27 @@ contains
         !! Initialise the NN module using FTorch
 
         character(len=136), intent(in) :: nn_filename
-            !! PyTorch model filename (.pt file) from which to load model 
+            !! PyTorch model filename (.pt file) from which to load model
         character(len=136), intent(in) :: metadata_filename
-        !! NetCDF file with dimensions and scaling parameters
-        
+            !! NetCDF file with dimensions and scaling parameters
+
         ! Local variables for error handling
         character(128) :: errstring
-        integer :: iulog
-    
-        ! Set logging unit (use standard output or your logging system)
-        iulog = 6  ! Standard output, or use your model's logging unit
+        integer :: iulog_local
+
+        iulog_local = 6  ! Standard output
 
         ! Initialise the Neural Net from PyTorch file
         call nn_cf_net_init(nn_filename, metadata_filename, n_inputs, n_outputs, nrf, &
-                        model_ftorch, iulog, errstring)
-        
+                        model_ftorch, iulog_local, errstring)
+
         ! Check for errors
         if (len_trim(errstring) > 0) then
-            write(iulog, *) 'ERROR in nn_convection_flux_init: ', trim(errstring)
+            write(iulog_local, *) 'ERROR in nn_convection_flux_init: ', trim(errstring)
             stop 'Failed to initialize neural network'
         end if
 
-        write(iulog, *) 'Neural network initialized successfully'
+        write(iulog_local, *) 'Neural network initialized successfully'
 
         ! Set init flag as complete
         do_init = .false.
@@ -73,309 +77,196 @@ contains
     end subroutine nn_convection_flux_init
 
 
-    subroutine nn_convection_flux(tabs_i, q_i, &
-                                  tabs, &
-                                  t, q, &
+    subroutine nn_convection_flux(tabs_i, q_i, ps_i, landfrac, &
                                   rho, adz, dz, dtn, &
-                                  precsfc)
-        !! Interface to the neural net that applies physical constraints and reshaping
-        !! of variables.
-        !! Operates on subcycle of timestep dtn to update t, q, precsfc, and prec_xy
+                                  t_rad_rest_tend, t_flux_adv, &
+                                  q_flux_adv, q_tend_auto, q_sed_flux)
+      
+      !! Interface to the neural net that applies physical constraints and reshaping
+      !! of variables.
+      !! Operates on subcycle of timestep dtn to update t, q, precsfc, and prec_xy
 
-        ! -----------------------------------
-        ! Input Variables
-        ! -----------------------------------
+      ! -----------------------------------
+      ! Input Variables
+      ! -----------------------------------
+      
+      ! ---------------------
+      ! Fields from beginning of time step used as NN inputs
+      ! ---------------------
+      != unit s :: tabs_i
+      real(8), intent(in) :: tabs_i(:, :)
+      !! Temperature
+      
+      != unit 1 :: q_i
+      real(8), intent(in) :: q_i(:, :)
+      !! Non-precipitating water mixing ratio
 
-        ! ---------------------
-        ! Fields from beginning of time step used as NN inputs
-        ! ---------------------
-        != unit s :: tabs_i
-        real(8), intent(in) :: tabs_i(:, :)
-            !! Temperature
+      != unit Pa :: ps_i
+      real(8), intent(in) :: ps_i(:)
+      !! Surface pressure
 
-        != unit 1 :: q_i
-        real(8), intent(in) :: q_i(:, :)
-            !! Non-precipitating water mixing ratio
+      != unit 1 :: landfrac
+      real(8), intent(in) :: landfrac(:)
+      !! landfraction
+      
+      ! ---------------------
+      ! reference vertical profiles:
+      ! ---------------------
+      != unit (kg / m**3) :: rho
+      real(8), intent(in) :: rho(:)
+      !! air density at pressure levels
+      
+      != unit 1 :: adz
+      real(8), intent(in) :: adz(:)
+      !! ratio of the pressure level grid height spacing [m] to dz (lowest dz spacing)
 
-        ! ---------------------
-        ! Other fields from SAM
-        ! ---------------------
-        != unit K :: tabs
-        real(8), intent(in) :: tabs(:, :)
-            !! absolute temperature
-        
-        != unit (J / kg) :: t
-        real(8), intent(inout) :: t(:, :)
-            !! Liquid Ice static energy (cp*T + g*z − L(qliq + qice) − Lf*qice)
+      ! ---------------------
+      ! Single value parameters from model/grid
+      ! ---------------------
+      != unit m :: dz
+      real(8), intent(in) :: dz
+      !! grid spacing in z direction for the lowest grid layer
+      
+      != unit s :: dtn
+      real(8), intent(in) :: dtn
+      !! current dynamical timestep (can be smaller than dt due to subcycling)
+      
+      ! -----------------------------------
+      ! Local Variables
+      ! -----------------------------------
+      integer  i, k, dim_counter, out_dim_counter
+      integer ncol
+      !! Number of columns in a subdomain
+      integer nzm
+      !! Number of z points in a subdomain - 1
+      real(8),   dimension(size(tabs_i, 1),size(tabs_i, 2)) :: irhoadz, irhoadzdz
+      real(8),   dimension(size(tabs_i,1),size(tabs_i, 2)) :: nn_mask      
+      ! -----------------------------------
+      ! variables for NN
+      ! -----------------------------------
+      real(4), dimension(n_inputs) :: features
+      !! Vector of input features for the NN
+      real(4), dimension(n_outputs) :: outputs
+      !! vector of output features from the NN
+      ! NN outputs
+      real(8),  intent(out), dimension(size(tabs_i, 1), size(tabs_i, 2)) :: t_flux_adv, q_flux_adv, q_tend_auto, &
+           q_sed_flux, t_rad_rest_tend
 
-        != unit 1 :: q
-        real(8), intent(inout) :: q(:, :)
-            !! total water
+      real(8), allocatable, dimension(:) :: landfrac_bin
 
-        ! ---------------------
-        ! reference vertical profiles:
-        ! ---------------------
-        != unit (kg / m**3) :: rho
-        real(8), intent(in) :: rho(:)
-            !! air density at pressure levels
+      ncol = size(tabs_i, 1)
+      nzm = size(tabs_i, 2)
+      allocate(landfrac_bin(ncol))
 
-        ! != unit mb :: pres
-        ! real(8), intent(in) pres(nzm)
-        !     !! pressure,mb at scalar levels
+      ! Check that we have initialised all of the variables.
+      if (do_init) call error_mesg('NN has not yet been initialised using nn_convection_flux_init.')
 
-        != unit 1 :: adz
-        real(8), intent(in) :: adz(:)
-            !! ratio of the pressure level grid height spacing [m] to dz (lowest dz spacing)
+      ! The NN operates on atmospheric columns which have been flattened into 2D
+      do i=1,ncol
 
-        ! ---------------------
-        ! Single value parameters from model/grid
-        ! ---------------------
-        != unit m :: dz
-        real(8), intent(in) :: dz
-            !! grid spacing in z direction for the lowest grid layer
+         ! Define useful variables relating to grid spacing to convert fluxes to tendencies            
+         do k=1,nzm
+            irhoadz(i,k) = dtn/(rho(k)*adz(k)) !  Temporary factor for below
+            irhoadzdz(i,k) = irhoadz(i,k)/dz ! 2.0 * dtn / (rho(k)*(z(k+1) - z(k-1))) [(kg.m/s)^-1]
+         end do
+         
+         ! Initialize variables
+         features = 0.
+         dim_counter = 0
+         outputs = 0.
 
-        != unit s :: dtn
-        real(8), intent(in) :: dtn
-            !! current dynamical timestep (can be smaller than dt due to subcycling)
+         t_rad_rest_tend(i,:) = 0.
+         t_flux_adv(i,:) = 0.
+         q_flux_adv(i,:) = 0.
+         q_tend_auto(i,:) = 0.
+         q_sed_flux(i,:) = 0.
+         landfrac_bin(i) = 0.
+         
+         ! transform landfrac from continuous to binary
+         if (landfrac(i) .gt. 0.5) then
+            landfrac_bin(i)=1.0
+         else
+            landfrac_bin(i)=0.0
+         end if
+         
+         !-----------------------------------------------------
+         ! Combine all features into one vector
+         
+         ! Add temperature as input feature
+         features(dim_counter+1:dim_counter + input_ver_dim) = real(tabs_i(i,1:input_ver_dim),4)
+         dim_counter = dim_counter + input_ver_dim
 
-        ! -----------------------------------
-        ! Output Variables
-        ! -----------------------------------
-        != unit (J / kg) :: t_delta_adv, t_delta_auto, t_delta_sed
-        != unit 1 :: q_delta_adv, q_delta_auto, q_delta_sed
-        real(8), dimension(size(tabs_i, 1), size(tabs_i, 2)) :: t_delta_adv, q_delta_adv, &
-                                                             t_delta_auto, q_delta_auto, &
-                                                             t_delta_sed, q_delta_sed
-            !! delta values of t and q generated by the NN
+         ! Add non-precipitating water mixing ratio
+         features(dim_counter+1:dim_counter+input_ver_dim) = real(q_i(i,1:input_ver_dim),4)
+         dim_counter =  dim_counter + input_ver_dim
 
-        != unit kg / m**2 :: precsfc
-        real(8), intent(out), dimension(:)   :: precsfc
-            !! Surface precipitation due to autoconversion and sedimentation
+         ! XL XL XL
+         ! Add land fraction
+         features(dim_counter+1:dim_counter+1) = real(landfrac_bin(i),4)
+         dim_counter =  dim_counter + 1
 
-        ! -----------------------------------
-        ! Local Variables
-        ! -----------------------------------
-        integer  i, k, dim_counter, out_dim_counter
-        integer ncol
-            !! Number of columns in a subdomain
-        integer nzm
-            !! Number of z points in a subdomain - 1
-        ! real(8) :: omn
-        !     !! variable to store result of omegan function
-        !     !! Note that if using you will need to import omegan() from SAM_consts_mod
+         ! Add surface pressure
+         features(dim_counter+1:dim_counter+1) = real(ps_i(i)/100.0,4)
+         dim_counter =  dim_counter + 1         
+           
+         !-----------------------------------------------------
+         ! Call the forward method of the NN on the input features
+         ! Scaling and normalisation done as layers in NN
 
-        ! Other variables
-        real(8),   dimension(nrf) :: omp, fac
-        real(8),   dimension(size(tabs_i, 2)) :: rsat, irhoadz, irhoadzdz
+         call net_forward(features, model_ftorch, outputs)
+         !-----------------------------------------------------
+         ! Separate physical outputs from NN output vector
+           
+         out_dim_counter = 0
+           
+         ! Moist Static Energy radiative + rest(microphysical changes) tendency
+         t_rad_rest_tend(i,1:nrf) = outputs(out_dim_counter+1:out_dim_counter+nrf)
+         out_dim_counter = out_dim_counter + nrf
 
-        ! -----------------------------------
-        ! variables for NN
-        ! -----------------------------------
-        real(4), dimension(n_inputs) :: features
-            !! Vector of input features for the NN
-        real(4), dimension(n_outputs) :: outputs
-            !! vector of output features from the NN
-        ! NN outputs
-        real(8),   dimension(nrf) :: t_flux_adv, q_flux_adv, q_tend_auto, &
-                                  q_sed_flux, t_rad_rest_tend
+         ! Moist Static Energy advective subgrid flux
+         ! BC: advection surface flux is zero
+         t_flux_adv(i,1:nrf) = outputs(out_dim_counter+1:out_dim_counter+nrf)
+         t_flux_adv(i,1) = 0.0         
+         out_dim_counter = out_dim_counter + nrf                     
 
-        ncol = size(tabs_i, 1)
-        nzm = size(tabs_i, 2)
+         ! Total non-precip. water mix. ratio advective flux
+         ! BC: advection surface flux is zero
+         q_flux_adv(i,1:nrf) = outputs(out_dim_counter+1:out_dim_counter+nrf)
+!         q_flux_adv(i,1) = 0.0         
+         out_dim_counter = out_dim_counter + nrf         
 
-        ! Check that we have initialised all of the variables.
-        if (do_init) call error_mesg('NN has not yet been initialised using nn_convection_flux_init.')
+         ! Total non-precip. water autoconversion tendency
+         q_tend_auto(i,1:nrf) = outputs(out_dim_counter+1:out_dim_counter+nrf)
+         out_dim_counter = out_dim_counter + nrf
 
-        ! Define useful variables relating to grid spacing to convert fluxes to tendencies
-        do k=1,nzm
-            irhoadz(k) = dtn/(rho(k)*adz(k)) !  Temporary factor for below
-            irhoadzdz(k) = irhoadz(k)/dz ! 2.0 * dtn / (rho(k)*(z(k+1) - z(k-1))) [(kg.m/s)^-1]
-        end do
+         ! total non-precip. water mix. ratio ice-sedimenting flux
+         q_sed_flux(i,1:nrf) = outputs(out_dim_counter+1:out_dim_counter+nrf)
+!         q_sed_flux(i,1:nrf)=q_sed_flux(i,1:nrf)*1000.0 ! needed for V<V5
+         
+         !!!!!!!!!!!!!!!!!!
+         ! XL XL XL : SET TENDENCIES ABOVE CUTOFF LEVELS TO NULL            
+         nn_mask(i,:) = 1.0
+         nn_mask_do: do k=nrf,1,-1
+            if (t_flux_adv(i,k) .gt. -0.02) then ! Between -0.2 and -0.1 ! -0.02
+               nn_mask(i,k) = 0.0
+            else
+               exit nn_mask_do
+            end if
+         end do nn_mask_do
+         
+!         write(iulog,*)'t_flux_adv',t_flux_adv
+         
+         t_rad_rest_tend(i,1:nrf) = t_rad_rest_tend(i,1:nrf) * nn_mask(i,1:nrf)
+         t_flux_adv(i,1:nrf) = t_flux_adv(i,1:nrf) * nn_mask(i,1:nrf)
+         q_flux_adv(i,1:nrf) = q_flux_adv(i,1:nrf) * nn_mask(i,1:nrf)
+         q_tend_auto(i,1:nrf) = q_tend_auto(i,1:nrf) * nn_mask(i,1:nrf)
+         q_sed_flux(i,1:nrf) = q_sed_flux(i,1:nrf) * nn_mask(i,1:nrf)         
+         !!!!!!!!!!!!!!!!!!
+         
+      end do
 
-        ! The NN operates on atmospheric columns which have been flattened into 2D
-        do i=1,ncol
-            ! Initialize variables
-            features = 0.
-            dim_counter = 0
-            outputs = 0.
-            t_rad_rest_tend = 0.
-            t_flux_adv = 0.
-            q_flux_adv = 0.
-            t_delta_adv(i,:) = 0.
-            q_delta_adv(i,:) = 0.
-            q_tend_auto = 0.
-            t_delta_auto(i,:) = 0.
-            q_delta_auto(i,:) = 0.
-            q_sed_flux = 0.
-            t_delta_sed(i,:) = 0.
-            q_delta_sed(i,:) = 0.
-            precsfc(i) = 0.
-            omp = 0.
-            fac = 0.
-
-            !-----------------------------------------------------
-            ! Combine all features into one vector
-
-            ! Add temperature as input feature
-            features(dim_counter+1:dim_counter + input_ver_dim) = real(tabs_i(i,1:input_ver_dim),4)
-            dim_counter = dim_counter + input_ver_dim
-
-            ! Add non-precipitating water mixing ratio as input feature using random forest (rf) approach from earlier paper
-            ! Currently we do not use rf_uses_rh option, but may add it back in later
-            ! if (rf_uses_rh) then
-            ! ! If using generalised relative humidity convert non-precip. water content to rel. hum
-            !     do k=1,nzm
-            !         omn = omegan(tabs(i,j,k))
-            !         rsat(k) = omn * rsatw(tabs(i,j,k),pres(k)) + (1.-omn) * rsati(tabs(i,j,k),pres(k))
-            !     end do
-            !     features(dim_counter+1:dim_counter+input_ver_dim) = real(q_i(i,j,1:input_ver_dim)/rsat(1:input_ver_dim),4)
-            !     dim_counter = dim_counter + input_ver_dim
-            ! else
-            ! ! if using non-precipitating water as water content
-                features(dim_counter+1:dim_counter+input_ver_dim) = real(q_i(i,1:input_ver_dim),4)
-                dim_counter =  dim_counter + input_ver_dim
-            ! endif
-
-            !-----------------------------------------------------
-            ! Call the forward method of the NN on the input features
-            ! Scaling and normalisation done as layers in NN
-
-            call net_forward(features, model_ftorch,  outputs)
-
-            !-----------------------------------------------------
-            ! Separate physical outputs from NN output vector
-
-            out_dim_counter = 0
-
-            ! Moist Static Energy radiative + rest(microphysical changes) tendency
-            t_rad_rest_tend(1:nrf) = outputs(out_dim_counter+1:out_dim_counter+nrf)
-            out_dim_counter = out_dim_counter + nrf
-
-            ! Moist Static Energy advective subgrid flux
-            ! BC: advection surface flux is zero
-            t_flux_adv(1) = 0.0
-            t_flux_adv(2:nrf) = outputs(out_dim_counter+1:out_dim_counter+nrfq)
-            out_dim_counter = out_dim_counter + nrfq
-
-            ! Total non-precip. water mix. ratio advective flux
-            ! BC: advection surface flux is zero
-            q_flux_adv(1) = 0.0
-            q_flux_adv(2:nrf) = outputs(out_dim_counter+1:out_dim_counter+nrfq)
-            out_dim_counter = out_dim_counter + nrfq
-
-            ! Total non-precip. water autoconversion tendency
-            q_tend_auto(1:nrf) = outputs(out_dim_counter+1:out_dim_counter+nrf)
-            out_dim_counter = out_dim_counter + nrf
-
-            ! total non-precip. water mix. ratio ice-sedimenting flux
-            q_sed_flux(1:nrf) = outputs(out_dim_counter+1:out_dim_counter+nrf)
-
-            !-----------------------------------------------------
-            ! Apply physical constraints and update q and t
-
-            ! Non-precip. water content must be >= 0, so ensure advective fluxes
-            ! will not reduce it below 0 anywhere
-            do k=2,nrf
-                if (q_flux_adv(k) < 0) then
-                    ! If flux is negative ensure we don't lose more than is already present
-                    if ( q(i,k) < -q_flux_adv(k)* irhoadzdz(k)) then
-                        q_flux_adv(k) = -q(i,k)/irhoadzdz(k)
-                    end if
-                else
-                    ! If flux is positive ensure we don't gain more than is in the box below
-                    if (q(i,k-1) < q_flux_adv(k)* irhoadzdz(k)) then
-                        q_flux_adv(k) = q(i,k-1)/irhoadzdz(k)
-                    end if
-                end if
-            end do
-
-            ! Convert advective fluxes to deltas
-            do k=1,nrf-1
-                t_delta_adv(i,k) = - (t_flux_adv(k+1) - t_flux_adv(k)) * irhoadzdz(k)
-                q_delta_adv(i,k) = - (q_flux_adv(k+1) - q_flux_adv(k)) * irhoadzdz(k)
-            end do
-            ! Enforce boundary condition at top of column
-            t_delta_adv(i,nrf) = - (0.0 - t_flux_adv(nrf)) * irhoadzdz(nrf)
-            q_delta_adv(i,nrf) = - (0.0 - q_flux_adv(nrf)) * irhoadzdz(nrf)
-            ! q must be >= 0 so ensure delta won't reduce it below zero
-            do k=1,nrf
-                if (q(i,k) < -q_delta_adv(i,k)) then
-                    q_delta_adv(i,k) = -q(i,k)
-                end if
-            end do
-
-            ! Update q and t with delta values
-            q(i,1:nrf) = q(i,1:nrf) + q_delta_adv(i,1:nrf)
-            t(i,1:nrf) = t(i,1:nrf) + t_delta_adv(i,1:nrf)
-
-            ! ensure autoconversion tendency won't reduce q below 0
-            do k=1,nrf
-                omp(k) = max(0.,min(1.,(tabs(i,k)-tprmin)*a_pr))
-                fac(k) = (fac_cond + fac_fus * (1.0 - omp(k)))
-                if (q_tend_auto(k) < 0) then
-                    q_delta_auto(i,k) = - min(-q_tend_auto(k) * dtn, q(i,k))
-                else
-                    q_delta_auto(i,k) = q_tend_auto(k) * dtn
-                endif
-            end do
-
-            ! Update with autoconversion q and t deltas (dt = -dq*(latent_heat/cp))
-            q(i,1:nrf) = q(i,1:nrf) + q_delta_auto(i,1:nrf)
-            t_delta_auto(i,1:nrf) = - q_delta_auto(i,1:nrf)*fac(1:nrf)
-            t(i,1:nrf) = t(i,1:nrf) + t_delta_auto(i,1:nrf)
-
-            ! Ensure sedimenting ice will not reduce q below zero anywhere
-            do k=2,nrf
-                if (q_sed_flux(k) < 0) then
-                    ! If flux is negative ensure we don't lose more than is already present
-                    if ( q(i,k) < -q_sed_flux(k)* irhoadzdz(k)) then
-                        q_sed_flux(k) = -q(i,k)/irhoadzdz(k)
-                    end if
-                else
-                    ! If flux is positive ensure we don't gain more than is in the box below
-                    if (q(i,k-1) < q_sed_flux(k)* irhoadzdz(k)) then
-                        q_sed_flux(k) = q(i,k-1)/irhoadzdz(k)
-                    end if
-                end if
-            end do
-
-            ! Convert sedimenting fluxes to deltas
-            do k=1,nrf-1 ! One level less than I actually use
-                q_delta_sed(i,k) = - (q_sed_flux(k+1) - q_sed_flux(k)) * irhoadzdz(k)
-            end do
-            ! Enforce boundary condition at top of column
-            q_delta_sed(i,nrf) = - (0.0 - q_sed_flux(nrf)) * irhoadzdz(nrf)
-            ! q must be >= 0 so ensure delta won't reduce it below zero
-            do k=1,nrf
-                if (q_delta_sed(i,k) < 0) then
-                    q_delta_sed(i,k) = min(-q_delta_sed(i,k), q(i,k))
-                    q_delta_sed(i,k) = -q_delta_sed(i,k)
-                end if
-            end do
-
-            ! Update q and t with sed q and t deltas (dt = -dq*(latent_heat/cp))
-            q(i,1:nrf) = q(i,1:nrf) + q_delta_sed(i,1:nrf)
-            t(i,1:nrf) = t(i,1:nrf) - q_delta_sed(i,1:nrf)*(fac_fus+fac_cond)
-
-            ! Apply radiation rest tendency (multiply by dtn to get delta value)
-            t(i,1:nrf) = t(i,1:nrf) + t_rad_rest_tend(1:nrf)*dtn
-
-            ! Calculate surface precipitation
-            ! Combination of sedimentation at surface, and autoconversion in the column
-            ! Apply sedimenting flux at surface to get rho*dq term
-            precsfc(i) = precsfc(i) - q_sed_flux(1) * irhoadzdz(1) * rho(1) * adz(1) !!  *dtn/dz
-            ! Loop up column for all autoconverted precipitation
-            do k=1,nrf
-                precsfc(i) = precsfc(i) - q_delta_auto(i,k) * rho(k) * adz(k)
-            end do
-            precsfc(i) = precsfc(i) * dz
-
-            ! As a final check enforce q must be >= 0.0
-            do k = 1,nrf
-                q(i,k) = max(0.,q(i,k))
-            end do
-        end do
-        ! End of loop over columns
-
+      deallocate(landfrac_bin)
+      
     end subroutine nn_convection_flux
 
 
@@ -383,7 +274,7 @@ contains
         !! Finalize the NN module
 
         ! Finalize the Neural Net deallocating arrays
-        ! call nn_cf_net_finalize()
+        ! call nn_cf_net_finalize()  ! not implemented in FTorch nn_cf_net.F90
 
     end subroutine nn_convection_flux_finalize
 

--- a/CAM_Convection_YOG/src/cam/nn_interface_cam.F90
+++ b/CAM_Convection_YOG/src/cam/nn_interface_cam.F90
@@ -13,6 +13,7 @@ use SAM_consts_mod, only: nrf, ggr, cp, tbgmax, tbgmin, tprmax, tprmin, &
                           fac_cond, fac_sub, fac_fus, &
                           a_bg, a_pr, an, bn, ap, bp, &
                           omegan, check
+use cam_logfile,    only: iulog
 
 implicit none
 private
@@ -27,6 +28,7 @@ public  nn_convection_flux_CAM, &
 ! otherwise not required outside this module.
 public interp_to_sam, interp_to_cam
 public SAM_var_conversion, CAM_var_conversion
+public interp_flux_cam_midpoint
 
 !---------------------------------------------------------------------
 ! local/private data
@@ -56,12 +58,12 @@ contains
     ! Public Subroutines
 
     subroutine nn_convection_flux_CAM_init(nn_filename, metadata_filename, sounding_filename)
-        !! Initialise the NN module
+        !! Initialise the NN module using FTorch
 
         character(len=136), intent(in) :: nn_filename
-            !! Pytorch .pt filename from which to read model weights
+            !! PyTorch model filename (.pt file) from which to load model
         character(len=136), intent(in) :: metadata_filename
-            !! NetCDF filename from which to read scale and dimension parameters
+            !! NetCDF file with dimensions and scaling parameters
         character(len=136), intent(in) :: sounding_filename
             !! NetCDF filename from which to read SAM sounding and grid data
 
@@ -75,17 +77,22 @@ contains
 
 
     subroutine nn_convection_flux_CAM(pres_cam, pres_int_cam, pres_sfc_cam, &
-                                      tabs_cam, qv_cam, qc_cam, qi_cam, &
+                                      tabs_cam, qv_cam, qc_cam, qi_cam, phis_cam, zm_cam, &
+                                      landfrac, ps_cam, &
                                       cp_cam, &
                                       dtn, &
                                       ncol, &
                                       precsfc, &
-                                      dqi, dqv, dqc, ds)
-        !! Interface to the nn_convection parameterisation for the CAM model
+                                      dqi, dqv, dqc, ds, &
+                                      q_delta_adv, q_delta_auto, q_delta_sed, &
+                                      t_delta_adv, t_delta_auto, t_delta_sed, t_delta_rad, &
+                                      t_flux_adv)
 
+        !! Interface to the nn_convection parameterisation for the CAM model
+      
         real(8), intent(in) :: dtn    ! Seconds
         integer, intent(in) :: ncol   ! Number of columns 'used' in each array
-
+        
         real(8), intent(in) :: cp_cam
             !! specific heat capacity of dry air from CAM [J/kg/K]
         real(8), dimension(:,:), intent(in) :: pres_cam
@@ -95,131 +102,247 @@ contains
         real(8), dimension(:), intent(in)   :: pres_sfc_cam
             !! surface pressure [Pa] from the CAM model
         real(8), dimension(:,:), intent(in) :: tabs_cam
-            !! absolute temperature [K] from the CAM model
+        !! absolute temperature [K] from the CAM model        
         real(8), dimension(:,:), intent(in) :: qv_cam, qc_cam, qi_cam
             !! moisture content [kg/kg] from the CAM model
+        real(8), dimension(:,:), intent(in) :: zm_cam
+        real(8), dimension(:), intent(in) :: phis_cam
+        real(8), dimension(:), intent(in)   :: landfrac, ps_cam
+            !! surface pressure [Pa] from the CAM model
 
+        
         real(8), dimension(:, :), intent(out) :: dqi, dqv, dqc, ds
             !! Output tendencies - CAM variables on the CAM grid
         real(8), dimension(:), intent(out) :: precsfc
             !! Output surface precipitation in CAM
 
+        !! XL XL XL
+        real(8), dimension(:,:), intent(out) :: q_delta_adv, q_delta_auto, q_delta_sed, t_delta_adv, t_delta_auto, t_delta_sed, t_delta_rad
+        real(8), dimension(:,:), intent(out) :: t_flux_adv
+
+        real(8), allocatable, dimension(:) :: ps0_cam
+        real(8), allocatable, dimension(:,:) :: gamaz_cam
+        real(8), allocatable, dimension(:,:) :: qi0_cam, qv0_cam, qc0_cam, tabs0_cam, q0_cam, t0_cam
+        real(8), allocatable, dimension(:,:) :: qi1_cam, qv1_cam, qc1_cam, tabs1_cam, q1_cam, t1_cam
+        real(8), allocatable, dimension(:,:) :: delta_t_cam, delta_q_cam
+
+        real(8), allocatable, dimension(:, :) :: t_rad_rest_tend, q_flux_adv, q_tend_auto, q_sed_flux
+        real(8), allocatable, dimension(:, :) :: t_flux_adv_f, q_flux_adv_f, q_sed_flux_f
+        
         ! Local input variables on the SAM grid
-        real(8), dimension(ncol, nrf) :: tabs_sam
-            !! absolute temperature [K] on the SAM grid
-        real(8), dimension(ncol, nrf) :: r_sam
-            !! non-precipitating water mixing ratio [kg/kg] on the SAM grid
-        real(8), dimension(ncol, nrf) :: t_sam
-            !! static energy [J/kg] on the SAM grid
-        real(8), dimension(ncol, nrf) :: qi_sam, qv_sam, qc_sam
-            !! mixing ratios [kg/kg] on the SAM grid
-        real(8), dimension(ncol, nrf) :: qi0_sam, qv0_sam, qc0_sam, tabs0_sam, r0_sam
-            !! Variables at the start of the parameterisation on the SAM grid - used to calculate tendencies
-        real(8), dimension(ncol, nrf) :: dqi_sam, dqv_sam, dqc_sam, ds_sam
-            !! CAM variable tendencies calculated on the SAM grid
-        real(8), dimension(ncol)      :: qi_surf, qv_surf, qc_surf, tabs_surf
+        real(8), dimension(ncol, nrf) :: qi0_sam, qv0_sam, qc0_sam, tabs0_sam, q0_sam, t0_sam
+        !! Variables at the start of the parameterisation on the SAM grid - used to calculate tendencies
+        real(8), dimension(ncol) :: ps0_sam
+
+        !! XL XL XL
+        real(8), dimension(ncol, nrf) :: t_rad_rest_tend_sam, t_flux_adv_sam, q_flux_adv_sam, q_tend_auto_sam, q_sed_flux_sam
+        real(8), dimension(ncol, nrf) :: t_flux_adv_sam_f, q_flux_adv_sam_f, q_sed_flux_sam_f
+
+        real(8), dimension(ncol, nrf) :: q_delta_adv_sam, q_delta_sed_sam, t_delta_adv_sam, t_delta_sed_sam
+        real(8), dimension(ncol, nrf) :: gamaz_sam
+        
+        !! CAM variable tendencies calculated on the SAM grid
+        real(8), dimension(ncol)      :: qi0_surf, qv0_surf, qc0_surf, tabs0_surf, q0_surf
             !! Surface values
         real(8) :: y_in(ncol)
             !! Distance of column from equator (proxy for insolation and sfc albedo)
-        real(8), dimension(ncol)      :: precsfc_i
-            !! precipitation at surface from one call to parameterisation
 
-        integer :: k
+        real(8), dimension(:), allocatable :: landmask_1D
+        real(8), dimension(:,:), allocatable :: landmask_2D  
+        
+        integer :: k, i
+        integer, dimension(:), allocatable :: idx
+        integer :: pver
 
+        ! XL        
+        pver = size(tabs_cam, 2)        
+        allocate(gamaz_cam(ncol, pver))        
+        
+        allocate(q0_cam(ncol, pver))
+        allocate(t0_cam(ncol, pver))        
+        allocate(tabs0_cam(ncol, pver))
+        allocate(qv0_cam(ncol, pver))        
+        allocate(qc0_cam(ncol, pver))
+        allocate(qi0_cam(ncol, pver))
+
+        allocate(q1_cam(ncol, pver))
+        allocate(t1_cam(ncol, pver))        
+        allocate(tabs1_cam(ncol, pver))
+        allocate(qv1_cam(ncol, pver))
+        allocate(qc1_cam(ncol, pver))
+        allocate(qi1_cam(ncol, pver))
+
+        allocate(delta_t_cam(ncol, pver))
+        allocate(delta_q_cam(ncol, pver))
+
+        allocate(t_rad_rest_tend(ncol, pver))
+        allocate(q_flux_adv(ncol, pver))
+        allocate(q_sed_flux(ncol, pver))        
+        allocate(q_tend_auto(ncol, pver))
+
+        allocate(t_flux_adv_f(ncol, pver))
+        allocate(q_flux_adv_f(ncol, pver))
+        allocate(q_sed_flux_f(ncol, pver))
+        
+        allocate(landmask_1D(ncol))
+        allocate(landmask_2D(ncol, pver))
+        ! XL        
+        
         ! Initialise precipitation to 0 if required and at start of cycle if subcycling
         precsfc(:)=0.
 
-        !-----------------------------------------------------
+        do i = 1,ncol
+           do k = 1,pver
+              !              gamaz_cam(i,k) = zm_cam(i,k)*ggr/cp_cam 
+              gamaz_cam(i,k) = zm_cam(i,k)*ggr/cp_cam + phis_cam(i)/cp_cam
+           end do
+        end do
+        ! cpairv
+        
+        ! NOTE: tabs0_cam/qv0_cam/qc0_cam/qi0_cam are allocated to the actual
+        ! ncol extent, while tabs_cam/qv_cam/qc_cam/qi_cam are assumed-shape
+        ! dummy args bound to the caller's full-pcols-extent slices. Must be
+        ! explicitly bounded to ncol on both sides to avoid a shape-mismatched
+        ! whole-array assignment writing past the allocated extent (same class
+        ! of bug as the dqv/dqc/dqi/ds fix below).
+        tabs0_cam(1:ncol,:) = tabs_cam(1:ncol,:)
+        qv0_cam(1:ncol,:)   = qv_cam(1:ncol,:)
+        qc0_cam(1:ncol,:)   = qc_cam(1:ncol,:)
+        qi0_cam(1:ncol,:)   = qi_cam(1:ncol,:)
 
-        ! Interpolate CAM variables to the SAM pressure levels
-        ! TODO Interpolate all variables in one call
-        ! Set surface values
-        call extrapolate_to_surface(pres_cam(1:ncol, :), qi_cam(1:ncol, :), pres_sfc_cam(1:ncol), qi_surf)
-        where (qi_surf>=0)
-            qi_surf = qi_surf
-        elsewhere
-            qi_surf = 0
-        end where
-        call extrapolate_to_surface(pres_cam(1:ncol, :), qc_cam(1:ncol, :), pres_sfc_cam(1:ncol), qc_surf)
-        where (qc_surf>=0)
-            qc_surf = qc_surf
-        elsewhere
-            qc_surf = 0
-        end where
-        call extrapolate_to_surface(pres_cam(1:ncol, :), qv_cam(1:ncol, :), pres_sfc_cam(1:ncol), qv_surf)
-        where (qv_surf>=0)
-            qv_surf = qv_surf
-        elsewhere
-            qv_surf = 0
-        end where
-        call extrapolate_to_surface(pres_cam(1:ncol, :), tabs_cam(1:ncol, :), pres_sfc_cam(1:ncol), tabs_surf)
-
-        call interp_to_sam(pres_cam(1:ncol, :), pres_sfc_cam(1:ncol), &
-                           tabs_cam(1:ncol, :), tabs_sam, tabs_surf)
-        call interp_to_sam(pres_cam(1:ncol, :), pres_sfc_cam(1:ncol), &
-                           qi_cam(1:ncol, :), qi_sam, qi_surf)
-        call interp_to_sam(pres_cam(1:ncol, :), pres_sfc_cam(1:ncol), &
-                           qc_cam(1:ncol, :), qc_sam, qc_surf)
-        call interp_to_sam(pres_cam(1:ncol, :), pres_sfc_cam(1:ncol), &
-                           qv_cam(1:ncol, :), qv_sam, qv_surf)
-
-        !-----------------------------------------------------
-
-        ! Convert CAM Moistures and tabs to SAM q and t
-        call  CAM_var_conversion(qv_sam, qc_sam, qi_sam, r_sam, tabs_sam, t_sam)
-
+        call  CAM_var_conversion(qv0_cam, qc0_cam, qi0_cam, gamaz_cam, q0_cam, tabs0_cam, t0_cam)
         ! Store variables on SAM grid at the start of the timestep
-        ! for calculating tendencies later
-        qv0_sam = qv_sam
-        qc0_sam = qc_sam
-        qi0_sam = qi_sam
-        tabs0_sam = tabs_sam
-
+        ! for calculating tendencies later        
         !-----------------------------------------------------
 
-        tabs0_sam = tabs_sam
-        r0_sam = r_sam
+        ! Set surface values
+        call extrapolate_to_surface(pres_cam(1:ncol, :), tabs0_cam(1:ncol, :), pres_sfc_cam(1:ncol), tabs0_surf)
+        call extrapolate_to_surface(pres_cam(1:ncol, :), q0_cam(1:ncol, :), pres_sfc_cam(1:ncol), q0_surf)        
+        where (q0_surf>=0)
+            q0_surf = q0_surf
+        elsewhere
+            q0_surf = 0
+        end where
+        call interp_to_sam(pres_cam(1:ncol, :), pres_sfc_cam(1:ncol), &
+                           tabs0_cam(1:ncol, :), tabs0_sam, tabs0_surf)
+        call interp_to_sam(pres_cam(1:ncol, :), pres_sfc_cam(1:ncol), &
+                           q0_cam(1:ncol, :), q0_sam, q0_surf)
+
+        ps0_sam=ps_cam(1:ncol)
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!        
         ! Run the neural net parameterisation
         ! Updates q and t with delta values
         ! advective, autoconversion (dt = -dq*(latent_heat/cp)),
         ! sedimentation (dt = -dq*(latent_heat/cp)),
         ! radiation rest tendency (multiply by dtn to get dt)
-        call nn_convection_flux(tabs0_sam, r0_sam, &
-                                tabs_sam, &
-                                t_sam, r_sam, &
-                                rho, adz, dz, dtn, &
-                                precsfc_i)
-        ! Update precsfc with prec from this timestep
-        precsfc = precsfc + precsfc_i
+        
+        call nn_convection_flux(tabs0_sam, q0_sam, ps0_sam, landfrac, &
+             rho, adz, dz, dtn, &
+             t_rad_rest_tend_sam, t_flux_adv_sam_f, &
+             q_flux_adv_sam_f, q_tend_auto_sam, q_sed_flux_sam_f)
 
-        !-----------------------------------------------------
+        ! We interpolate fluxes at lower level interface from SAM to CAM grid
+        call interp_flux_sam_to_cam(pres_int_cam(1:ncol, :), pres_sfc_cam(1:ncol), t_flux_adv_sam_f, t_flux_adv_f)
+        call interp_flux_sam_to_cam(pres_int_cam(1:ncol, :), pres_sfc_cam(1:ncol), q_flux_adv_sam_f, q_flux_adv_f)
+        call interp_flux_sam_to_cam(pres_int_cam(1:ncol, :), pres_sfc_cam(1:ncol), q_sed_flux_sam_f, q_sed_flux_f)
 
-        ! Formulate the output variables to CAM as required.
-        call SAM_var_conversion(t_sam, r_sam, tabs_sam, qv_sam, qc_sam, qi_sam)
-        ! Convert precipitation from kg/m^2 to m by dividing by density (1000)
-        precsfc = precsfc * 1.0D-3
-
-        !-----------------------------------------------------
-
-        ! Convert back into CAM variable tendencies (diff div by dtn) on SAM grid
-        ! q into components and tabs to s (mult by cp)
-        dqv_sam = (qv_sam - qv0_sam) / dtn
-        dqc_sam = (qc_sam - qc0_sam) / dtn
-        dqi_sam = (qi_sam - qi0_sam) / dtn
-        ds_sam = cp_cam * (tabs_sam - tabs0_sam) / dtn
-        ! Convert precipitation from total in m to date in m / s by div by dtn
-        precsfc = precsfc / dtn
-
-        !-----------------------------------------------------
+        call interp_flux_cam_midpoint(pres_cam(1:ncol, :), pres_int_cam(1:ncol, :), pres_sfc_cam(1:ncol), t_flux_adv_f, t_flux_adv)
+        call interp_flux_cam_midpoint(pres_cam(1:ncol, :), pres_int_cam(1:ncol, :), pres_sfc_cam(1:ncol), q_flux_adv_f, q_flux_adv)
 
         ! Interpolate SAM variables to the CAM pressure levels
         ! setting tendencies above the SAM grid to 0.0
         ! TODO Interpolate all variables in one call
-        call interp_to_cam(pres_cam(1:ncol, :), pres_int_cam(1:ncol, :), pres_sfc_cam(1:ncol), dqv_sam, dqv(1:ncol, :))
-        call interp_to_cam(pres_cam(1:ncol, :), pres_int_cam(1:ncol, :), pres_sfc_cam(1:ncol), dqc_sam, dqc(1:ncol, :))
-        call interp_to_cam(pres_cam(1:ncol, :), pres_int_cam(1:ncol, :), pres_sfc_cam(1:ncol), dqi_sam, dqi(1:ncol, :))
-        call interp_to_cam(pres_cam(1:ncol, :), pres_int_cam(1:ncol, :), pres_sfc_cam(1:ncol), ds_sam,  ds(1:ncol, :))
+        call interp_to_cam(pres_cam(1:ncol, :), pres_int_cam(1:ncol, :), pres_sfc_cam(1:ncol), t_rad_rest_tend_sam, t_rad_rest_tend(1:ncol, :))
+        call interp_to_cam(pres_cam(1:ncol, :), pres_int_cam(1:ncol, :), pres_sfc_cam(1:ncol), q_tend_auto_sam, q_tend_auto(1:ncol, :))
+        call update_tendencies(dtn, tabs0_cam, q0_cam, t0_cam, pres_int_cam, t_rad_rest_tend, t_flux_adv_f, q_flux_adv_f, q_tend_auto, q_sed_flux_f, t1_cam, t_delta_adv, t_delta_auto, t_delta_sed, t_delta_rad, q1_cam, q_delta_adv, q_delta_auto, q_delta_sed, precsfc)
+                
+        ! Convert precipitation from kg/m^2 to m by dividing by density (1000)
+        precsfc = precsfc * 1.0D-3
+        
+        !-----------------------------------------------------
+        ! Formulate the output variables to CAM as required. !
+        call SAM_var_conversion(t0_cam, q0_cam, tabs0_cam, qv0_cam, qc0_cam, qi0_cam, gamaz_cam, pres_cam, t1_cam, q1_cam, tabs1_cam, qv1_cam, qc1_cam, qi1_cam)
+        
+        !-----------------------------------------------------
 
+        ! Convert back into CAM variable tendencies (diff div by dtn) on SAM grid
+        ! q into components and tabs to s (mult by cp)
+        ! NOTE: dqv/dqc/dqi/ds are assumed-shape, bound to the caller's
+        ! full-pcols-extent ptend%q(:,...) slices, while qv1_cam/qv0_cam etc.
+        ! are allocated to the actual ncol extent. ncol < pcols for any
+        ! partial/edge chunk, so these must be explicitly bounded to ncol on
+        ! both sides to avoid a shape-mismatched whole-array assignment.
+        dqv(1:ncol,:) = (qv1_cam(1:ncol,:) - qv0_cam(1:ncol,:)) / dtn
+        dqc(1:ncol,:) = (qc1_cam(1:ncol,:) - qc0_cam(1:ncol,:)) / dtn
+        dqi(1:ncol,:) = (qi1_cam(1:ncol,:) - qi0_cam(1:ncol,:)) / dtn
+        ds(1:ncol,:)  = cp_cam * (tabs1_cam(1:ncol,:) - tabs0_cam(1:ncol,:)) / dtn
+        ! Convert precipitation from total in m to date in m / s by div by dtn
+        precsfc = precsfc / dtn
+!        write(iulog,*)'precsfc',precsfc        
+        !-----------------------------------------------------
+
+        q_delta_adv(1:ncol, :)=q_delta_adv(1:ncol, :)/dtn
+        q_delta_auto(1:ncol, :)=q_delta_auto(1:ncol, :)/dtn
+        q_delta_sed(1:ncol, :)=q_delta_sed(1:ncol, :)/dtn
+        t_delta_adv(1:ncol, :)=t_delta_adv(1:ncol, :)/dtn
+        t_delta_auto(1:ncol, :)=t_delta_auto(1:ncol, :)/dtn
+        t_delta_sed(1:ncol, :)=t_delta_sed(1:ncol, :)/dtn
+        t_delta_rad(1:ncol, :)=t_delta_rad(1:ncol, :)/dtn        
+
+!        !define landmask: 0 for land - 1 for ocean (convention reversed from landfrac) - any land fraction > 0 defines land 
+!        landmask_1D(1:ncol)=1.0
+!        landmask_2D(1:ncol,:)=1.0
+!        do i=1,ncol      
+!           if (landfrac(i) .gt. 0.0) then
+!              landmask_1D(i)=0.0
+!           end if
+!        end do
+!        do k=1,pver
+!           landmask_2D(1:ncol,k)=landmask_1D(1:ncol)
+!        end do
+
+!        dqi(:ncol,:pver)=dqi(:ncol,:pver)*landmask_2D(:ncol,:pver)
+!        dqv(:ncol,:pver)=dqv(:ncol,:pver)*landmask_2D(:ncol,:pver)
+!        dqc(:ncol,:pver)=dqc(:ncol,:pver)*landmask_2D(:ncol,:pver)
+!        ds(:ncol,:pver)=ds(:ncol,:pver)*landmask_2D(:ncol,:pver)
+        
+!        precsfc(:ncol)=precsfc(:ncol)*landmask_1D(:ncol)   
+   
+!        q_delta_adv(:ncol,:pver)=q_delta_adv(:ncol,:pver)*landmask_2D(:ncol,:pver)
+!        q_delta_auto(:ncol,:pver)=q_delta_auto(:ncol,:pver)*landmask_2D(:ncol,:pver)
+!        q_delta_sed(:ncol,:pver)=q_delta_sed(:ncol,:pver)*landmask_2D(:ncol,:pver)
+!        t_delta_adv(:ncol,:pver)=t_delta_adv(:ncol,:pver)*landmask_2D(:ncol,:pver)
+!        t_delta_auto(:ncol,:pver)=t_delta_auto(:ncol,:pver)*landmask_2D(:ncol,:pver)
+!        t_delta_sed(:ncol,:pver)=t_delta_sed(:ncol,:pver)*landmask_2D(:ncol,:pver)
+!        t_delta_rad(:ncol,:pver)=t_delta_rad(:ncol,:pver)*landmask_2D(:ncol,:pver)
+!        t_flux_adv(:ncol,:pver)=t_flux_adv(:ncol,:pver)*landmask_2D(:ncol,:pver)        
+        
+        ! deallocate
+        deallocate(gamaz_cam)
+        deallocate(q0_cam)
+        deallocate(t0_cam)
+        deallocate(tabs0_cam)        
+        deallocate(qi0_cam)
+        deallocate(qv0_cam)
+        deallocate(qc0_cam)
+
+
+        deallocate(q1_cam)
+        deallocate(t1_cam)        
+        deallocate(tabs1_cam)
+        deallocate(qi1_cam)        
+        deallocate(qv1_cam)
+        deallocate(qc1_cam)
+
+        deallocate(delta_t_cam)
+        deallocate(delta_q_cam)
+
+        deallocate(t_rad_rest_tend)
+        deallocate(q_tend_auto)
+
+        deallocate(landmask_1D)
+        deallocate(landmask_2D)        
+        
     end subroutine nn_convection_flux_CAM
 
 
@@ -235,6 +358,229 @@ contains
     !-----------------------------------------------------------------
     ! Private Subroutines
 
+    ! ---------------------
+    subroutine update_tendencies(dtn, tabs, q_in, t_in, pres_int, t_rad_rest_tend, &
+         t_flux_adv, q_flux_adv, q_tend_auto, q_sed_flux, &
+         t_out, t_delta_adv, t_delta_auto, t_delta_sed, t_delta_rad, &
+         q_out, q_delta_adv, q_delta_auto, q_delta_sed, precsfc)
+      
+      ! all fluxes are defined on half levels (pres_int)
+      
+      integer :: ncol, nrf
+      !! array sizes
+      integer :: i, k
+
+      real(8) :: fmaxfac
+      
+      real(8), intent(in) :: dtn    ! Seconds            
+      real(8), dimension(:,:), intent(in) :: tabs, q_in, t_in
+      real(8), dimension(:,:), intent(in) :: pres_int
+      real(8), dimension(:), intent(inout) :: precsfc
+            !! interface pressure [Pa] from the CAM model      
+      real(8), dimension(:,:), intent(inout) :: t_rad_rest_tend, q_tend_auto, t_flux_adv, q_flux_adv, q_sed_flux
+      real(8), dimension(:,:), intent(out) :: t_delta_adv, q_delta_adv, q_delta_sed
+      real(8), dimension(:,:), intent(out) :: t_out, t_delta_auto, t_delta_sed, t_delta_rad
+      real(8), dimension(:,:), intent(out) :: q_out, q_delta_auto     
+
+      real(8), allocatable, dimension(:,:) :: irhoadzdz, dp, omp, fac, nn_mask
+
+      ! NOTE: t_delta_adv is bound to the caller's full-pcols-extent slice,
+      ! while tabs/q_in/t_in (and t_out/q_out) are correctly sized to the
+      ! real ncol. Using size(t_delta_adv,1) here returned pcols instead of
+      ! ncol, causing an out-of-bounds read on t_in/q_in/tabs for any
+      ! partial/edge chunk (DEBUG=TRUE caught this: "Subscript #1 of T_IN
+      ! has value 16 which is greater than the upper bound of 15").
+      ncol = size(tabs, 1)
+      nrf = size(tabs, 2)
+      allocate(irhoadzdz(ncol,nrf))
+      allocate(dp(ncol,nrf))
+      allocate(omp(ncol,nrf))
+      allocate(fac(ncol,nrf))
+      allocate(nn_mask(ncol,nrf))
+      
+      do i=1,ncol
+         ! Initialize variables
+         t_out(i,:) = t_in(i,:)
+         q_out(i,:) = q_in(i,:)
+         t_delta_auto(i,:) = 0.
+         q_delta_auto(i,:) = 0.
+         t_delta_sed(i,:) = 0.
+         t_delta_rad(i,:) = 0.
+         t_delta_adv(i,:) = 0.
+         q_delta_adv(i,:) = 0.
+         q_delta_sed(i,:) = 0.
+         
+         omp(i,:) = 0.
+         fac(i,:) = 0.
+         precsfc(i) = 0.
+         
+         !-----------------------------------------------------
+         ! Apply physical constraints and update q and t
+         do k=1,nrf
+            dp(i,k) = abs(pres_int(i, k+1) - pres_int(i, k))
+            if (dp(i,k) > 0.0) then
+               irhoadzdz(i,k) = ggr/dp(i,k)*dtn
+            else
+               irhoadzdz(i,k) = 0.0
+            end if
+         end do
+         
+         !-----------------------------------------------------
+         ! Non-precip. water content must be >= 0, so ensure advective fluxes
+         ! will not reduce it below 0 anywhere
+         
+         do k=1,nrf-1               
+            t_delta_adv(i,k) = - (t_flux_adv(i,k+1) - t_flux_adv(i,k)) * irhoadzdz(i,k)
+            q_delta_adv(i,k) = - (q_flux_adv(i,k+1) - q_flux_adv(i,k)) * irhoadzdz(i,k)
+         end do
+         ! Enforce boundary condition at top of column
+         t_delta_adv(i,nrf) = - (0.0 - t_flux_adv(i,nrf)) * irhoadzdz(i,nrf)
+         q_delta_adv(i,nrf) = - (0.0 - q_flux_adv(i,nrf)) * irhoadzdz(i,nrf)
+
+         ! Update q and t with delta values                                                                                         
+         q_out(i,1:nrf) = q_out(i,1:nrf) + q_delta_adv(i,1:nrf)
+         t_out(i,1:nrf) = t_out(i,1:nrf) + t_delta_adv(i,1:nrf)        
+                           
+         ! Convert sedimenting fluxes to deltas
+         do k=1,nrf-1
+            q_delta_sed(i,k) = - (q_sed_flux(i,k+1) - q_sed_flux(i,k)) * irhoadzdz(i,k)
+         end do
+         ! Enforce boundary condition at top of column
+         q_delta_sed(i,nrf) = - (0.0 - q_sed_flux(i,nrf)) * irhoadzdz(i,nrf)                    
+
+         ! Compute sedimentation on dt (dt = -dq*(latent_heat/cp))
+         t_delta_sed(i,1:nrf) = - q_delta_sed(i,1:nrf)*(fac_fus+fac_cond)
+         ! Update q and t with delta values
+         q_out(i,1:nrf)=q_out(i,1:nrf)+q_delta_sed(i,1:nrf)         
+         t_out(i,1:nrf)=t_out(i,1:nrf)+t_delta_sed(i,1:nrf)
+
+         ! ensure autoconversion tendency won't reduce q below 0
+         do k=1,nrf
+            omp(i,k) = max(0.,min(1.,(tabs(i,k)-tprmin)*a_pr))
+            fac(i,k) = (fac_cond + fac_fus * (1.0 - omp(i,k)))
+            q_delta_auto(i,k) = q_tend_auto(i,k) * dtn
+         end do      
+         ! Compute autoconversion on dt (dt = -dq*(latent_heat/cp))
+         t_delta_auto(i,1:nrf) = - q_delta_auto(i,1:nrf)*fac(i,1:nrf)
+         ! Update q and t with delta values 
+         q_out(i,1:nrf) = q_out(i,1:nrf) + q_delta_auto(i,1:nrf)
+         t_out(i,1:nrf) = t_out(i,1:nrf) + t_delta_auto(i,1:nrf)
+         
+         ! Apply radiation rest tendency (multiply by dtn to get delta value)
+         t_delta_rad(i,1:nrf) = t_rad_rest_tend(i,1:nrf)*dtn
+         ! Update t with delta values 
+         t_out(i,1:nrf) = t_out(i,1:nrf) + t_delta_rad(i,1:nrf)                  
+
+         ! As a final check enforce q must be >= 0.0 - reset q_out to q_in if q_out <0
+         ! This reset is a source of non-precipitating water, which is assumed to be from autoconversion
+         ! (e.g. droplet evaporation, ice sublimation, re-entrainment of falling condensate, breakup/collision droplets/crystals)
+         ! This added autoconversion implies a decrease in specific energy ('cooling') locally.
+
+         ! Note 1: (negative) autoconversion terms sumed over the column cannot be less than the positive source of moisture added by this reset - if so, we end up with net positive column autoconversion (negative precipitation) - if precipitation is negative, I reset the entire column by setting all tendencies to 0.
+         ! Note 2: we do not consider moisture reset to affect either advection or sedimentation terms. Doing so would lead to column water not being conserved despite advection acting conservatively.
+         do k = 1,nrf
+            if ( q_out(i,k) < 0.0 ) then
+!               write(iulog,*)'Negative q at level ',k, ' - total q tendency reset to 0 by autoconversion'
+               q_delta_auto(i,k) = q_delta_auto(i,k) + (q_in(i,k) - q_out(i,k))
+               t_out(i,k) = t_out(i,k) - fac(i,k) * (q_in(i,k) - q_out(i,k))
+               q_out(i,k) = q_in(i,k)
+            end if
+         end do
+         
+         ! Compute net water loss in column (precipitation)
+         do k=1,nrf
+            precsfc(i) = precsfc(i) - (q_out(i,k) - q_in(i,k))* dp(i,k) / ggr                       
+         end do
+
+         if ( precsfc(i) < 0.0 ) then
+!            write(iulog,*)'Negative Precipitation - All tendencies set to 0 in column'            
+            q_out(i,1:nrf) = q_in(i,1:nrf)
+            t_out(i,1:nrf) = t_in(i,1:nrf)
+            q_delta_auto(i,1:nrf) = 0.0
+            t_delta_auto(i,1:nrf) = 0.0            
+            q_delta_adv(i,1:nrf) = 0.0
+            t_delta_adv(i,1:nrf) = 0.0            
+            q_delta_sed(i,1:nrf) = 0.0
+            t_delta_sed(i,1:nrf) = 0.0            
+            t_delta_rad(i,1:nrf) = 0.0
+            precsfc(i) = 0.0
+         end if
+                  
+      end do
+
+      ! deallocate
+      deallocate(irhoadzdz)
+      deallocate(dp)
+      deallocate(omp)
+      deallocate(fac)
+      
+    end subroutine update_tendencies
+
+    subroutine interp_flux_sam_to_cam(pres_int_cam, pres_sfc_cam, flux_adv_sam, flux_adv_cam)
+
+      real(8), dimension(:,:), intent(in) :: pres_int_cam
+      real(8), dimension(:), intent(in) :: pres_sfc_cam
+      real(8), dimension(:,:), intent(in) :: flux_adv_sam
+      real(8), dimension(:,:), intent(out) :: flux_adv_cam
+
+      real(8), dimension(:,:), allocatable :: p_norm_cam
+      real(8), dimension(:), allocatable :: p_norm_sam
+      
+      integer :: i, k, ncol, nz_sam, nz_cam, k_l, k_u
+
+      ncol = size(flux_adv_sam, 1)
+      nz_sam = size(flux_adv_sam, 2)
+      ! NOTE: pres_int_cam is an interface-level array (pver+1 levels), but
+      ! flux_adv_cam (the array actually being written below) is a mid-level
+      ! array with only pver levels. Bounding nz_cam by pres_int_cam's extent
+      ! (DEBUG=TRUE caught this: "Subscript #2 of FLUX_ADV_CAM has value 33
+      ! which is greater than the upper bound of 32") wrote one level past
+      ! flux_adv_cam's allocated extent. Use flux_adv_cam's own extent instead.
+      nz_cam = size(flux_adv_cam, 2)
+
+      allocate(p_norm_sam(nz_sam))
+      allocate(p_norm_cam(ncol,nz_cam))
+      
+      p_norm_sam(:) = presi(:) / presi(1)
+      do i = 1,ncol
+         do k=1,nz_cam
+            p_norm_cam(i,k) = pres_int_cam(i,k) / pres_sfc_cam(i)
+         end do
+      end do
+
+      do i = 1,ncol
+         flux_adv_cam(i,1)=flux_adv_sam(i,1)
+         do k=2,nz_cam
+
+            ! assess whether sam levels exists at cam level
+            if (p_norm_sam(nz_sam) .gt. p_norm_cam(i,k)) then
+               flux_adv_cam(i,k) = 0.0
+            else               
+               ! find sam level just below cam level: k_l
+               k_l = 1
+               do while (p_norm_sam(k_l) .ge. p_norm_cam(i,k) .and. k_l < nz_sam)
+                  k_l = k_l + 1
+               end do
+               k_l = k_l - 1
+               k_u = k_l + 1
+               
+               if (p_norm_sam(k_l)==p_norm_cam(i,k)) then
+                  flux_adv_cam(i,k) = flux_adv_sam(i,k_l)
+               else                                 
+                  ! linearly interpolate
+                  flux_adv_cam(i,k) = flux_adv_sam(i,k_l) + (flux_adv_sam(i,k_u)-flux_adv_sam(i,k_l))*(p_norm_cam(i,k)-p_norm_sam(k_l))/(p_norm_sam(k_u)-p_norm_sam(k_l))
+               end if
+
+            end if
+
+         end do
+      end do
+      
+      deallocate(p_norm_sam)
+      deallocate(p_norm_cam)      
+      
+    end subroutine interp_flux_sam_to_cam
+          
     subroutine interp_to_sam(p_cam, p_surf_cam, var_cam, var_sam, var_cam_surface)
         !! Interpolate from the CAM pressure grid to the SAM pressure grid.
         !! Uses linear interpolation between nearest grid points on domain (CAM) grid.
@@ -402,7 +748,7 @@ contains
                 ps_u = p_int_norm_sam(ks_u+1)
                 do while ((ps_u > pc_u) .and. (ks_u < nrf))
                     ks_u = ks_u + 1
-                    ps_u = p_int_norm_sam(ks_u+1)
+                    ps_u = p_int_norm_sam(ks_u+1)                    
                 end do
                 ! ks_l is the SAM block with a lower interface below the CAM block
                 ks_l = ks_u
@@ -441,7 +787,7 @@ contains
         deallocate(p_norm_cam)
         deallocate(p_int_norm_cam)
 
-    end subroutine interp_to_cam
+      end subroutine interp_to_cam
 
     subroutine extrapolate_to_surface(p_cam, var_cam, p_surf_cam, var_surf_cam)
         !! Extrapolate variable profile to the surface, required for interpolation.
@@ -534,8 +880,8 @@ contains
 
     end subroutine sam_sounding_finalize
 
-
-    subroutine CAM_var_conversion(qv, qc, qi, r, tabs, t)
+    
+    subroutine CAM_var_conversion(qv, qc, qi, gamaz, r, tabs, t)
         !! Convert CAM moist mixing ratios for species qv, qc, qi to
         !! dry mixing ratio r to used by SAM parameterisation
         !! q is total water qv/c/i is cloud vapor/liquid/ice
@@ -543,8 +889,8 @@ contains
         !! by inverting lines 49-53 of diagnose.f90 from SAM where
 
         !! WARNING: This routine uses gamaz(k) which is defined on the SAM grid.
-        !!          Using a grid that does not match the SAM grid for input/output
-        !!          data will produce unphysical values.
+        !! OR
+        !! The native geopotential height on CAM grid
 
         integer :: ncol, nz
             !! array sizes
@@ -567,6 +913,8 @@ contains
             !! Cloud water from CAM
         real(8), intent(in) :: qi(:, :)
             !! Cloud ice from CAM
+        real(8), intent(in) :: gamaz(:, :)
+            !! Geopotential Height
 
         real(8), intent(out) :: t(:, :)
             !! Static energy as required by SAM NN
@@ -590,14 +938,14 @@ contains
             t(i,k) = tabs(i,k) &
                    ! - (fac_cond+(1.-omp)*fac_fus)*qp(i,k) &  ! There is no qp in CAM
                      - (fac_cond+(1.-omn)*fac_fus)*(rc + ri) &
-                     + gamaz(k)
+                     + gamaz(i,k)
           end do
         end do
 
     end subroutine CAM_var_conversion
 
 
-    subroutine SAM_var_conversion(t, r, tabs, qv, qc, qi)
+    subroutine SAM_var_conversion(t0, r0, tabs0, qv0, qc0, qi0, gamaz, pres_cam, t, r, tabs, qv, qc, qi)
         !! Convert SAM t and r to tabs, qv, qc, qi used by CAM
         !! t is normalised liquid ice static energy, r is a dry mixing ratio
         !! tabs is absolute temperature, q is cloud vapor/liquid/ice,
@@ -610,13 +958,23 @@ contains
         ! ---------------------
         ! Fields from SAM/CAM
         ! ---------------------
-        != unit K :: tabs, tabs1
-        real(8), intent(inout) :: tabs(:, :)
-            !! absolute temperature
-        real(8) :: tabs1
-            !! Temporary variable for tabs
 
+        real(8), intent(in) :: t0(:, :)
+            !! normalised liquid ice static energy (init) XL XL XL       
+        real(8), intent(in) :: r0(:, :)
+            !! Total non-precipitating water mixing ratio from SAM (init) XL XL XL
+        real(8), intent(in) :: tabs0(:, :)
+            !! Total non-precipitating water mixing ratio from SAM
+        real(8), intent(in) :: qv0(:, :)
+            !! Cloud water vapour in CAM
+        real(8), intent(in) :: qc0(:, :)
+            !! Cloud water (liquid) in CAM
+        real(8), intent(in) :: qi0(:, :)
+            !! Cloud ice in CAM       
+        
         != unit kg/kg :: r, qv, qc, qi
+        real(8), intent(in) :: t(:, :)
+            !! normalised liquid ice static energy (init) XL XL XL               
         real(8), intent(in) :: r(:, :)
             !! Total non-precipitating water mixing ratio from SAM
         real(8), intent(out) :: qv(:, :)
@@ -626,103 +984,175 @@ contains
         real(8), intent(out) :: qi(:, :)
             !! Cloud ice in CAM
 
+        != unit K :: tabs, tabs1
+        real(8), intent(out) :: tabs(:, :)
+            !! absolute temperature
+        real(8) :: tabs1
+        !! Temporary variable for tabs
+        
         != K :: t
-        real(8), intent(in) :: t(:, :)
-            !! normalised liquid ice static energy
+        real(8), intent(in) :: gamaz(:, :)
+            !! Geopotential Height
 
+        real(8), intent(in) :: pres_cam(:, :)
+        !! Mid-level pressure level
+
+        real(8), allocatable, dimension(:,:) :: pres_m(:, :)
+            !! Mid-level pressure level        
+        
         ! Intermediate variables
         real(8) :: rsat, om, omn, dtabs, drsat, lstarn, dlstarn, fff, dfff, rn, rv, r_temp
-
+        
         ncol = size(tabs, 1)
         nz = size(tabs, 2)
 
+        allocate(pres_m(ncol,nz))
+        
         ! Loop over all cells and iterate until equilibrium of condensed species is achieved.
         ! This code is adapted from cloud.f90 in SAM
         do k = 1, nz
         do i = 1, ncol
 
-            ! Enforce r >= 0.0
-            r_temp=max(0.,r(i,k))
+            if( (t0(i,k) .eq. t(i,k)) .and. (r0(i,k) .eq. r(i,k)) ) then
+               tabs(i,k) = tabs0(i,k)
+               qc(i,k) = qc0(i,k)
+               qi(i,k) = qi0(i,k)
+               qv(i,k) = qv0(i,k)
 
-            ! Initial guess for temperature assuming no cloud water/ice:
-            tabs(i,k) = t(i,k)-gamaz(k)
-            tabs1=tabs(i,k)
-
-            ! Set saturation vapour based on cloud type
-            ! Warm cloud:
-            if(tabs1 >= tbgmax) then
-                rsat = rsatw(tabs1,pres(k))
-            ! Ice cloud:
-            elseif(tabs1 <= tbgmin) then
-                rsat = rsati(tabs1,pres(k))
-            ! Mixed-phase cloud:
             else
-                om = an*tabs1-bn
-                rsat = om*rsatw(tabs1,pres(k))+(1.-om)*rsati(tabs1,pres(k))
-            endif
+           
+               pres_m(i,k)=pres_cam(i,k)/100.0
+               ! pres_m(i,k)=pres(k)
+               ! Enforce r >= 0.0
+               r_temp=max(0.,r(i,k))
 
-            !  Test if condensation is possible (humidity is above saturation) and iterate:
-            if(r_temp > rsat) then
-                niter=0
-                dtabs = 100.
-                do while(abs(dtabs) > 0.01 .and. niter < 10)
-                    ! Warm cloud regime
-                    if(tabs1 >= tbgmax) then
+               ! Initial guess for temperature assuming no cloud water/ice:
+               tabs(i,k) = t(i,k)-gamaz(i,k)
+               tabs1=tabs(i,k)
+
+               ! Set saturation vapour based on cloud type
+               ! Warm cloud:
+               if(tabs1 >= tbgmax) then
+                  rsat = rsatw(tabs1,pres_m(i,k))
+                  ! Ice cloud:
+               elseif(tabs1 <= tbgmin) then
+                  rsat = rsati(tabs1,pres_m(i,k))
+                  ! Mixed-phase cloud:
+               else
+                  om = an*tabs1-bn
+                  rsat = om*rsatw(tabs1,pres_m(i,k))+(1.-om)*rsati(tabs1,pres_m(i,k))
+               endif
+
+               !  Test if condensation is possible (humidity is above saturation) and iterate:
+               if(r_temp > rsat) then
+                  niter=0
+                  dtabs = 100.
+                  !                do while(abs(dtabs) > 0.01 .and. niter < 10)
+                  do while(abs(dtabs) > 0.001)                   
+                     ! Warm cloud regime
+                     if(tabs1 >= tbgmax) then
                         om=1.
                         lstarn=fac_cond
                         dlstarn=0.
-                        rsat=rsatw(tabs1,pres(k))
-                        drsat=dtrsatw(tabs1,pres(k))
-                    ! Ice cloud regime
-                    else if(tabs1 <= tbgmin) then
+                        rsat=rsatw(tabs1,pres_m(i,k))
+                        drsat=dtrsatw(tabs1,pres_m(i,k))
+                        ! Ice cloud regime
+                     else if(tabs1 <= tbgmin) then
                         om=0.
                         lstarn=fac_sub
                         dlstarn=0.
-                        rsat=rsati(tabs1,pres(k))
-                        drsat=dtrsati(tabs1,pres(k))
-                    ! Mixed cloud regime
-                    else
+                        rsat=rsati(tabs1,pres_m(i,k))
+                        drsat=dtrsati(tabs1,pres_m(i,k))
+                        ! Mixed cloud regime
+                     else
                         om=an*tabs1-bn
                         lstarn=fac_cond+(1.-om)*fac_fus
                         dlstarn=an
-                        rsat=om*rsatw(tabs1,pres(k))+(1.-om)*rsati(tabs1,pres(k))
-                        drsat=om*dtrsatw(tabs1,pres(k))+(1.-om)*dtrsati(tabs1,pres(k))
-                    endif
+                        rsat=om*rsatw(tabs1,pres_m(i,k))+(1.-om)*rsati(tabs1,pres_m(i,k))
+                        drsat=om*dtrsatw(tabs1,pres_m(i,k))+(1.-om)*dtrsati(tabs1,pres_m(i,k))
+                     endif
 
-                    ! Update thermodynamics and check for convergence
-                    fff = tabs(i,k)-tabs1+lstarn*(r_temp-rsat)
-                    dfff=dlstarn*(r_temp-rsat)-lstarn*drsat-1.
-                    dtabs=-fff/dfff
-                    niter=niter+1
-                    tabs1=tabs1+dtabs
-               end do
+                     ! Update thermodynamics and check for convergence
+                     fff = tabs(i,k)-tabs1+lstarn*(r_temp-rsat)
+                     dfff=dlstarn*(r_temp-rsat)-lstarn*drsat-1.
+                     dtabs=-fff/dfff
+                     niter=niter+1
+                     tabs1=tabs1+dtabs
+                  end do
 
-               ! Update saturation point and then calculate water and residual vapour content
-               rsat = rsat + drsat * dtabs
-               rn = max(0., r_temp-rsat)
-               rv = max(0., r_temp-rn)
+                  ! Update saturation point and then calculate water and residual vapour content
+                  rsat = rsat + drsat * dtabs
+                  rn = max(0., r_temp-rsat)
+                  rv = max(0., r_temp-rn)
 
-            ! If condensation not possible rn is 0.0
-            else
-              rn = 0.
-              rv = r_temp
+                  ! If condensation not possible rn is 0.0
+               else
+                  rn = 0.
+                  rv = r_temp
 
-            endif
+               endif
 
-            ! Set tabs to iterated tabs after convection
-            tabs(i,k) = tabs1
+               ! Set tabs to iterated tabs after convection
+               tabs(i,k) = tabs1
 
-            ! Code for calculating qc and qi from rn.
-            ! Adapted from statistics.f90 in SAM assuming dokruegermicro=.false.
-            ! Also implements conversion from SAM dry mixing ratios to CAM moist mixing ratios
-            omn = omegan(tabs(i,k))
-            qc(i,k) = rn*omn/(1.+rv)
-            qi(i,k) = rn*(1.-omn)/(1.+rv)
-            qv(i,k) = rv/(1.+rv)
+               ! Code for calculating qc and qi from rn.
+               ! Adapted from statistics.f90 in SAM assuming dokruegermicro=.false.
+               ! Also implements conversion from SAM dry mixing ratios to CAM moist mixing ratios
+               omn = omegan(tabs(i,k))
+               qc(i,k) = rn*omn/(1.+rv)
+               qi(i,k) = rn*(1.-omn)/(1.+rv)
+               qv(i,k) = rv/(1.+rv)
 
-        end do
-        end do
+            end if
+            
+         end do
+      end do
 
+      deallocate(pres_m)
+        
     end subroutine SAM_var_conversion
 
+    subroutine interp_flux_cam_midpoint(pres_cam, pres_int_cam, pres_sfc_cam, flux_adv_cam_int, flux_adv_cam)
+      
+      real(8), dimension(:,:), intent(in) :: pres_cam, pres_int_cam, flux_adv_cam_int
+      real(8), dimension(:), intent(in) :: pres_sfc_cam
+      real(8), dimension(:,:), intent(out) :: flux_adv_cam
+      real(8), dimension(:,:), allocatable :: p_norm_cam, p_norm_cam_int
+      integer :: i, k, nz, ncol
+      
+      ncol = size(flux_adv_cam_int, 1)
+      nz = size(flux_adv_cam_int, 2)
+      allocate(p_norm_cam(ncol, nz))
+      allocate(p_norm_cam_int(ncol, nz+1))
+      
+      do i = 1,ncol
+         do k=1, nz
+            p_norm_cam(i,k) = pres_cam(i,k) / pres_sfc_cam(i)
+            p_norm_cam_int(i,k) = pres_int_cam(i,k) / pres_sfc_cam(i)
+         end do
+         p_norm_cam_int(i,nz+1) = pres_int_cam(i,nz+1) / pres_sfc_cam(i)
+      end do
+      
+      do i = 1,ncol
+         do k=1, nz-1
+            flux_adv_cam(i,k) = flux_adv_cam_int(i,k) + (flux_adv_cam_int(i,k+1)-flux_adv_cam_int(i,k))*(p_norm_cam(i,k)-p_norm_cam_int(i,k))/(p_norm_cam_int(i,k+1)-p_norm_cam_int(i,k))
+         end do
+         flux_adv_cam(i,nz) = flux_adv_cam_int(i,nz) + (0.0-flux_adv_cam_int(i,nz))*(p_norm_cam(i,nz)-p_norm_cam_int(i,nz))/(p_norm_cam_int(i,nz+1)-p_norm_cam_int(i,nz))     
+      end do                  
+
+      deallocate(p_norm_cam)
+      deallocate(p_norm_cam_int)
+      
+    end subroutine interp_flux_cam_midpoint
+!        ! We interpolate from lower level interface to mid level in SAM grid
+!        call interp_sam_lower2mid(t_flux_adv_sam_f, t_flux_adv_sam)
+!        call interp_sam_lower2mid(q_flux_adv_sam_f, q_flux_adv_sam)
+!        call interp_sam_lower2mid(q_sed_flux_sam_f, q_sed_flux_sam)        
+        ! We interpolate from mid level to lower level interface in CAM grid
+!        call interp_cam_mid2lower(pres_cam(1:ncol, :), pres_int_cam(1:ncol, :), pres_sfc_cam(1:ncol), t_flux_adv_sam_f(1:ncol,1), t_flux_adv, t_flux_adv_f)
+!        call interp_cam_mid2lower(pres_cam(1:ncol, :), pres_int_cam(1:ncol, :), pres_sfc_cam(1:ncol), q_flux_adv_sam_f(1:ncol,1), q_flux_adv, q_flux_adv_f)
+!        call interp_cam_mid2lower(pres_cam(1:ncol, :), pres_int_cam(1:ncol, :), pres_sfc_cam(1:ncol), q_sed_flux_sam_f(1:ncol,1), q_sed_flux, q_sed_flux_f)       
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+    
 end module nn_interface_CAM

--- a/CAM_Convection_YOG/src/cam/physpkg.F90
+++ b/CAM_Convection_YOG/src/cam/physpkg.F90
@@ -157,7 +157,7 @@ contains
     use cam_diagnostics,    only: diag_register
     use cloud_diagnostics,  only: cloud_diagnostics_register
     use cospsimulator_intr, only: cospsimulator_intr_register
-    use rad_constituents,   only: rad_cnst_get_info ! Added to query if it is a modal aero sim or not
+    use radiative_aerosol,   only: rad_aer_get_info ! Added to query if it is a modal aero sim or not
     use radheat,            only: radheat_register
     use subcol,             only: subcol_register
     use subcol_utils,       only: is_subcol_on, subcol_get_scheme
@@ -271,7 +271,7 @@ contains
        call conv_water_register()
 
        ! Determine whether its a 'modal' aerosol simulation  or not
-       call rad_cnst_get_info(0, nmodes=nmodes)
+       call rad_aer_get_info(0, nmodes=nmodes)
        clim_modal_aero = (nmodes > 0)
 
        if (clim_modal_aero) then
@@ -302,10 +302,6 @@ contains
        ! register various data model gasses with pbuf
        call ghg_data_register()
 
-       ! carma microphysics
-       !
-       call carma_register()
-
        ! Register iondrag variables with pbuf
        call iondrag_register()
 
@@ -326,6 +322,10 @@ contains
        call radiation_register
        call cloud_diagnostics_register
        call radheat_register
+
+       ! carma microphysics
+       !
+       call carma_register()
 
        ! COSP
        call cospsimulator_intr_register
@@ -740,7 +740,7 @@ contains
     use convect_shallow,    only: convect_shallow_init
     use constituents,       only: cnst_get_ind
     use cam_diagnostics,    only: diag_init
-    use gw_drag,            only: gw_init
+    use gw_drag_cam,        only: gw_drag_cam_init
     use radheat,            only: radheat_init
     use radiation,          only: radiation_init
     use cloud_diagnostics,  only: cloud_diagnostics_init
@@ -748,6 +748,7 @@ contains
     use wv_saturation,      only: wv_sat_init
     use microp_driver,      only: microp_driver_init
     use microp_aero,        only: microp_aero_init
+    use aerosol_instances_mod, only: aerosol_instances_init, aerosol_instances_init_states
     use macrop_driver,      only: macrop_driver_init
     use conv_water,         only: conv_water_init
     use tracers,            only: tracers_init
@@ -757,6 +758,7 @@ contains
     use vertical_diffusion, only: vertical_diffusion_init
     use phys_debug_util,    only: phys_debug_init
     use rad_constituents,   only: rad_cnst_init
+    use radiative_aerosol,  only: rad_aer_init
     use aer_rad_props,      only: aer_rad_props_init
     use subcol,             only: subcol_init
     use qbo,                only: qbo_init
@@ -863,7 +865,10 @@ contains
     call solar_data_init()
 
     ! Initialize rad constituents and their properties
-    call rad_cnst_init()
+    call rad_aer_init()   ! aerosol init: physprop_init + mode/bin/list init
+    call aerosol_instances_init()  ! create abstract aerosol factory objects
+    call aerosol_instances_init_states(phys_state, pbuf2d)  ! create persistent per-chunk state objects
+    call rad_cnst_init()  ! gas-specific init
 
     call radiation_init(pbuf2d)
 
@@ -898,7 +903,7 @@ contains
        call co2_init()
     end if
 
-    call gw_init()
+    call gw_drag_cam_init()
 
     call rayleigh_friction_init(pver, rf_nl_tau0, rf_nl_krange, rf_nl_k0, masterproc, &
          iulog, errmsg, errflg)
@@ -1398,7 +1403,7 @@ contains
     use shr_kind_mod,       only: r8 => shr_kind_r8
     use chemistry,          only: chem_is_active, chem_timestep_tend, chem_emissions
     use cam_diagnostics,    only: diag_phys_tend_writeout
-    use gw_drag,            only: gw_tend
+    use gw_drag_cam,        only: gw_drag_cam_tend
     use trb_mtn_stress_cam, only: trb_mtn_stress_tend
     use beljaars_drag_cam,  only: beljaars_drag_tend
     use vertical_diffusion, only: vertical_diffusion_tend
@@ -1423,7 +1428,7 @@ contains
     use dycore,             only: dycore_is
     use cam_control_mod,    only: aqua_planet
     use mo_gas_phase_chemdr,only: map2chm
-    use clybry_fam,         only: clybry_fam_set
+    use clybryiy_fam,       only: clybryiy_fam_set
     use charge_neutrality,  only: charge_balance
     use qbo,                only: qbo_relax
     use iondrag,            only: iondrag_calc, do_waccm_ions
@@ -1476,6 +1481,7 @@ contains
     real(r8) :: tmp_trac  (pcols,pver,pcnst) ! tmp space
     real(r8) :: tmp_pdel  (pcols,pver) ! tmp space
     real(r8) :: tmp_ps    (pcols)      ! tmp space
+    real(r8) :: tmp_cpcv  (pcols,pver) ! tmp space
     real(r8) :: scaling(pcols,pver)
     logical  :: moist_mixing_ratio_dycore
 
@@ -1542,6 +1548,12 @@ contains
 
     ifld = pbuf_get_index('AST')
     call pbuf_get_field(pbuf, ifld, ast, start=(/1,1,itim_old/), kount=(/pcols,pver,1/) )
+
+    ! zero out local variables that may be written to snapshot for safety.
+    fh2o(:) = 0._r8         ! used in chem_timestep_tend.
+    surfric(:) = 0._r8      ! out from vertical_diffusion_tend.
+    obklen(:) = 0._r8       ! out from vertical_diffusion_tend.
+    flx_heat(:) = 0._r8     ! first out from gw_drag_cam.
 
     !
     ! accumulate fluxes into net flux array for spectral dycores
@@ -1690,7 +1702,7 @@ contains
     end if
 
     call trb_mtn_stress_tend(state, pbuf, cam_in)
-    call beljaars_drag_tend(state, pbuf, cam_in)
+    call beljaars_drag_tend(state, pbuf)
 
     if (trim(cam_take_snapshot_after) == "orographic_form_drag_stress") then
        call cam_snapshot_all_outfld_tphysac(cam_snapshot_after_num, state, tend, cam_in, cam_out, pbuf,&
@@ -1847,7 +1859,7 @@ contains
                     fh2o, surfric, obklen, flx_heat)
     end if
 
-    call gw_tend(state, pbuf, ztodt, ptend, cam_in, flx_heat)
+    call gw_drag_cam_tend(state, pbuf, ztodt, ptend, cam_in, flx_heat)
 
     if ( (trim(cam_take_snapshot_after) == "gw_tend") .and.                   &
          (trim(cam_take_snapshot_before) == trim(cam_take_snapshot_after))) then
@@ -1988,11 +2000,6 @@ contains
     ! FV: convert dry-type mixing ratios to moist here because physics_dme_adjust
     !     assumes moist. This is done in p_d_coupling for other dynamics. Bundy, Feb 2004.
     moist_mixing_ratio_dycore = dycore_is('LR').or. dycore_is('FV3')
-    !
-    ! update cp/cv for energy computation based in updated water variables
-    !
-    call cam_thermo_water_update(state%q(:ncol,:,:), lchnk, ncol, vc_dycore,&
-         to_dry_factor=state%pdel(:ncol,:)/state%pdeldry(:ncol,:))
 
     ! for dry mixing ratio dycore, physics_dme_adjust is called for energy diagnostic purposes only.
     ! So, save off tracers
@@ -2006,10 +2013,17 @@ contains
         tmp_trac(:ncol,:pver,:pcnst) = state%q(:ncol,:pver,:pcnst)
         tmp_pdel(:ncol,:pver)        = state%pdel(:ncol,:pver)
         tmp_ps(:ncol)                = state%ps(:ncol)
+        tmp_cpcv(:ncol,:pver)        = cp_or_cv_dycore(:ncol,:pver,lchnk)
         if (trim(cam_take_snapshot_before) == "physics_dme_adjust") then
           call cam_snapshot_all_outfld_tphysac(cam_snapshot_before_num, state, tend, cam_in, cam_out, pbuf,&
                fh2o, surfric, obklen, flx_heat)
-        end if
+       end if
+       !
+       ! update cp/cv for energy computation based in updated water variables
+       !
+       call cam_thermo_water_update(state%q(:ncol,:,:), lchnk, ncol, vc_dycore,&
+            to_dry_factor=state%pdel(:ncol,:)/state%pdeldry(:ncol,:))
+
         call physics_dme_adjust(state, tend, qini, totliqini, toticeini, ztodt)
         if (trim(cam_take_snapshot_after) == "physics_dme_adjust") then
           call cam_snapshot_all_outfld_tphysac(cam_snapshot_after_num, state, tend, cam_in, cam_out, pbuf,&
@@ -2021,6 +2035,7 @@ contains
         state%q(:ncol,:pver,:pcnst) = tmp_trac(:ncol,:pver,:pcnst)
         state%pdel(:ncol,:pver)     = tmp_pdel(:ncol,:pver)
         state%ps(:ncol)             = tmp_ps(:ncol)
+        cp_or_cv_dycore(:ncol,:pver,lchnk) = tmp_cpcv(:ncol,:pver)
       end if
     else
       !
@@ -2085,7 +2100,7 @@ contains
 
     call diag_phys_tend_writeout (state, pbuf,  tend, ztodt, qini, cldliqini, cldiceini)
 
-    call clybry_fam_set( ncol, lchnk, map2chm, state%q, pbuf )
+    call clybryiy_fam_set( ncol, lchnk, map2chm, state%q, pbuf )
 
     ! clean CARMA diagnostics object
     if (associated(carma_diags_obj)) then
@@ -2170,7 +2185,7 @@ contains
     use cloud_diagnostics, only: cloud_diagnostics_calc
     use perf_mod
     use mo_gas_phase_chemdr,only: map2chm
-    use clybry_fam,         only: clybry_fam_adj
+    use clybryiy_fam,       only: clybryiy_fam_adj
     use clubb_intr,      only: clubb_tend_cam
     use sslt_rebin,      only: sslt_rebin_adv
     use tropopause,      only: tropopause_output
@@ -2188,12 +2203,16 @@ contains
     use dyn_tests_utils, only: vc_dycore
     use surface_emissions_mod,only: surface_emissions_set
     use elevated_emissions_mod,only: elevated_emissions_set
+    use aerosol_properties_mod, only: aerosol_properties
+    use aerosol_state_mod, only: aerosol_state
+    use aerosol_instances_mod, only: aerosol_instances_get_props, &
+         aerosol_instances_get_num_models, aerosol_instances_get_state
 
     ! Arguments
 
     real(r8), intent(in) :: ztodt                          ! 2 delta t (model time increment)
 
-    type(physics_state), intent(inout) :: state
+    type(physics_state), intent(inout), target :: state
     type(physics_tend ), intent(inout) :: tend
     type(physics_buffer_desc), pointer :: pbuf(:)
 
@@ -2286,7 +2305,6 @@ contains
     real(r8) :: zero(pcols)                    ! array of zeros
     real(r8) :: zero_sc(pcols*psubcols)        ! array of zeros
     real(r8) :: rliq(pcols)                    ! vertical integral of liquid not yet in q(ixcldliq)
-    real(r8) :: rice(pcols)                    ! vertical integral of ice not yet in q(ixcldice)
     real(r8) :: rliq2(pcols)                   ! vertical integral of liquid from shallow scheme
     real(r8) :: det_s  (pcols)                 ! vertical integral of detrained static energy from ice
     real(r8) :: det_ice(pcols)                 ! vertical integral of detrained ice
@@ -2295,11 +2313,20 @@ contains
     type(check_tracers_data):: tracerint             ! energy integrals and cummulative boundary fluxes
     real(r8) :: zero_tracers(pcols,pcnst)
 
+    ! For abstract aerosol interface (calcsize/wateruptake)
+    class(aerosol_properties), pointer :: aero_props
+    class(aerosol_state), pointer :: aero_state_obj
+
+    integer :: iaermod_lcl
+
     ! For aerosol budget diagnostics
     character(len=16) :: pname      !! package name
     type(carma_diags_t), pointer :: carma_diags_obj
 
     !-----------------------------------------------------------------------
+    nullify(aero_props)
+    nullify(aero_state_obj)
+
     carma_diags_obj => carma_diags_t()
     if (.not.associated(carma_diags_obj)) then
        call endrun('tphysbc: carma_diags_obj allocation failed')
@@ -2349,16 +2376,16 @@ contains
     if (state_debug_checks) &
          call physics_state_check(state, name="before tphysbc (dycore?)")
 
-    call clybry_fam_adj( ncol, lchnk, map2chm, state%q, pbuf )
+    call clybryiy_fam_adj( ncol, lchnk, map2chm, state%q, pbuf )
 
-    ! Since clybry_fam_adj operates directly on the tracers, and has no
+    ! Since clybryiy_fam_adj operates directly on the tracers, and has no
     ! physics_update call, re-run qneg3.
     call qneg3('TPHYSBCc',lchnk  ,ncol    ,pcols   ,pver    , &
          1, pcnst, qmin  ,state%q )
 
-    ! Validate output of clybry_fam_adj.
+    ! Validate output of clybryiy_fam_adj.
     if (state_debug_checks) &
-         call physics_state_check(state, name="clybry_fam_adj")
+         call physics_state_check(state, name="clybryiy_fam_adj")
 
     !
     ! Dump out "before physics" state
@@ -2369,6 +2396,18 @@ contains
     call check_tracers_init(state, tracerint)
 
     call t_stopf('bc_init')
+
+    ! Zero-initialize subroutine-level variables for snapshot
+    cmfmc(:,:) = 0._r8
+    cmfcme(:,:) = 0._r8
+    zdu(:,:) = 0._r8
+    rliq(:) = 0._r8
+    dlf(:,:) = 0._r8
+    dlf2(:,:) = 0._r8
+    rliq2(:) = 0._r8
+    det_s(:) = 0._r8
+    det_ice(:) = 0._r8
+    net_flx(:) = 0._r8
 
     !===================================================
     ! Global mean total energy fixer
@@ -2436,7 +2475,7 @@ contains
 
     if (trim(cam_take_snapshot_before) == "dadadj_tend") then
        call cam_snapshot_all_outfld_tphysbc(cam_snapshot_before_num, state, tend, cam_in, cam_out, pbuf, &
-           flx_heat, cmfmc, cmfcme, zdu, rliq, rice, dlf, dlf2, rliq2, det_s, det_ice, net_flx)
+           flx_heat, cmfmc, cmfcme, zdu, rliq, dlf, dlf2, rliq2, det_s, det_ice, net_flx)
     end if
 
     call dadadj_tend(ztodt, state, ptend)
@@ -2449,7 +2488,7 @@ contains
 
     if (trim(cam_take_snapshot_after) == "dadadj_tend") then
        call cam_snapshot_all_outfld_tphysbc(cam_snapshot_after_num, state, tend, cam_in, cam_out, pbuf, &
-           flx_heat, cmfmc, cmfcme, zdu, rliq, rice, dlf, dlf2, rliq2, det_s, det_ice, net_flx)
+           flx_heat, cmfmc, cmfcme, zdu, rliq, dlf, dlf2, rliq2, det_s, det_ice, net_flx)
     end if
 
     call t_stopf('dry_adjustment')
@@ -2463,13 +2502,13 @@ contains
 
     if (trim(cam_take_snapshot_before) == "convect_deep_tend") then
        call cam_snapshot_all_outfld_tphysbc(cam_snapshot_before_num, state, tend, cam_in, cam_out, pbuf, &
-           flx_heat, cmfmc, cmfcme, zdu, rliq, rice, dlf, dlf2, rliq2, det_s, det_ice, net_flx)
+           flx_heat, cmfmc, cmfcme, zdu, rliq, dlf, dlf2, rliq2, det_s, det_ice, net_flx)
     end if
 
     call convect_deep_tend(  &
          cmfmc,      cmfcme,             &
          zdu,       &
-         rliq,    rice,      &
+         rliq,      &
          ztodt,   &
          state,   ptend, cam_in%landfrac, pbuf)
 
@@ -2488,7 +2527,7 @@ contains
 
     if (trim(cam_take_snapshot_after) == "convect_deep_tend") then
        call cam_snapshot_all_outfld_tphysbc(cam_snapshot_after_num, state, tend, cam_in, cam_out, pbuf, &
-           flx_heat, cmfmc, cmfcme, zdu, rliq, rice, dlf, dlf2, rliq2, det_s, det_ice, net_flx)
+           flx_heat, cmfmc, cmfcme, zdu, rliq, dlf, dlf2, rliq2, det_s, det_ice, net_flx)
     end if
 
     call t_stopf('convect_deep_tend')
@@ -2511,14 +2550,15 @@ contains
 
     ! Check energy integrals, including "reserved liquid"
     flx_cnd(:ncol) = prec_dp(:ncol) + rliq(:ncol)
-    snow_dp(:ncol) = snow_dp(:ncol) + rice(:ncol)
         ! Yuval O'Gorman scheme
     if (yog_scheme=='on') then
         call t_startf('yog_nn')
 
-        call yog_tend(ztodt, state, ptend, pbuf)
+        call yog_tend(ztodt, state, ptend, pbuf, cam_in%landfrac)
+
 
         call physics_update(state, ptend, ztodt, tend)
+
 
         call t_stopf('yog_nn')
 
@@ -2526,7 +2566,6 @@ contains
         call check_energy_cam_chng(state, tend, "yog_nn", nstep, ztodt, zero, flx_cnd, zero, flx_heat)
     end if
     call check_energy_cam_chng(state, tend, "convect_deep", nstep, ztodt, zero, flx_cnd, snow_dp, zero)
-    snow_dp(:ncol) = snow_dp(:ncol) - rice(:ncol)
 
     !
     ! Call Hack (1994) convection scheme to deal with shallow/mid-level convection
@@ -2540,13 +2579,9 @@ contains
        dlf(:,:) = 0._r8
     end if
 
-    ! Zero-initialize subroutine-level variables for snapshot
-    dlf2(:,:) = 0._r8
-    rliq2(:) = 0._r8
-
     if (trim(cam_take_snapshot_before) == "convect_shallow_tend") then
        call cam_snapshot_all_outfld_tphysbc(cam_snapshot_before_num, state, tend, cam_in, cam_out, pbuf, &
-           flx_heat, cmfmc, cmfcme, zdu, rliq, rice, dlf, dlf2, rliq2, det_s, det_ice, net_flx)
+           flx_heat, cmfmc, cmfcme, zdu, rliq, dlf, dlf2, rliq2, det_s, det_ice, net_flx)
     end if
 
     call convect_shallow_tend (ztodt   , cmfmc, &
@@ -2570,7 +2605,7 @@ contains
 
     if (trim(cam_take_snapshot_after) == "convect_shallow_tend") then
        call cam_snapshot_all_outfld_tphysbc(cam_snapshot_after_num, state, tend, cam_in, cam_out, pbuf, &
-           flx_heat, cmfmc, cmfcme, zdu, rliq, rice, dlf, dlf2, rliq2, det_s, det_ice, net_flx)
+           flx_heat, cmfmc, cmfcme, zdu, rliq, dlf, dlf2, rliq2, det_s, det_ice, net_flx)
     end if
 
     flx_cnd(:ncol) = prec_sh(:ncol) + rliq2(:ncol)
@@ -2625,7 +2660,7 @@ contains
 
        if (trim(cam_take_snapshot_before) == "rk_stratiform_tend") then
             call cam_snapshot_all_outfld_tphysbc(cam_snapshot_before_num, state, tend, cam_in, cam_out, pbuf, &
-                 flx_heat, cmfmc, cmfcme, zdu, rliq, rice, dlf, dlf2, rliq2, det_s, det_ice, net_flx)
+                 flx_heat, cmfmc, cmfcme, zdu, rliq, dlf, dlf2, rliq2, det_s, det_ice, net_flx)
        end if
 
        call rk_stratiform_cam_tend(state, ptend, pbuf, ztodt, &
@@ -2645,7 +2680,7 @@ contains
 
        if (trim(cam_take_snapshot_after) == "rk_stratiform_tend") then
            call cam_snapshot_all_outfld_tphysbc(cam_snapshot_after_num, state, tend, cam_in, cam_out, pbuf, &
-               flx_heat, cmfmc, cmfcme, zdu, rliq, rice, dlf, dlf2, rliq2, det_s, det_ice, net_flx)
+               flx_heat, cmfmc, cmfcme, zdu, rliq, dlf, dlf2, rliq2, det_s, det_ice, net_flx)
        end if
 
        call check_energy_cam_chng(state, tend, "cldwat_tend", nstep, ztodt, zero, prec_str, snow_str, zero)
@@ -2686,7 +2721,7 @@ contains
 
              if (trim(cam_take_snapshot_before) == "macrop_driver_tend") then
                 call cam_snapshot_all_outfld_tphysbc(cam_snapshot_before_num, state, tend, cam_in, cam_out, pbuf, &
-                     flx_heat, cmfmc, cmfcme, zdu, rliq, rice, dlf, dlf2, rliq2, det_s, det_ice, net_flx)
+                     flx_heat, cmfmc, cmfcme, zdu, rliq, dlf, dlf2, rliq2, det_s, det_ice, net_flx)
              end if
 
              call macrop_driver_tend( &
@@ -2717,7 +2752,7 @@ contains
 
              if (trim(cam_take_snapshot_after) == "macrop_driver_tend") then
                 call cam_snapshot_all_outfld_tphysbc(cam_snapshot_after_num, state, tend, cam_in, cam_out, pbuf, &
-                     flx_heat, cmfmc, cmfcme, zdu, rliq, rice, dlf, dlf2, rliq2, det_s, det_ice, net_flx)
+                     flx_heat, cmfmc, cmfcme, zdu, rliq, dlf, dlf2, rliq2, det_s, det_ice, net_flx)
              end if
 
              call check_energy_cam_chng(state, tend, "macrop_tend", nstep, ztodt, &
@@ -2733,7 +2768,7 @@ contains
 
              if (trim(cam_take_snapshot_before) == "clubb_tend_cam") then
                 call cam_snapshot_all_outfld_tphysbc(cam_snapshot_before_num, state, tend, cam_in, cam_out, pbuf, &
-                     flx_heat, cmfmc, cmfcme, zdu, rliq, rice, dlf, dlf2, rliq2, det_s, det_ice, net_flx)
+                     flx_heat, cmfmc, cmfcme, zdu, rliq, dlf, dlf2, rliq2, det_s, det_ice, net_flx)
              end if
 
              call clubb_tend_cam(state, ptend, pbuf, cld_macmic_ztodt,&
@@ -2763,7 +2798,7 @@ contains
 
              if (trim(cam_take_snapshot_after) == "clubb_tend_cam") then
                 call cam_snapshot_all_outfld_tphysbc(cam_snapshot_after_num, state, tend, cam_in, cam_out, pbuf, &
-                      flx_heat, cmfmc, cmfcme, zdu, rliq, rice, dlf, dlf2, rliq2, det_s, det_ice, net_flx)
+                      flx_heat, cmfmc, cmfcme, zdu, rliq, dlf, dlf2, rliq2, det_s, det_ice, net_flx)
              end if
 
              ! Use actual qflux (not lhf/latvap) for consistency with surface fluxes and revised code
@@ -2800,7 +2835,7 @@ contains
 
           if (trim(cam_take_snapshot_before) == "microp_section") then
              call cam_snapshot_all_outfld_tphysbc(cam_snapshot_before_num, state, tend, cam_in, cam_out, pbuf, &
-                  flx_heat, cmfmc, cmfcme, zdu, rliq, rice, dlf, dlf2, rliq2, det_s, det_ice, net_flx)
+                  flx_heat, cmfmc, cmfcme, zdu, rliq, dlf, dlf2, rliq2, det_s, det_ice, net_flx)
           end if
 
           call carma_diags_obj%update(cam_in, state, pbuf)
@@ -2815,7 +2850,7 @@ contains
 
              if (trim(cam_take_snapshot_before) == "microp_driver_tend_subcol") then
                 call cam_snapshot_all_outfld_tphysbc(cam_snapshot_before_num, state_sc, tend_sc, cam_in, cam_out, pbuf, &
-                     flx_heat, cmfmc, cmfcme, zdu, rliq, rice, dlf, dlf2, rliq2, det_s, det_ice, net_flx)
+                     flx_heat, cmfmc, cmfcme, zdu, rliq, dlf, dlf2, rliq2, det_s, det_ice, net_flx)
              end if
 
              call microp_driver_tend(state_sc, ptend_sc, cld_macmic_ztodt, pbuf)
@@ -2867,7 +2902,7 @@ contains
 
              if (trim(cam_take_snapshot_after) == "microp_driver_tend_subcol") then
                 call cam_snapshot_all_outfld_tphysbc(cam_snapshot_after_num, state_sc, tend_sc, cam_in, cam_out, pbuf, &
-                   flx_heat, cmfmc, cmfcme, zdu, rliq, rice, dlf, dlf2, rliq2, det_s, det_ice, net_flx)
+                   flx_heat, cmfmc, cmfcme, zdu, rliq, dlf, dlf2, rliq2, det_s, det_ice, net_flx)
              end if
 
              call check_energy_cam_chng(state_sc, tend_sc, "microp_tend_subcol", &
@@ -2904,7 +2939,7 @@ contains
 
           if (trim(cam_take_snapshot_after) == "microp_section") then
              call cam_snapshot_all_outfld_tphysbc(cam_snapshot_after_num, state, tend, cam_in, cam_out, pbuf, &
-                  flx_heat, cmfmc, cmfcme, zdu, rliq, rice, dlf, dlf2, rliq2, det_s, det_ice, net_flx)
+                  flx_heat, cmfmc, cmfcme, zdu, rliq, dlf, dlf2, rliq2, det_s, det_ice, net_flx)
           end if
 
           call check_energy_cam_chng(state, tend, "microp_tend", nstep, ztodt, &
@@ -2951,25 +2986,36 @@ contains
 
        call t_startf('aerosol_wet_processes')
        if (clim_modal_aero) then
+          ! Find the modal aerosol model properties object.
+          do iaermod_lcl = 1, aerosol_instances_get_num_models()
+             aero_props => aerosol_instances_get_props(iaermod_lcl, list_idx=0)
+             if (associated(aero_props)) then
+                if (aero_props%model_is('MAM')) exit
+             end if
+          end do
+          !REMOVECAM - get persistent state from factory; under CAM-SIMA states will be passed as scheme inputs
+          aero_state_obj => aerosol_instances_get_state(iaermod_lcl, 0, state%lchnk)
+          !REMOVECAM_END
+
           if (prog_modal_aero) then
              call physics_ptend_init(ptend, state%psetcols, 'aero_water_uptake', lq=wetdep_lq)
              ! Do calculations of mode radius and water uptake if:
              ! 1) modal aerosols are affecting the climate, or
              ! 2) prognostic modal aerosols are enabled
-             call modal_aero_calcsize_sub(state, ptend, ztodt, pbuf)
+             call modal_aero_calcsize_sub(state, ptend, ztodt, pbuf, aero_props, aero_state_obj)
              ! for prognostic modal aerosols the transfer of mass between aitken and accumulation
              ! modes is done in conjunction with the dry radius calculation
-             call modal_aero_wateruptake_dr(state, pbuf)
+             call modal_aero_wateruptake_dr(state, pbuf, aero_props, aero_state_obj)
              call physics_update(state, ptend, ztodt, tend)
           else
-             call modal_aero_calcsize_diag(state, pbuf)
-             call modal_aero_wateruptake_dr(state, pbuf)
+             call modal_aero_calcsize_diag(state, pbuf, aero_props, aero_state_obj)
+             call modal_aero_wateruptake_dr(state, pbuf, aero_props, aero_state_obj)
           endif
        endif
 
        if (trim(cam_take_snapshot_before) == "aero_model_wetdep") then
           call cam_snapshot_all_outfld_tphysbc(cam_snapshot_before_num, state, tend, cam_in, cam_out, pbuf, &
-                  flx_heat, cmfmc, cmfcme, zdu, rliq, rice, dlf, dlf2, rliq2, det_s, det_ice, net_flx)
+                  flx_heat, cmfmc, cmfcme, zdu, rliq, dlf, dlf2, rliq2, det_s, det_ice, net_flx)
        end if
 
        call carma_diags_obj%update(cam_in, state, pbuf)
@@ -2984,7 +3030,7 @@ contains
 
        if (trim(cam_take_snapshot_after) == "aero_model_wetdep") then
           call cam_snapshot_all_outfld_tphysbc(cam_snapshot_after_num, state, tend, cam_in, cam_out, pbuf, &
-                  flx_heat, cmfmc, cmfcme, zdu, rliq, rice, dlf, dlf2, rliq2, det_s, det_ice, net_flx)
+                  flx_heat, cmfmc, cmfcme, zdu, rliq, dlf, dlf2, rliq2, det_s, det_ice, net_flx)
        end if
 
        if (carma_do_wetdep) then
@@ -3041,7 +3087,7 @@ contains
 
     if (trim(cam_take_snapshot_before) == "radiation_tend") then
        call cam_snapshot_all_outfld_tphysbc(cam_snapshot_before_num, state, tend, cam_in, cam_out, pbuf, &
-                  flx_heat, cmfmc, cmfcme, zdu, rliq, rice, dlf, dlf2, rliq2, det_s, det_ice, net_flx)
+                  flx_heat, cmfmc, cmfcme, zdu, rliq, dlf, dlf2, rliq2, det_s, det_ice, net_flx)
     end if
 
     call radiation_tend( &
@@ -3060,7 +3106,7 @@ contains
 
     if (trim(cam_take_snapshot_after) == "radiation_tend") then
        call cam_snapshot_all_outfld_tphysbc(cam_snapshot_after_num, state, tend, cam_in, cam_out, pbuf, &
-                  flx_heat, cmfmc, cmfcme, zdu, rliq, rice, dlf, dlf2, rliq2, det_s, det_ice, net_flx)
+                  flx_heat, cmfmc, cmfcme, zdu, rliq, dlf, dlf2, rliq2, det_s, det_ice, net_flx)
     end if
 
     call check_energy_cam_chng(state, tend, "radheat", nstep, ztodt, zero, zero, zero, net_flx)

--- a/CAM_Convection_YOG/src/cam/yog_intr.F90
+++ b/CAM_Convection_YOG/src/cam/yog_intr.F90
@@ -17,7 +17,7 @@ module yog_intr
                            nn_convection_flux_CAM,                   &
                            nn_convection_flux_CAM_finalize
 
-   use physconst,    only: cpair, pi 
+   use physconst,    only: cpair, pi
    use ppgrid,       only: pver, pcols, pverp, begchunk, endchunk
    use cam_abortutils,   only: endrun
    use perf_mod
@@ -27,11 +27,13 @@ module yog_intr
    implicit none
    private
    save
-   character(len=256),     save :: yog_nn_weights  = ''    ! location of weights for the YOG NN, set in namelist
-   character(len=256),     save :: yog_nn_scale    = ''    ! location of dimensions and scaling parameters  set in namelist
+   character(len=136),     save :: yog_nn_weights  = ''    ! location of weights for the YOG NN, set in namelist
+   character(len=136),     save :: yog_nn_scale    = ''    ! location of dimensions and scaling parameters  set in namelist
    character(len=136),     save :: SAM_sounding    = ''    ! location of SAM sounding profile for the YOG NN, set in namelist
-   character(len=64 ),     save :: yog_device      = 'cpu' ! optional
-   integer,                save :: yog_safety_level = 2    ! optional
+   real(r8),               save :: yog_lat_max     = 30._r8 ! restrict YOG to |lat| <= yog_lat_max degrees
+                                                              ! (NN was trained on tropical SAM data; applying
+                                                              ! it at high latitudes/cold columns produced an
+                                                              ! out-of-distribution blow-up that crashed CLUBB)
 
 
    ! Public methods
@@ -51,7 +53,7 @@ contains
 
 subroutine yog_readnl(nlfile)
 
-   use spmd_utils,      only: mpi_character, masterprocid, mpicom
+   use spmd_utils,      only: mpi_character, mpi_real8, masterprocid, mpicom
    use namelist_utils,  only: find_group_name
    use units,           only: getunit, freeunit
 
@@ -61,7 +63,7 @@ subroutine yog_readnl(nlfile)
    integer :: unitn, ierr
    character(len=*), parameter :: subname = 'yog_readnl'
 
-   namelist /yog_params_nl/ yog_nn_weights,  yog_nn_scale, SAM_sounding
+   namelist /yog_params_nl/ yog_nn_weights,  yog_nn_scale, SAM_sounding, yog_lat_max
    !-----------------------------------------------------------------------------
 
    if (masterproc) then
@@ -86,6 +88,8 @@ subroutine yog_readnl(nlfile)
    if (ierr /= 0) call endrun("yog_readnl: FATAL: mpi_bcast: yog_nn_scale")
    call mpi_bcast(SAM_sounding, len(SAM_sounding), mpi_character, masterprocid, mpicom, ierr)
    if (ierr /= 0) call endrun("yog_readnl: FATAL: mpi_bcast: SAM_sounding")
+   call mpi_bcast(yog_lat_max, 1, mpi_real8, masterprocid, mpicom, ierr)
+   if (ierr /= 0) call endrun("yog_readnl: FATAL: mpi_bcast: yog_lat_max")
 
 end subroutine yog_readnl
 
@@ -116,6 +120,16 @@ subroutine yog_init()
   call addfld ('PREC_YOG',   horiz_only ,  'A', 'm/s','Surface preciptation - Yuval-OGorman convection')
   call addfld ('YOGDNUMLIQ', (/ 'lev' /),  'A', 'N/s','Cloud liq number conc. tendency - Yuval-OGorman convection')
   call addfld ('YOGDNUMICE', (/ 'lev' /),  'A', 'N/s','Cloud ice number conc. tendency - Yuval-OGorman convection')
+
+  call addfld ('YOG_DQ_ADV  ',   (/ 'lev' /),  'A', '(kg/kg)/kg/s','Q subg. vert. adv. flux conv. - YOG ')
+  call addfld ('YOG_DQ_AUTO ',   (/ 'lev' /),  'A', '(kg/kg)/kg/s','Q cloud microphysics tend. - YOG')
+  call addfld ('YOG_DQ_SED  ',   (/ 'lev' /),  'A', '(kg/kg)/kg/s','Q cloud ice sediment. flux conv. - YOG')
+  call addfld ('YOG_DT_ADV  ',   (/ 'lev' /),  'A', 'J/kg/s','H subg. vert. adv. flux conv. - YOG')
+  call addfld ('YOG_DT_AUTO ',   (/ 'lev' /),  'A', 'J/kg/s','H cloud microphysics tend. - YOG')
+  call addfld ('YOG_DT_SED  ',   (/ 'lev' /),  'A', 'J/kg/s','H cloud ice sediment. flux conv. - YOG')
+  call addfld ('YOG_DT_RAD  ',   (/ 'lev' /),  'A', 'J/kg/s','H radiative & phase change tend. - YOG')
+  call addfld ('YOG_DT_ADVFLX  ',   (/ 'lev' /),  'A', 'J/m2/s','H subg. vert. adv. flux - YOG')
+
   if (masterproc) then
      write(iulog,*)'YOG output fields added to buffer'
   end if
@@ -131,6 +145,15 @@ subroutine yog_init()
      call add_default('PREC_YOG', history_budget_histfile_num, ' ')
      call add_default('YOGDNUMLIQ', history_budget_histfile_num, ' ')
      call add_default('YOGDNUMICE', history_budget_histfile_num, ' ')
+
+     call add_default('YOG_DQ_ADV ' , history_budget_histfile_num, ' ')
+     call add_default('YOG_DQ_AUTO' , history_budget_histfile_num, ' ')
+     call add_default('YOG_DQ_SED ' , history_budget_histfile_num, ' ')
+     call add_default('YOG_DT_ADV ' , history_budget_histfile_num, ' ')
+     call add_default('YOG_DT_AUTO' , history_budget_histfile_num, ' ')
+     call add_default('YOG_DT_SED ' , history_budget_histfile_num, ' ')
+     call add_default('YOG_DT_RAD ' , history_budget_histfile_num, ' ')
+     call add_default('YOG_DT_ADVFLX ' , history_budget_histfile_num, ' ')
   end if
 
   call nn_convection_flux_CAM_init(yog_nn_weights, yog_nn_scale, SAM_sounding)
@@ -138,6 +161,7 @@ subroutine yog_init()
      write(iulog,*)'yog_nn_weights at: ', yog_nn_weights
      write(iulog,*)'yog_nn_scale at: ', yog_nn_scale
      write(iulog,*)'SAM_sounding at: ', SAM_sounding
+     write(iulog,*)'yog_lat_max at: ', yog_lat_max
      write(iulog,*)'YOG scheme initialised'
   endif
 
@@ -159,7 +183,7 @@ end subroutine yog_final
 
 !=========================================================================================
 
-subroutine yog_tend(ztodt, state, ptend, pbuf)
+subroutine yog_tend(ztodt, state, ptend, pbuf, landfrac)
 
 !----------------------------------------
 ! Purpose:  tendency calculation for YOG scheme
@@ -180,11 +204,11 @@ subroutine yog_tend(ztodt, state, ptend, pbuf)
    type(physics_buffer_desc), pointer       :: pbuf(:)
 
    real(r8), intent(in) :: ztodt                       ! 2 delta t (model time increment)
+   real(r8), intent(in) :: landfrac(pcols)             ! Land fraction
 
    ! Local variables
 
    integer :: i, k
-   integer :: nstep
    integer :: ixcldice, ixcldliq      ! constituent indices for cloud liquid and ice water.
    integer :: ixnumice, ixnumliq      ! constituent indices for cloud liquid and ice number concentration.
    integer :: lchnk                   ! chunk identifier
@@ -192,6 +216,10 @@ subroutine yog_tend(ztodt, state, ptend, pbuf)
 
    real(r8) :: ftem(pcols,pver)       ! Temporary workspace for outfld variables
    real(r8) :: num_tem                ! Temporary holder for number tendency
+
+   real(r8) :: q_delta_adv(pcols,pver), q_delta_auto(pcols,pver), q_delta_sed(pcols,pver), &
+               t_delta_adv(pcols,pver), t_delta_auto(pcols,pver), t_delta_sed(pcols,pver), &
+               t_delta_rad(pcols,pver), t_flux_adv(pcols,pver)
 
    logical  :: lq(pcnst)
 
@@ -217,12 +245,44 @@ subroutine yog_tend(ztodt, state, ptend, pbuf)
    call nn_convection_flux_CAM(state%pmid(:,pver:1:-1), state%pint(:,pverp:1:-1), state%ps, &
                                state%t(:,pver:1:-1), state%q(:,pver:1:-1,1), &
                                state%q(:,pver:1:-1,ixcldliq), state%q(:,pver:1:-1,ixcldice), &
+                               state%phis, state%zm(:,pver:1:-1), &
+                               landfrac, state%ps, &
                                cpair, &
                                ztodt, &
                                ncol, &
                                yog_precsfc, &
                                ptend%q(:,pver:1:-1,ixcldice), ptend%q(:,pver:1:-1,1), &
-                               ptend%q(:,pver:1:-1,ixcldliq), ptend%s(:,pver:1:-1))
+                               ptend%q(:,pver:1:-1,ixcldliq), ptend%s(:,pver:1:-1), &
+                               q_delta_adv(:,pver:1:-1), q_delta_auto(:,pver:1:-1), &
+                               q_delta_sed(:,pver:1:-1), t_delta_adv(:,pver:1:-1), &
+                               t_delta_auto(:,pver:1:-1), t_delta_sed(:,pver:1:-1), &
+                               t_delta_rad(:,pver:1:-1), t_flux_adv(:,pver:1:-1))
+
+
+   ! Restrict YOG to the tropics: the NN was trained on tropical SAM data,
+   ! and applying it at high latitudes/cold columns produced an
+   ! out-of-distribution tendency blow-up that crashed CLUBB (see job
+   ! 6514906, nstep 1254, lat~68N: YOGDT reached 0.55 K/s). ZM continues
+   ! to handle deep convection everywhere regardless of this mask, since
+   ! YOG is an additive correction applied after convect_deep_tend.
+   do i = 1, ncol
+      if (abs(state%lat(i)) * 180._r8/pi > yog_lat_max) then
+         ptend%s(i,:pver)          = 0._r8
+         ptend%q(i,:pver,1)        = 0._r8
+         ptend%q(i,:pver,ixcldice) = 0._r8
+         ptend%q(i,:pver,ixcldliq) = 0._r8
+         yog_precsfc(i)            = 0._r8
+         q_delta_adv(i,:pver)      = 0._r8
+         q_delta_auto(i,:pver)     = 0._r8
+         q_delta_sed(i,:pver)      = 0._r8
+         t_delta_adv(i,:pver)      = 0._r8
+         t_delta_auto(i,:pver)     = 0._r8
+         t_delta_sed(i,:pver)      = 0._r8
+         t_delta_rad(i,:pver)      = 0._r8
+         t_flux_adv(i,:pver)       = 0._r8
+      end if
+   end do
+
 
    ftem(:ncol,:pver) = ptend%s(:ncol,:pver)/cpair
    call outfld('YOGDT   ',ftem               ,pcols   ,lchnk   )
@@ -231,38 +291,49 @@ subroutine yog_tend(ztodt, state, ptend, pbuf)
    call outfld('YOGDLIQ ',ptend%q(1,1,ixcldliq) ,pcols   ,lchnk   )
    call outfld('PREC_YOG',yog_precsfc ,pcols   ,lchnk   )
 
+   call outfld('YOG_DQ_ADV   ',q_delta_adv ,pcols   ,lchnk   )
+   call outfld('YOG_DQ_AUTO  ',q_delta_auto,pcols   ,lchnk   )
+   call outfld('YOG_DQ_SED   ',q_delta_sed ,pcols   ,lchnk   )
+   call outfld('YOG_DT_ADV   ',t_delta_adv ,pcols   ,lchnk   )
+   call outfld('YOG_DT_AUTO  ',t_delta_auto,pcols   ,lchnk   )
+   call outfld('YOG_DT_SED   ',t_delta_sed ,pcols   ,lchnk   )
+   call outfld('YOG_DT_RAD   ',t_delta_rad ,pcols   ,lchnk   )
+   call outfld('YOG_DT_ADVFLX   ', t_flux_adv,pcols   ,lchnk   )
+
+
    ! Add prec_yog to prec_dp for passing to physpkg and coupler
    ! Note that prec_dp is initialised in the physics buffer and zeroed for deep_scheme='off'
    prec(:ncol) = prec(:ncol) + yog_precsfc(:ncol)
 
-   !======== NUMBER CONCENTRATION IS CURRENTLY NOT SET AS IT DETRIMENTALLY IMPACTS THE 
-   !         RESULTS HOWEVER, THE CODE FOR THE CALCULATION IS KEPT BELOW, COMMENTED OUT
-   ! ! Update the number concentration tendencies for liquid and ice species for all cells
-   ! ! Match calculations in the `clubb_tend_cam()` subroutine
-   ! ! YOG could produce negative number tendency, so we ensure it doesn't reduce total
-   ! ! number concentration below 0.0 - note that a check on this is also made in physics_update()
-   ! call cnst_get_ind('NUMLIQ', ixnumliq)
-   ! call cnst_get_ind('NUMICE', ixnumice)
-   ! do k = 1, pver
-   ! do i = 1, ncol
-   !    ! Liquid
-   !    num_tem = 3. * ptend%q(i,k,ixcldliq) / (4.0*3.14* 8.0e-6**3*997.0)
-   !    if (num_tem .lt. 0) then
-   !       ptend%q(i,k,ixnumliq) = - min(-num_tem, state%q(i,k,ixnumliq)/ztodt)
-   !    else
-   !       ptend%q(i,k,ixnumliq) = num_tem
-   !    endif
-   !    ! Ice
-   !    num_tem = 3. * ptend%q(i,k,ixcldice) / (4.0*3.14*25.0e-6**3*500.0)
-   !    if (num_tem .lt. 0) then
-   !       ptend%q(i,k,ixnumice) = - min(-num_tem, state%q(i,k,ixnumice)/ztodt)
-   !    else
-   !       ptend%q(i,k,ixnumice) = num_tem
-   !    endif
-   ! end do
-   ! end do
-   ! call outfld('YOGDNUMLIQ ',ptend%q(1,1,ixnumliq) ,pcols   ,lchnk   )
-   ! call outfld('YOGDNUMICE ',ptend%q(1,1,ixnumice) ,pcols   ,lchnk   )
+
+   ! Update the number concentration tendencies for liquid and ice species for all cells
+   ! Match calculations in the `clubb_tend_cam()` subroutine
+   ! YOG could produce negative number tendency, so we ensure it doesn't reduce total
+   ! number concentration below 0.0 - note that a check on this is also made in physics_update()
+   call cnst_get_ind('NUMLIQ', ixnumliq)
+   call cnst_get_ind('NUMICE', ixnumice)
+   do k = 1, pver
+   do i = 1, ncol
+      ! Liquid
+      num_tem = 3. * ptend%q(i,k,ixcldliq) / (4.0*3.14* 8.0e-6**3*997.0)
+      if (num_tem .lt. 0) then
+         ptend%q(i,k,ixnumliq) = - min(-num_tem, state%q(i,k,ixnumliq)/ztodt)
+      else
+         ptend%q(i,k,ixnumliq) = num_tem
+      endif
+      ! Ice
+      num_tem = 3. * ptend%q(i,k,ixcldice) / (4.0*3.14*25.0e-6**3*500.0) * 0.2
+      if (num_tem .lt. 0) then
+         ptend%q(i,k,ixnumice) = - min(-num_tem, state%q(i,k,ixnumice)/ztodt)
+      else
+         ptend%q(i,k,ixnumice) = num_tem
+      endif
+   end do
+   end do
+
+   call outfld('YOGDNUMLIQ ',ptend%q(1,1,ixnumliq) ,pcols   ,lchnk   )
+   call outfld('YOGDNUMICE ',ptend%q(1,1,ixnumice) ,pcols   ,lchnk   )
+
 
 end subroutine yog_tend
 


### PR DESCRIPTION
## Summary
- Refreshes the YOG deep-convection integration from cesm3_0_alpha07f to cesm3_0_alpha09e (CAM cam6_4_186)
- Updates all src/cam/*.F90 files, adds the previously-missing SAM_consts.F90, and updates the CAM namelist XML files
- Fixes a CMake/Catamount shared-library build failure in libraries/FTorch/buildlib, surfaced by Derecho's 24.12->25.10 default module stack upgrade
- Expands the README and build instructions with the concrete porting/build gotchas hit along the way: the physpkg.F90 merge needed for upstream CAM changes near the YOG hook, the nested FTorch submodule init issue, the USE_FTORCH=TRUE requirement, the CMake/Catamount fix, and the yog_lat_max=30 default (a prior global-application test crashed CLUBB around simulated day 26)

## Test plan
- [x] Built cleanly on Derecho (F2000climo/f09_f09_mg17)
- [x] 1-day smoke test run completed with yog_scheme='on' -- scheme initializes and produces output with no crash