### PR TITLE
Add TAU_ML_microphysics: 9-input ML warm-rain autoconversion emulator

### DIFF
--- a/TAU_ML_microphysics/README.md
+++ b/TAU_ML_microphysics/README.md
@@ -1,0 +1,225 @@
+# ML Warm-Rain Microphysics (TAU Emulator) Integration
+
+This folder documents and provides sources for a neural-network emulator of
+the TAU bin-resolved warm-rain (cloud-rain autoconversion/accretion)
+microphysics scheme in CESM/CAM, implemented as a self-contained Fortran +
+netCDF neural network (no FTorch/PyTorch dependency).
+
+- **Component:** CAM (CESM3), PUMAS microphysics package
+- **What's replaced:** the deterministic bin-resolved TAU warm-rain
+  calculation (`pumas_stochastic_collect_tau.F90`) with a fast NN surrogate,
+  selected via the existing `micro_mg_warm_rain = 'emulated'` namelist option
+- **Key idea:** PUMAS already had a namelist-selectable `'emulated'` scheme
+  path upstream; this integration swaps in a 9-input neural network (with
+  droplet/rain size-distribution shape parameters as inputs and dual
+  forward/inverse quantile interpolation) in place of upstream's simpler
+  7-input version
+
+## ⚠️ Requires CAM7 physics (`-phys cam7`)
+
+`micro_mg_warm_rain` and the whole `'tau'`/`'emulated'` scheme selection only
+exist in the **CAM7** physics driver
+(`src/atmos_phys` → `src/physics/cam7/micro_pumas_cam.F90`). They are
+**absent** from the CAM6 driver (`src/physics/cam/micro_pumas_cam.F90`).
+Using a CAM6-physics compset (e.g. `F2000climo`, which defaults to
+`-phys cam6`) will fail at startup with:
+
+```
+micro_pumas_cam_readnl:: ERROR reading namelist
+```
+
+because the Fortran namelist reader chokes on `micro_mg_warm_rain` as an
+unrecognized variable in `&micro_mg_nl`. Use a CAM7-native compset instead,
+e.g. `F2000dev` (`2000_CAM70_CLM60%SP_...`).
+
+## Repository Structure
+
+```text
+TAU_ML_microphysics/
+├── src/
+│   ├── module_neural_net.F90       # Dense NN layers, activations, forward/inverse quantile interpolation
+│   ├── tau_neural_net_quantile.F90 # TAU emulator driver: builds NN inputs, calls the model, returns tendencies
+│   ├── tester.F90                  # Debug utility (write_test_values), used by tau_neural_net_quantile.F90
+│   ├── micro_pumas_v1.F90          # Modified: 'emulated' branch call site (NN inputs, in-cloud rescaling)
+│   ├── micro_pumas_utils.F90       # Modified: added qsmall_emulator threshold
+│   └── ML_fixer_check.F90          # Unmodified from upstream v1.39; included for reference (part of the call chain)
+│
+├── bld/
+│   └── namelist_files/
+│       ├── namelist_defaults_cam.xml
+│       └── namelist_definition.xml
+│
+├── docs/
+│   └── build_instructions.md
+│
+└── README.md
+```
+
+Note: `pumas_stochastic_collect_tau.F90` (the deterministic bin-resolved TAU
+scheme, selected by `micro_mg_warm_rain = 'tau'`) is **not** included here —
+it's a separate, mutually-exclusive code path from the ML `'emulated'`
+scheme, and was left untouched during this integration (its own
+`lcldm`/`precip_frac` handling changed independently upstream between PUMAS
+`v1.36` and `v1.39`, unrelated to this ML work).
+
+---
+
+## Prerequisites
+
+- CESM3 (tested with `cesm3_0_alpha09e`, base CAM tag `cam6_4_186`,
+  PUMAS `pumas_cam-release_v1.39`)
+- CAM7 physics package (`-phys cam7`) — see warning above
+- No FTorch/PyTorch dependency — this is pure Fortran + netCDF
+
+## Overview of Integration
+
+```
+micro_pumas_v1.F90 (micro_pumas_tend, 'emulated' branch)
+         ↓
+tau_neural_net_quantile.F90 (tau_emulated_cloud_rain_interactions)
+         ↓
+module_neural_net.F90 (neural_net_predict, quantile_transform/quantile_inv_transform)
+```
+
+### 1. `micro_pumas_v1.F90` — Call Site
+
+**Purpose:** Selects and drives the ML emulator when
+`micro_mg_warm_rain = 'emulated'` (mutually exclusive with `'tau'`,
+`'sb2001'`, `'kk2000'`).
+
+**Key changes vs. upstream v1.39's `'emulated'` branch:**
+
+- Passes cloud/rain size-distribution shape parameters (`pgam`, `lamc`,
+  `lamr`, `n0r` — already computed elsewhere in this subroutine for the
+  deterministic scheme) into the NN call, in addition to the in-cloud/
+  in-precip state (`qcic`, `ncic`, `qric`, `nric`) upstream already uses:
+
+  ```fortran
+  call tau_emulated_cloud_rain_interactions(qcic(1:mgncol,k), ncic(1:mgncol,k), &
+                                            qric(1:mgncol,k), nric(1:mgncol,k), &
+                                            pgam(1:mgncol,k), lamc(1:mgncol,k), &
+                                            lamr(1:mgncol,k), n0r(1:mgncol,k), &
+                                            rho(1:mgncol,k), lcldm(1:mgncol,k), &
+                                            precip_frac(1:mgncol,k), mgncol, qsmall_emulator, &
+                                            proc_rates%qctend_TAU(1:mgncol,k), &
+                                            proc_rates%qrtend_TAU(1:mgncol,k), &
+                                            proc_rates%nctend_TAU(1:mgncol,k), &
+                                            proc_rates%nrtend_TAU(1:mgncol,k))
+  ```
+
+- Uses a dedicated `qsmall_emulator` threshold (1e-8) instead of the general
+  `qsmall` (1e-18).
+
+- `ML_fixer_calc` is called with in-cloud/in-precip values (`qcic`/`ncic`/
+  `qric`/`nric`) rather than grid-mean values.
+
+- After both calls, rescales the resulting tendencies by `lcldm`/
+  `precip_frac` to convert from in-cloud/in-precip space back to grid-box
+  means:
+
+  ```fortran
+  do i=1,mgncol
+     prc(i,k)  = -proc_rates%qctend_TAU(i,k) * lcldm(i,k)
+     nprc1(i,k)= -proc_rates%nctend_TAU(i,k) * lcldm(i,k)
+  end do
+  do i=1,mgncol
+     if (proc_rates%nrtend_TAU(i,k) > 0._r8) then
+        nprc(i,k)  = proc_rates%nrtend_TAU(i,k) * precip_frac(i,k)
+     else
+        nragg(i,k) = proc_rates%nrtend_TAU(i,k) * precip_frac(i,k)
+     end if
+  end do
+  ```
+
+### 2. `tau_neural_net_quantile.F90` — Emulator Driver
+
+**Purpose:** Builds the 9-element NN input vector, runs it through the
+quantile-transformed neural network, and returns tendencies.
+
+**Key difference vs. upstream's 7-input version:**
+
+```fortran
+integer, parameter :: num_inputs = 9   ! upstream v1.39: 7
+
+nn_inputs(1,1) = qc(i);   nn_inputs(1,2) = qr(i)
+nn_inputs(1,3) = nc(i);   nn_inputs(1,4) = nr(i)
+nn_inputs(1,5) = pgam(i); nn_inputs(1,6) = lamc(i)
+nn_inputs(1,7) = lamr(i); nn_inputs(1,8) = n0r(i)
+nn_inputs(1,9) = rho(i)
+```
+
+Upstream's 7-input version uses `precip_frac`/`lcldm` as direct NN inputs
+instead of the size-distribution shape parameters; this version instead
+applies `lcldm`/`precip_frac` as a rescaling step after the NN call (see
+`micro_pumas_v1.F90` above).
+
+### 3. `module_neural_net.F90` — NN Math
+
+**Purpose:** Dense-layer neural network primitives (matrix multiply via
+`dgemm`, activation functions) and quantile-based input/output scaling.
+
+**Key difference vs. upstream:** two separate interpolation routines,
+`linear_interp_forward` and `linear_interp_inverse`, instead of a single
+shared `linear_interp` — used respectively by `quantile_transform` (inputs)
+and `quantile_inv_transform` (outputs).
+
+### 4. `tester.F90`
+
+Debug utility (`write_test_values`) — writes NN input/output arrays to a
+file for offline validation. `tau_neural_net_quantile.F90` imports this
+module but does not currently call it in the main code path.
+
+## Configuration
+
+### Namelist Configuration
+
+```fortran
+&micro_mg_nl
+  micro_mg_warm_rain = 'emulated'
+/
+
+&stochastic_emulated_nl
+  stochastic_emulated_filename_quantile     = '/path/to/quantile_neural_net_fortran.nc'
+  stochastic_emulated_filename_input_scale  = '/path/to/input_quantile_scaler.nc'
+  stochastic_emulated_filename_output_scale = '/path/to/output_quantile_scaler.nc'
+/
+```
+
+These namelist variables and groups already exist in upstream
+`namelist_definition.xml` (`stochastic_emulated_nl`) — no new namelist
+entries were needed for this integration, only the underlying Fortran.
+
+## Required Input Files
+
+1. **NN weights file** (`quantile_neural_net_fortran.nc`) — dense-layer
+   weights/biases/activations, one dimension pair per layer
+   (`dense_NN_in`/`dense_NN_out`). Must have `dense_00_in = 9` to match this
+   9-input model.
+2. **Input quantile scaler** (`input_quantile_scaler.nc`) — `column`
+   dimension must be 9, matching the input feature count.
+3. **Output quantile scaler** (`output_quantile_scaler.nc`) — matches the
+   3 NN outputs (`qc`/`nc`/`nr` tendencies).
+
+Verify weight-file compatibility before running:
+```
+ncdump -h quantile_neural_net_fortran.nc | grep dense_00_in
+ncdump -h input_quantile_scaler.nc | grep column
+```
+Both should show `9`.
+
+## Provenance
+
+Ported from the `wkchuang/PUMAS` fork
+(https://github.com/wkchuang/PUMAS, branch `1nn_tau_emulator`, commit
+`8b76bac`) onto the CCPP-ized `pumas_cam-release_v1.39` baseline (PUMAS
+moved from a standalone `src/physics/pumas` submodule to a nested submodule
+under `src/atmos_phys/schemes/pumas/pumas` between these two states, and the
+fork's `shr_kind_mod` usage was adapted to this codebase's host-agnostic
+`pumas_kinds` module).
+
+## References
+
+- Based on the TAU bin-resolved stochastic collection scheme
+  (Morrison/Lebo, Gettelman and Chen 2018)
+- PUMAS: https://github.com/ESCOMP/PUMAS
+- ML fork: https://github.com/wkchuang/PUMAS (branch `1nn_tau_emulator`)

--- a/TAU_ML_microphysics/bld/namelist_files/namelist_defaults_cam.xml
+++ b/TAU_ML_microphysics/bld/namelist_files/namelist_defaults_cam.xml
@@ -1,0 +1,4289 @@
+<?xml version="1.0"?>
+
+<namelist_defaults>
+
+<!-- Timestep size (this is the atm coupling interval) -->
+<dtime dyn="fv"                    >1800</dtime>
+<dtime dyn="fv"    waccmx="1"      >300 </dtime>
+
+<dtime dyn="fv3"                   >1800</dtime>
+<dtime dyn="fv3"   waccmx="1"      >300 </dtime>
+<dtime dyn="fv3"   hgrid="C24"     >1800</dtime>
+<dtime dyn="fv3"   hgrid="C48"     >1800</dtime>
+<dtime dyn="fv3"   hgrid="C96"     >1800</dtime>
+<dtime dyn="fv3"   hgrid="C192"    >900</dtime>
+<dtime dyn="fv3"   hgrid="C384"    >450</dtime>
+
+<dtime dyn="se"                    >1800</dtime>
+<dtime dyn="se"    waccmx="1"      >300 </dtime>
+<dtime dyn="se"    hgrid="ne5np4"  >1800</dtime>
+<dtime dyn="se"    hgrid="ne16np4" >1800</dtime>
+<dtime dyn="se"    hgrid="ne30np4" >1800</dtime>
+<dtime dyn="se"    hgrid="ne60np4" > 900</dtime>
+<dtime dyn="se"    hgrid="ne120np4"> 450</dtime>
+<dtime dyn="se"    hgrid="ne240np4"> 225</dtime>
+<dtime dyn="se"    hgrid="ne0np4CONUS.ne30x8">225</dtime>
+<dtime dyn="se"    hgrid="ne0np4.ARCTIC.ne30x4">450</dtime>
+<dtime dyn="se"    hgrid="ne0np4.ARCTICGRIS.ne30x8">225</dtime>
+<dtime dyn="se"    hgrid="ne0np4.POLARCAP.ne30x4">450</dtime>
+<dtime dyn="se"    hgrid="ne0np4.NATL.ne30x8">225</dtime>
+
+<dtime dyn="mpas"                  >1800</dtime>
+
+<!-- Initial files -->
+
+<!-- Vertical coordinates only -->
+<ncdata nlev="26" analytic_ic="1" >atm/cam/inic/cam_vcoords_L26_c180105.nc</ncdata>
+<ncdata nlev="30" analytic_ic="1" >atm/cam/inic/cam_vcoords_L30_c180105.nc</ncdata>
+<ncdata nlev="32" analytic_ic="1" >atm/cam/inic/cam_vcoords_L32_c180105.nc</ncdata>
+<ncdata nlev="58" analytic_ic="1" >atm/cam/inic/cam_vcoords_L58_c250227.nc</ncdata>
+
+<!-- Vertical/Horizontal coordinates only - MPAS initial files for analytic cases-->
+<ncdata hgrid="mpasa120" nlev="26" analytic_ic="1" >atm/cam/inic/mpas/mpasa120_L26_notopo_coords_c251105.nc</ncdata>
+<ncdata hgrid="mpasa480" nlev="32" analytic_ic="1" >atm/cam/inic/mpas/mpasa480_L32_notopo_coords_c240507.nc</ncdata>
+<ncdata hgrid="mpasa120" nlev="32" analytic_ic="1" >atm/cam/inic/mpas/mpasa120_L32_notopo_coords_c240507.nc</ncdata>
+<ncdata hgrid="mpasa60"  nlev="32" analytic_ic="1" >atm/cam/inic/mpas/mpasa60_L32_notopo_coords_c240507.nc</ncdata>
+<ncdata hgrid="mpasa30"  nlev="32" analytic_ic="1" >atm/cam/inic/mpas/mpasa30_L32_notopo_coords_c240507.nc</ncdata>
+<ncdata hgrid="mpasa480" nlev="58" analytic_ic="1" >atm/cam/inic/mpas/mpasa480_L58_notopo_coords_c240814.nc</ncdata>
+<ncdata hgrid="mpasa120" nlev="58" analytic_ic="1" >atm/cam/inic/mpas/mpasa120_L58_notopo_coords_c240814.nc</ncdata>
+<ncdata hgrid="mpasa60"  nlev="58" analytic_ic="1" >atm/cam/inic/mpas/mpasa60_L58_notopo_coords_c240814.nc</ncdata>
+<ncdata hgrid="mpasa480" nlev="93" analytic_ic="1" >atm/cam/inic/mpas/mpasa480_L93_notopo_coords_c240814.nc</ncdata>
+<ncdata hgrid="mpasa120" nlev="93" analytic_ic="1" >atm/cam/inic/mpas/mpasa120_L93_notopo_coords_c240814.nc</ncdata>
+<ncdata hgrid="mpasa60"  nlev="93" analytic_ic="1" >atm/cam/inic/mpas/mpasa60_L93_notopo_coords_c240814.nc</ncdata>
+<!-- Next entries are mostly used in EarthWorks -->
+<ncdata hgrid="mpasa30"  nlev="58" analytic_ic="1" >atm/cam/inic/mpas/mpasa30_L58_notopo_coords_c240814.nc</ncdata>
+<ncdata hgrid="mpasa15"  nlev="58" analytic_ic="1" >atm/cam/inic/mpas/mpasa15_L58_notopo_coords_c240911.nc</ncdata>
+<!-- END EarthWorks specific -->
+
+<!-- FV Initial Conditions -->
+<ncdata hgrid="10x15" nlev="26"                    >atm/cam/inic/fv/cami_0000-01-01_10x15_L26_c030918.nc</ncdata>
+<ncdata hgrid="10x15" nlev="26" aquaplanet="1"     >atm/cam/inic/fv/aqua_0000-01-01_10x15_L26_c161230.nc</ncdata>
+<ncdata hgrid="10x15" nlev="26" chem="trop_mozart" >atm/cam/inic/fv/camchemi_0012-01-01_10x15_L26_c081104.nc</ncdata>
+<ncdata hgrid="10x15" nlev="26" chem="trop_mozart" ic_ymd="901" >atm/cam/chem/trop_mozart/ic/cami_0000-09-01_10x15_L26_c060216.nc</ncdata>
+<ncdata hgrid="10x15" nlev="30"                    >atm/cam/inic/fv/cami_0000-01-01_10x15_L30_c081013.nc</ncdata>
+<ncdata hgrid="10x15" nlev="30" aquaplanet="1"     >atm/cam/inic/fv/aqua_0000-01-01_10x15_L30_c170103.nc</ncdata>
+<ncdata hgrid="10x15" nlev="30" chem="trop_mozart" >atm/cam/inic/fv/camchemi_0012-01-01_10x15_L30_c081104.nc</ncdata>
+<ncdata hgrid="10x15" nlev="30" chem="trop_strat_mam4_vbs" >atm/cam/inic/fv/trop_strat_mam3_chem_2000-01-01_10x15_L30_c121015.nc</ncdata>
+<ncdata hgrid="10x15" nlev="30" chem="trop_strat_mam5_t1s1" >atm/cam/inic/fv/trop_strat_mam3_chem_2000-01-01_10x15_L30_c121015.nc</ncdata>
+<ncdata hgrid="10x15" nlev="32"                    >atm/cam/inic/fv/cami-mam4_0000-01-01_10x15_L32_c170914.nc</ncdata>
+<ncdata hgrid="10x15" nlev="32" aquaplanet="1"     >atm/cam/inic/fv/aqua_0000-01-01_10x15_L32_c170103.nc</ncdata>
+<ncdata hgrid="10x15" nlev="32" chem="trop_strat_mam5_t1s1">atm/cam/inic/fv/FC2000mam5_f10_0002-01-01_c221214.nc</ncdata>
+<ncdata hgrid="10x15" nlev="32" carma="trop_strat_soa5"   >atm/cam/inic/fv/carma_trop_strat_2000_10x15_spinup01.cam.i.0002-01-01-00000_c211027.nc</ncdata>
+<ncdata hgrid="10x15" nlev="32" carma="trop_strat_soa5" aquaplanet="1">atm/cam/inic/fv/aqua_carma_trop_strat_10x15_spinup01.cam.i.0002-01-01-00000_c211027.nc</ncdata>
+<ncdata hgrid="10x15" nlev="66"                    >atm/waccm/ic/cami_2000-01-01_10x15_L66_c041121.nc</ncdata>
+<ncdata hgrid="10x15" nlev="70"  carma="trop_strat_soa1" aquaplanet="1">atm/waccm/ic/aqua_carma_waccm_0002-01-01_10x15_L70_c220325.nc</ncdata>
+<ncdata hgrid="10x15" nlev="70"                    >atm/waccm/ic/f2000.waccm-mam3_10x15_L70.cam2.i.0017-01-01.c141016.nc</ncdata>
+<ncdata hgrid="10x15" nlev="81"  waccmx="1"        >atm/waccm/ic/WAX3548T08CO_2003top_f2000.waccm_0017bottom_10x15_L81_c141027.nc</ncdata>
+
+<ncdata hgrid="4x5" nlev="26"                      >atm/cam/inic/fv/cami_0001-01-01_4x5_L26_c060608.nc</ncdata>
+<ncdata hgrid="4x5" nlev="26" chem="trop_mozart"   >atm/cam/inic/fv/camchemi_0012-01-01_4x5_L26_c081104.nc</ncdata>
+<ncdata hgrid="4x5" nlev="26" chem="trop_mozart" ic_ymd="901" >atm/cam/chem/trop_mozart/ic/cami_0000-09-01_4x5_L26_c060217.nc</ncdata>
+<ncdata hgrid="4x5" nlev="30"                      >atm/cam/inic/fv/cami_0000-01-01_4x5_L30_c090108.nc</ncdata>
+<ncdata hgrid="4x5" nlev="30" chem="trop_mozart"   >atm/cam/inic/fv/camchemi_0012-01-01_4x5_L30_c081104.nc</ncdata>
+<ncdata hgrid="4x5" nlev="30" chem="trop_strat_mam4_vbs" >atm/cam/inic/fv/trop_strat_mam3_chem_2000-01-01_4x5_L30_c121015.nc</ncdata>
+<ncdata hgrid="4x5" nlev="30" chem="trop_strat_mam5_t1s1" >atm/cam/inic/fv/trop_strat_mam3_chem_2000-01-01_4x5_L30_c121015.nc</ncdata>
+<ncdata hgrid="4x5" nlev="66"                      >atm/waccm/ic/wa3_4x5_1950_spinup.cam2.i.1960-01-01-00000.nc</ncdata>
+<ncdata hgrid="4x5" nlev="66"  chem="waccm_ma_sulfur" >atm/waccm/ic/f40.2000.4deg.wcm.carma.sulf.004.cam2.i.0008-01-01-00000.nc</ncdata>
+<ncdata hgrid="4x5" nlev="70"                      >atm/waccm/ic/f2000.waccm-mam3_4x5_L70.cam2.i.0017-01-01.c121113.nc</ncdata>
+<ncdata hgrid="4x5" nlev="81"  waccmx="1"          >atm/waccm/ic/WAX3548T08CO_2003top_f2000.waccm_0017bottom_4x5_L81_c160630.nc</ncdata>
+<ncdata hgrid="4x5" nlev="126" waccmx="1" aquaplanet="1">atm/waccm/ic/waccmx_aqua_4x5_L126_c170705.nc</ncdata>
+<ncdata hgrid="4x5" nlev="130" waccmx="1" aquaplanet="1">atm/waccm/ic/waccmx_mam4_aqua_4x5_L130_c180803.nc</ncdata>
+
+<ncdata hgrid="2.5x3.33" nlev="26"                >atm/cam/inic/fv/cami_0000-01-01_2.5x3.33_L26_c110309.nc</ncdata>
+<ncdata hgrid="2.5x3.33" nlev="26" ic_ymd="901"   >atm/cam/inic/fv/cami_0000-09-01_2.5x3.33_L26_c091007.nc</ncdata>
+<ncdata hgrid="2.5x3.33" nlev="30"                >atm/cam/inic/fv/cami_0000-01-01_2.5x3.33_L30_c110309.nc </ncdata>
+<ncdata hgrid="2.5x3.33" nlev="30" ic_ymd="901"   >atm/cam/inic/fv/cami_0000-09-01_2.5x3.33_L30_c100831.nc</ncdata>
+
+<ncdata hgrid="1.9x2.5" nlev="26"                 >atm/cam/inic/fv/cami_0000-01-01_1.9x2.5_L26_c070408.nc</ncdata>
+<ncdata hgrid="1.9x2.5" nlev="26" ic_ymd="901"    >atm/cam/inic/fv/cami_0000-09-01_1.9x2.5_L26_c040809.nc</ncdata>
+<ncdata hgrid="1.9x2.5" nlev="26" aquaplanet="1"  >atm/cam/inic/fv/aqua_0006-01-01_1.9x2.5_L26_c161020.nc</ncdata>
+<ncdata hgrid="1.9x2.5" nlev="26" chem="trop_mozart" >atm/cam/inic/fv/camchemi_0012-01-01_1.9x2.5_L26_c081104.nc</ncdata>
+<ncdata hgrid="1.9x2.5" nlev="26" chem="trop_mozart" ic_ymd="19900101" >atm/cam/inic/fv/cami-chem_1990-01-01_1.9x2.5_L26_c080114.nc</ncdata>
+<ncdata hgrid="1.9x2.5" nlev="30"                  >atm/cam/inic/fv/cami-mam3_0000-01-01_1.9x2.5_L30_c090306.nc</ncdata>
+<ncdata hgrid="1.9x2.5" nlev="30" ic_ymd="901"     >atm/cam/inic/fv/cami_0000-09-01_1.9x2.5_L30_c070109.nc</ncdata>
+<ncdata hgrid="1.9x2.5" nlev="30" aquaplanet="1"   >atm/cam/inic/fv/aqua_0006-01-01_1.9x2.5_L30_c161020.nc</ncdata>
+<ncdata hgrid="1.9x2.5" nlev="30" chem="trop_strat_mam4_vbs" >atm/cam/inic/fv/trop_strat_mam3_chem_2000-01-01_1.9x2.5_L30_c121015.nc</ncdata>
+<ncdata hgrid="1.9x2.5" nlev="30" chem="trop_strat_mam5_t1s1" >atm/cam/inic/fv/trop_strat_mam3_chem_2000-01-01_1.9x2.5_L30_c121015.nc</ncdata>
+<ncdata hgrid="1.9x2.5" nlev="30" chem="trop_mozart"                   >atm/cam/inic/fv/camchemi_0012-01-01_1.9x2.5_L30_c081104.nc</ncdata>
+<ncdata hgrid="1.9x2.5" nlev="30" chem="trop_mozart" ic_ymd="19900101" >atm/cam/inic/fv/cami-chem_1990-01-01_1.9x2.5_L30_c080215.nc</ncdata>
+<ncdata hgrid="1.9x2.5" nlev="32"                  >atm/cam/inic/fv/cami-mam3_0000-01-01_1.9x2.5_L32_c150407.nc</ncdata>
+<ncdata hgrid="1.9x2.5" nlev="32" aquaplanet="1"   >atm/cam/inic/fv/aqua_0006-01-01_1.9x2.5_L32_c161020.nc</ncdata>
+<ncdata hgrid="1.9x2.5" nlev="32" carma="trop_strat_soa5" aquaplanet="1">atm/cam/inic/fv/QPCARMATS_f19_carmats4038_spinup01_0002-01-01_c241029.nc</ncdata>
+<ncdata hgrid="1.9x2.5" nlev="66"                  >atm/waccm/ic/cami_2000-07-01_1.9x2.5_L66_c040928.nc</ncdata>
+<ncdata hgrid="1.9x2.5" nlev="66" chem="waccm_ma_sulfur" >atm/waccm/ic/f40.2deg.wcm.carma.sulf.L66.cam2.i.2010-01-01.nc</ncdata>
+<ncdata hgrid="1.9x2.5" nlev="70" ic_ymd="18500101" >atm/waccm/ic/b1850.waccm-mam3_1.9x2.5_L70.cam2.i.0156-01-01.c120523.nc</ncdata>
+<ncdata hgrid="1.9x2.5" nlev="70" ic_ymd="20000101" >atm/waccm/ic/f2000.waccm-mam3_1.9x2.5_L70.cam2.i.0017-01-01.c120410.nc</ncdata>
+<ncdata hgrid="1.9x2.5" nlev="70" aquaplanet="1" ic_ymd="20000101" >atm/waccm/ic/aqua.cam6.waccmsc_1.9x2.5_L70.2000-01-01.c170123.nc</ncdata>
+<ncdata hgrid="1.9x2.5" nlev="70" chem="waccm_tsmlt_mam4" aquaplanet="1" ic_ymd="20000101">atm/waccm/ic/aqua.waccm_tsmlt_1.9x2.5_L70_c170814.nc</ncdata>
+<ncdata hgrid="1.9x2.5" nlev="70" chem="waccm_ma_mam4" aquaplanet="1" ic_ymd="20000101" >atm/waccm/ic/aqua.waccm_tsmlt_1.9x2.5_L70_c170814.nc</ncdata>
+<ncdata hgrid="1.9x2.5" nlev="70" carma="trop_strat_soa1" ic_ymd="19800101">atm/waccm/ic/FWmaCARMAHIST_f19_carmats038_spinupl03.cam.i.1980-01-01_c241025.nc</ncdata>
+<ncdata hgrid="1.9x2.5" nlev="70" carma="trop_strat_soa1" aquaplanet="1" ic_ymd="101">atm/cam/inic/fv/aqua_carma_waccm_0002-01-01_1.9x2.5_L70_c220809.nc</ncdata>
+<ncdata hgrid="1.9x2.5" nlev="81" waccmx="1"        >atm/waccm/ic/WAX3548T08CO_2003top_f2000.waccm_0017bottom_L81_c110906.nc</ncdata>
+<ncdata hgrid="1.9x2.5" nlev="103"                  >atm/waccm/ic/cami_2000-05-01_1.9x2.5_L103_c040928.nc</ncdata>
+<ncdata hgrid="1.9x2.5" nlev="126" waccmx="1"       >atm/waccm/ic/f.c54137.FX2000climo.f19_f19.ZGTest.001.cam.i.0002-01-01-00000_c170817.nc</ncdata>
+<ncdata hgrid="1.9x2.5" nlev="130" waccmx="1"       >atm/waccm/ic/wcmx-cam6-phys_1.9x2.5_130lev_2000_c181115.nc</ncdata>
+<ncdata hgrid="1.9x2.5" nlev="130" waccmx="1" aquaplanet="1">atm/waccm/ic/waccmx_mam4_aqua_1.9x2.5_L130_c180803.nc</ncdata>
+
+<ncdata hgrid="0.9x1.25" nlev="26"                 >atm/cam/inic/fv/cami_1987-01-01_0.9x1.25_L26_c060703.nc</ncdata>
+<ncdata hgrid="0.9x1.25" nlev="26" ic_ymd="901"    >atm/cam/inic/fv/cami_0000-09-01_0.9x1.25_L26_c051205.nc</ncdata>
+<ncdata hgrid="0.9x1.25" nlev="26" aquaplanet="1"  >atm/cam/inic/fv/aqua_0006-01-01_0.9x1.25_L26_c161020.nc</ncdata>
+<ncdata hgrid="0.9x1.25" nlev="30"                 >atm/cam/inic/fv/cami-mam3_0000-01-01_0.9x1.25_L30_c100618.nc</ncdata>
+<ncdata hgrid="0.9x1.25" nlev="30" aquaplanet="1"  >atm/cam/inic/fv/aqua_0006-01-01_0.9x1.25_L30_c161020.nc</ncdata>
+<ncdata hgrid="0.9x1.25" nlev="30" chem="trop_mozart" >atm/cam/inic/fv/cami-chem_1990-01-01_0.9x1.25_L30_c080724.nc</ncdata>
+<ncdata hgrid="0.9x1.25" nlev="32"                 >atm/cam/inic/fv/cami-mam3_0000-01-01_0.9x1.25_L32_c141031.nc</ncdata>
+<ncdata hgrid="0.9x1.25" nlev="32" aquaplanet="1"  >atm/cam/inic/fv/aqua_0006-01-01_0.9x1.25_L32_c161020.nc</ncdata>
+<ncdata hgrid="0.9x1.25" nlev="32" chem="trop_strat_mam4_vbs">atm/cam/inic/fv/f.e22.FC2010climo.f09_f09_mg17.cam6_2_022.001.cam.i.0016-01-01-00000_c200610.nc</ncdata>
+<ncdata hgrid="0.9x1.25" nlev="32" chem="trop_strat_mam4_ts2">atm/cam/inic/fv/f.e22.FC2010climo.f09_f09_mg17.cam6_2_022.001.cam.i.0016-01-01-00000_c200610.nc</ncdata>
+<ncdata hgrid="0.9x1.25" nlev="32" chem="trop_strat_mam5_t1s1">atm/cam/inic/fv/f.e22.FC2010climo.f09_f09_mg17.cam6_2_022.001.cam.i.0016-01-01-00000_c200610.nc</ncdata>
+<ncdata hgrid="0.9x1.25" nlev="32" chem="trop_strat_mam5_t2s1">atm/cam/inic/fv/f.e22.FC2010climo.f09_f09_mg17.cam6_2_022.001.cam.i.0016-01-01-00000_c200610.nc</ncdata>
+<ncdata hgrid="0.9x1.25" nlev="66"                 >atm/waccm/ic/cami_2000-02-01_0.9x1.25_L66_c040928.nc</ncdata>
+<ncdata hgrid="0.9x1.25" nlev="70"                 >atm/waccm/ic/FWT2000_f09_spinup01.cam.i.0001-01-02-00000_c160315.nc</ncdata>
+<ncdata hgrid="0.9x1.25" nlev="70" carma="trop_strat_soa1">atm/waccm/ic/FWmaCARMAHIST_f09_spinup01.cam.i.1980-01-01-00000_c220128.nc</ncdata>
+<ncdata hgrid="0.9x1.25" nlev="126" waccmx="1">atm/waccm/ic/fx2000_0.9x1.25_126lev_0002-01-01-00000_c181221.nc</ncdata>
+<ncdata hgrid="0.9x1.25" nlev="130" waccmx="1">atm/waccm/ic/wcmx-cam6-phys_0.9x1.25_130lev_2000_c190122.nc</ncdata>
+
+<ncdata hgrid="0.5x0.625" nlev="26"                >atm/cam/inic/fv/cami_0000-10-01_0.5x0.625_L26_c031204.nc</ncdata>
+
+<ncdata hgrid="0.47x0.63" nlev="26"                >atm/cam/inic/fv/cami_1980-01-01_0.47x0.63_L26_c071226.nc</ncdata>
+<ncdata hgrid="0.47x0.63" nlev="26" ic_ymd="901"   >atm/cam/inic/fv/cami_0000-09-01_0.47x0.63_L26_c061106.nc</ncdata>
+<ncdata hgrid="0.47x0.63" nlev="26" aquaplanet="1" >atm/cam/inic/fv/cami_0000-01-01_0.47x0.63_L26_APE_c080227.nc</ncdata>
+<ncdata hgrid="0.47x0.63" nlev="30"                >atm/cam/inic/fv/cami-mam3_0000-01-01_0.47x0.63_L30_c100929.nc</ncdata>
+<ncdata hgrid="0.47x0.63" nlev="130" waccmx="1"    >atm/waccm/ic/FC6X2000_f05_spinup01.cam.i.0002-01-01-00000_c190711.nc</ncdata>
+
+<ncdata hgrid="0.23x0.31" nlev="26"                >atm/cam/inic/fv/cami_0000-01-01_0.23x0.31_L26_c100513.nc</ncdata>
+<ncdata hgrid="0.23x0.31" nlev="26" ic_ymd="901"   >atm/cam/inic/fv/cami_0000-09-01_0.23x0.31_L26_c061106.nc</ncdata>
+<ncdata hgrid="0.23x0.31" nlev="30"                >atm/cam/inic/fv/cami-mam3_0000-01-01_0.23x0.31_L30_c110527.nc</ncdata>
+
+<!-- SE Initial Conditions -->
+<ncdata hgrid="ne3np4"   nlev="26"             >atm/cam/inic/se/cami_0000-01-01_ne3np4_L26_c120525.nc</ncdata>
+<ncdata hgrid="ne3np4"   nlev="30"             >atm/cam/inic/se/cami_0000-01-01_ne3np4_L30_c120315.nc</ncdata>
+<ncdata hgrid="ne3np4"   nlev="32"                 >atm/cam/inic/se/cam6_QPC6_topo_ne3pg3_mg37_L32_01-01-31_c221214.nc</ncdata>
+<ncdata hgrid="ne3np4"   nlev="32"  ic_ymd="901"   >atm/cam/inic/se/CESM2.F2000climo.ne3np4.cam.i.0003-09-01-00000.nc</ncdata>
+<ncdata hgrid="ne3np4"   nlev="32"  aquaplanet="1" >atm/cam/inic/se/cam6_QPC6_aqua_ne3pg3_mg37_L32_01-01-31_c221214.nc</ncdata>
+<ncdata hgrid="ne3np4"   nlev="58"             >atm/cam/inic/se/cam6_QPC6_topo_ne3pg3_mg37_L58_01-01-31_c221214.nc</ncdata>
+<ncdata hgrid="ne3np4"   nlev="93"             >atm/cam/inic/se/cam6_FMTHIST_ne3pg3_mg37_L93_79-02-01_c240517.nc</ncdata>
+<ncdata hgrid="ne3np4"   nlev="93" chem="trop_strat_mam5_t1s2">atm/cam/inic/se/FHISTC_MTt1s_ne3pg3_O2_spinup01.cam.i.1980-01-01_c260201.nc</ncdata>
+<ncdata hgrid="ne3np4"   nlev="93" chem="trop_strat_mam5_t4s2">atm/cam/inic/se/FHISTC_MTt1s_ne3pg3_O2_spinup01.cam.i.1980-01-01_c260201.nc</ncdata>
+
+<ncdata hgrid="ne5np4"   nlev="26"  aquaplanet="1" >atm/cam/inic/se/ape_cam4_ne5np4_L26_c170517.nc</ncdata>
+<ncdata hgrid="ne5np4"   nlev="30"                 >atm/cam/inic/homme/cami-mam3_0000-01_ne5np4_L30.140707.nc</ncdata>
+<ncdata hgrid="ne5np4"   nlev="30"  aquaplanet="1" >atm/cam/inic/se/ape_cam5_ne5np4_L30_c170517.nc</ncdata>
+<ncdata hgrid="ne5np4"   nlev="32"                 >atm/cam/inic/se/F2000climo_ne5pg3_mg37_L32_01-01-31_c230520.nc</ncdata>
+<ncdata hgrid="ne5np4"   nlev="32"  aquaplanet="1" >atm/cam/inic/se/ape_cam6_ne5np4_L32_c170517.nc</ncdata>
+<ncdata hgrid="ne5np4"   nlev="58"                 >atm/cam/inic/se/F2000climo_ne5pg3_mg37_L58_01-01-31_c230520.nc</ncdata>
+<ncdata hgrid="ne5np4"   nlev="66"                 >atm/waccm/ic/wa3_ne5np4_1950_spinup.cam2.i.1960-01-01-00000_c150810.nc</ncdata>
+<ncdata hgrid="ne5np4"   nlev="70"  aquaplanet="1" chem="waccm_ma_mam4">atm/waccm/ic/aqua_waccm_ma_ne5np4_70L_c220729.nc</ncdata>
+<ncdata hgrid="ne5np4"   nlev="70"  aquaplanet="1" chem="waccm_ma_mam5">atm/waccm/ic/aqua_waccm_ma_ne5np4_70L_c220729.nc</ncdata>
+<ncdata hgrid="ne5np4"   nlev="126" waccmx="1"     >atm/waccm/ic/waccmx_aqua_ne5np4_126L_c210304.nc</ncdata>
+
+<ncdata hgrid="ne16np4"  nlev="26"                 >atm/cam/inic/se/ape_topo_cam4_ne16np4_L26_c171020.nc</ncdata>
+<ncdata hgrid="ne16np4"  nlev="26"  aquaplanet="1" >atm/cam/inic/se/ape_cam4_ne16np4_L26_c170417.nc</ncdata>
+<ncdata hgrid="ne16np4"  nlev="30"                 >atm/cam/inic/se/ape_topo_cam4_ne16np4_L30_c171020.nc</ncdata>
+<ncdata hgrid="ne16np4"  nlev="30"  aquaplanet="1" >atm/cam/inic/se/ape_cam5_ne16np4_L30_c170417.nc</ncdata>
+<ncdata hgrid="ne16np4"  nlev="32"                 >atm/cam/inic/se/ape_topo_cam4_ne16np4_L32_c171020.nc</ncdata>
+<ncdata hgrid="ne16np4"  nlev="32"  aquaplanet="1" >atm/cam/inic/se/ape_cam6_ne16np4_L32_c170509.nc</ncdata>
+<ncdata hgrid="ne16np4"  nlev="126" waccmx="1"                                 >atm/waccm/ic/waccmx_ne16np4_126L_c200108.nc</ncdata>
+<ncdata hgrid="ne16np4"  nlev="126" waccmx="1" aquaplanet="1"                  >atm/waccm/ic/waccmx_aqua_ne16np4_126L_c191108.nc</ncdata>
+<ncdata hgrid="ne16np4"  nlev="126" waccmx="1" aquaplanet="1" ionosphere="none">atm/waccm/ic/waccmx4_neutral_aquap_ne16np4_126lev_c200827.nc</ncdata>
+<ncdata hgrid="ne16np4"  nlev="130" waccmx="1"     >atm/waccm/ic/FX2000_ne16pg3_spinup01.cam.i.0002-01-01_c251215.nc</ncdata>
+<ncdata hgrid="ne16np4"  nlev="58"                 >atm/cam/inic/se/FHISTC_LTso_ne16pg3_ne16pg3_mg17.i.c260220.nc</ncdata>
+<ncdata hgrid="ne16np4"  nlev="93"                 >atm/cam/inic/se/FHISTC_MTso_ne16pg3_ne16pg3_mg17.i.c260220.nc</ncdata>
+
+<ncdata hgrid="ne30np4"  nlev="26"                 >atm/cam/inic/se/ape_topo_cam4_ne30np4_L26_c171020.nc</ncdata>
+<ncdata hgrid="ne30np4"  nlev="26"  aquaplanet="1" >atm/cam/inic/se/ape_cam4_ne30np4_L26_c170417.nc</ncdata>
+<ncdata hgrid="ne30np4"  nlev="30"                 >atm/cam/inic/se/ape_topo_cam4_ne30np4_L30_c171020.nc</ncdata>
+<ncdata hgrid="ne30np4"  nlev="30"  aquaplanet="1" >atm/cam/inic/se/ape_cam5_ne30np4_L30_c170417.nc</ncdata>
+<ncdata hgrid="ne30np4"  nlev="32"                 >atm/cam/inic/se/F2000climo_ne30pg3_mg17_01-01-00000_c200424.nc</ncdata>
+<ncdata hgrid="ne30np4"  nlev="32"  aquaplanet="1" >atm/cam/inic/se/ape_cam6_ne30np4_L32_c170509.nc</ncdata>
+<ncdata hgrid="ne30np4"  nlev="32" chem="trop_strat_mam4_vbs">atm/cam/inic/se/f.e22.FC2010climo.ne30_ne30_mg17.cam6_2_032.001.cam.i.0006-01-01-00000_c200623.nc</ncdata>
+<ncdata hgrid="ne30np4"  nlev="32" chem="trop_strat_mam4_vbs" npg="3">atm/cam/inic/se/f.e22.FC2010climo.ne30pg3_ne30pg3_mg17.cam6_2_032.001.cam.i.0007-01-01-00000_c200623.nc</ncdata>
+<ncdata hgrid="ne30np4"  nlev="32" chem="trop_strat_mam5_t1s1">atm/cam/inic/se/f.e22.FC2010climo.ne30_ne30_mg17.cam6_2_032.001.cam.i.0006-01-01-00000_c200623.nc</ncdata>
+<ncdata hgrid="ne30np4"  nlev="32" chem="trop_strat_mam5_t1s1" npg="3">atm/cam/inic/se/f.e22.FC2010climo.ne30pg3_ne30pg3_mg17.cam6_2_032.001.cam.i.0007-01-01-00000_c200623.nc</ncdata>
+<ncdata hgrid="ne30np4"  nlev="32" chem="trop_strat_mam4_ts2">atm/cam/inic/se/f.e22.FC2010climo.ne30_ne30_mg17.cam6_2_032.001.cam.i.0006-01-01-00000_c200623.nc</ncdata>
+<ncdata hgrid="ne30np4"  nlev="32" chem="trop_strat_mam5_t2s1">atm/cam/inic/se/f.e22.FC2010climo.ne30_ne30_mg17.cam6_2_032.001.cam.i.0006-01-01-00000_c200623.nc</ncdata>
+<ncdata hgrid="ne30np4"  nlev="58" chem="trop_strat_mam5_t1s1">atm/cam/inic/se/f.e22.FCnudged.ne30_ne30_mg17.release-cesm2.2.0_spinup.2010_2020.001.cam.i.2011-01-01-00000_L58_c220310.nc</ncdata>
+<ncdata hgrid="ne30np4"  nlev="58"                 >atm/cam/inic/se/FLT_L58_ne30pg3_IC_c220623.nc</ncdata>
+<ncdata hgrid="ne30np4"  nlev="70" waccm_phys="1"  >atm/waccm/ic/FW2000.ne30pg3_ne30pg3_nlev70_c230906.nc</ncdata>
+<ncdata hgrid="ne30np4"  nlev="93"                           >atm/cam/inic/se/c153_ne30pg3_FMTHIST_x02.cam.i.1990-01-01-00000_c240618.nc</ncdata>
+<ncdata hgrid="ne30np4"  nlev="93" chem="trop_strat_mam5_t1s2">atm/cam/inic/se/FHISTC_MTt1s_ne30pg3_O2_spinup01.cam.i.1980-01-01_c260201.nc</ncdata>
+<ncdata hgrid="ne30np4"  nlev="93" chem="trop_strat_mam5_t4s2">atm/cam/inic/se/FHISTC_MTt1s_ne30pg3_O2_spinup01.cam.i.1980-01-01_c260201.nc</ncdata>
+<ncdata hgrid="ne30np4"  nlev="110"                >atm/waccm/ic/FWsc2000_ne30pg3_L110_01-01-0001_c200521.nc</ncdata>
+<ncdata hgrid="ne30np4"  nlev="130" waccmx="1"         >atm/waccm/ic/fx2000_phys-ionos-cpl_ne30_spinup01.cam.i.0002-01-01-00000_c201014.nc</ncdata>
+<ncdata hgrid="ne30np4"  nlev="130" waccmx="1" npg="3" >atm/waccm/ic/waccmx_ne30pg3_L130_c250307.nc</ncdata>
+
+<ncdata hgrid="ne60np4"  nlev="26"                 >atm/cam/inic/se/ape_topo_cam4_ne60np4_L26_c171018.nc</ncdata>
+<ncdata hgrid="ne60np4"  nlev="26"  aquaplanet="1" >atm/cam/inic/se/ape_cam4_ne60np4_L26_c171023.nc</ncdata>
+<ncdata hgrid="ne60np4"  nlev="30"                 >atm/cam/inic/se/ape_topo_cam4_ne60np4_L30_c171020.nc</ncdata>
+<ncdata hgrid="ne60np4"  nlev="32"                 >atm/cam/inic/se/ape_topo_cam4_ne60np4_L32_c171020.nc</ncdata>
+
+<ncdata hgrid="ne120np4" nlev="26"                 >atm/cam/inic/se/ape_topo_cam4_ne120np4_L26_c171018.nc</ncdata>
+<ncdata hgrid="ne120np4" nlev="26"  aquaplanet="1" >atm/cam/inic/se/ape_cam4_ne120np4_L26_c170419.nc</ncdata>
+<ncdata hgrid="ne120np4" nlev="30"                 >atm/cam/inic/se/ape_topo_cam4_ne120np4_L30_c171024.nc</ncdata>
+<ncdata hgrid="ne120np4" nlev="30"  aquaplanet="1" >atm/cam/inic/se/ape_cam5_ne120np4_L30_c170419.nc</ncdata>
+<ncdata hgrid="ne120np4" nlev="32"                 >atm/cam/inic/se/F2000climo_ne120pg3_mt13_01-01-00000_c200420.nc</ncdata>
+<ncdata hgrid="ne120np4" nlev="32"  aquaplanet="1" >atm/cam/inic/se/ape_cam6_ne120np4_L32_c170908.nc</ncdata>
+<ncdata hgrid="ne120np4" nlev="58"                 >atm/cam/inic/se/betacast_ERA5ml_20100101_ne120np4_L58_c260225.nc</ncdata>
+<ncdata hgrid="ne120np4" nlev="93"                 >atm/cam/inic/se/inic/betacast_ERA5ml_20100101_ne120np4_L93_c260225.nc</ncdata>
+<ncdata hgrid="ne120np4" nlev="273" waccmx="1"     >atm/waccm/ic/fx2000_ne120pg3L273.001.cam.i.0002-01-01-00000.noBRCL_c250522.nc</ncdata>
+
+<ncdata hgrid="ne240np4" nlev="26"                 >atm/cam/inic/homme/cami_1850-01-01_ne240np4_L26_c110314.nc</ncdata>
+<ncdata hgrid="ne240np4" nlev="26"  ic_ymd="901"   >atm/cam/inic/homme/cami_0000-09-01_ne240np4_L26_c061106.nc</ncdata>
+<ncdata hgrid="ne240np4" nlev="26"  aquaplanet="1" >atm/cam/inic/se/ape_cam4_ne240np4_L26_c170613.nc</ncdata>
+<ncdata hgrid="ne240np4" nlev="30"                 >atm/cam/inic/homme/cami-mam3_0000-01-ne240np4_L30_c111004.nc</ncdata>
+<ncdata hgrid="ne240np4" nlev="32"  aquaplanet="1" >atm/cam/inic/se/ape_cam6_ne240np4_L32_c170908.nc</ncdata>
+
+<ncdata hgrid="ne0np4CONUS.ne30x8" nlev="32" >atm/cam/inic/se/F2000climo_CONUS_30x8_mt12_mg3_01-01-00000_c200421.nc</ncdata>
+<ncdata hgrid="ne0np4CONUS.ne30x8" nlev="32" chem="trop_strat_mam4_vbs">atm/cam/inic/se/f.e22.FCnudged.ne0CONUSne30x8_ne0CONUSne30x8_mt12.cam6_2_032.002.cam.i.2013-01-01-00000_c200623.nc</ncdata>
+<ncdata hgrid="ne0np4CONUS.ne30x8" nlev="32" chem="trop_strat_mam5_t1s1">atm/cam/inic/se/f.e22.FCnudged.ne0CONUSne30x8_ne0CONUSne30x8_mt12.cam6_2_032.002.cam.i.2013-01-01-00000_c200623.nc</ncdata>
+<ncdata hgrid="ne0np4CONUS.ne30x8" nlev="70" >atm/waccm/ic/FW2000_CONUS_30x8_L70_01-01-0001_c200602.nc</ncdata>
+
+<ncdata hgrid="ne0np4.ARCTIC.ne30x4" nlev="32" >atm/cam/inic/se/FHIST_ARCTIC_ne30x4_mt12_1979bc-mg3_01-01-00000_c200424.nc</ncdata>
+<ncdata hgrid="ne0np4.ARCTICGRIS.ne30x8" nlev="32" >atm/cam/inic/se/FHIST_ARCTICGRIS_ne30x8_mt12_1979bc-mg3_01-01-00000_c200428.nc</ncdata>
+<ncdata hgrid="ne0np4.NATL.ne30x8" nlev="32" >atm/cam/inic/se/betacast_ERA5ml_20200101_NATL_L32_c250620.nc</ncdata>
+<ncdata hgrid="ne0np4CONUS.ne30x8" nlev="58" >atm/cam/inic/se/betacast_ERA5ml_20200101_CONUS_c250617.nc</ncdata>
+<ncdata hgrid="ne0np4.ARCTIC.ne30x4" nlev="58" >atm/cam/inic/se/betacast_ERA5ml_20200101_ARCTIC_c250617.nc</ncdata>
+<ncdata hgrid="ne0np4.ARCTICGRIS.ne30x8" nlev="58" >atm/cam/inic/se/betacast_ERA5ml_20200101_ARCTICGRIS_c250617.nc</ncdata>
+<ncdata hgrid="ne0np4.POLARCAP.ne30x4" nlev="58" >atm/cam/inic/se/betacast_ERA5ml_20200101_POLARCAP_c250322.nc</ncdata>
+<ncdata hgrid="ne0np4.NATL.ne30x8" nlev="58" >atm/cam/inic/se/betacast_ERA5ml_20200101_NATL_L58_c250618.nc</ncdata>
+<ncdata hgrid="ne0np4CONUS.ne30x8" nlev="93" >atm/cam/inic/se/betacast_ERA5ml_20100101_CONUS_ne30x8_L93_c260225.nc</ncdata>
+<ncdata hgrid="ne0np4.ARCTIC.ne30x4" nlev="93" >atm/cam/inic/se/betacast_ERA5ml_20100101_ARCTIC_ne30x4_L93_c260225.nc</ncdata>
+<ncdata hgrid="ne0np4.ARCTICGRIS.ne30x8" nlev="93" >atm/cam/inic/se/betacast_ERA5ml_20100101_ARCTICGRIS_ne30x8_L93_c260225.nc</ncdata>
+<ncdata hgrid="ne0np4.POLARCAP.ne30x4" nlev="93" >atm/cam/inic/se/betacast_ERA5ml_20100101_POLARCAP_ne30x4_L93_c260225.nc</ncdata>
+<ncdata hgrid="ne0np4.NATL.ne30x8" nlev="93" >atm/cam/inic/se/betacast_ERA5ml_20100101_NATL_ne30x8_L93_c260225.nc</ncdata>
+
+<!-- MPAS Initial Conditions -->
+<ncdata hgrid="mpasa480" nlev="32" >atm/cam/inic/mpas/cami_01-01-2000_00Z_mpasa480_L32_CFSR_c240508.nc</ncdata>
+<ncdata hgrid="mpasa480" nlev="58" >atm/cam/inic/mpas/cami_01-01-2000_00Z_mpasa480_L58_CFSR_c240814.nc</ncdata>
+<ncdata hgrid="mpasa480" nlev="58" aquaplanet="1" >atm/cam/inic/mpas/QPC7_mpasa480_L58_cami_c250527.nc</ncdata>
+
+<ncdata hgrid="mpasa120" nlev="32" >atm/cam/inic/mpas/cami_01-01-2000_00Z_mpasa120_L32_CFSR_c240508.nc</ncdata>
+<ncdata hgrid="mpasa120" nlev="58" >atm/cam/inic/mpas/cami_01-01-2000_00Z_mpasa120_L58_CFSR_c240814.nc</ncdata>
+<ncdata hgrid="mpasa120" nlev="58" aquaplanet="1" >atm/cam/inic/mpas/QPC7_mpasa120_L58_cami_c250527.nc</ncdata>
+<ncdata hgrid="mpasa120" nlev="70" waccm_phys="1">atm/waccm/ic/mpasa120_L70.waccm_topography_SC_c240904.nc</ncdata>
+<!-- Next entries are mostly used in EarthWorks, real-data ICs -->
+<ncdata hgrid="mpasa60"  nlev="58" >atm/cam/inic/mpas/cami_01-01-2000_00Z_mpasa60_L58_CFSR_c240905.nc</ncdata>
+<ncdata hgrid="mpasa30"  nlev="58" >atm/cam/inic/mpas/cami_01-01-2000_00Z_mpasa30_L58_CFSR_c240905.nc</ncdata>
+<ncdata hgrid="mpasa15"  nlev="58" >atm/cam/inic/mpas/cami_01-01-2000_00Z_mpasa15_L58_CFSR_c240905.nc</ncdata>
+<!-- END EarthWorks specific, real-data ICs -->
+
+<!-- FV3 Initial Conditions -->
+<ncdata hgrid="C24"  nlev="26"                  >atm/cam/inic/fv3/cami_0000-01-01_C24_L26_c200625.nc</ncdata>
+<ncdata hgrid="C24"  nlev="30"                  >atm/cam/inic/fv3/cami-mam3_0000-01-01_C24_L30_c200625.nc</ncdata>
+<ncdata hgrid="C24"  nlev="32"                  >atm/cam/inic/fv3/cami-mam3_0000-01-01_C24_L32_c200625.nc</ncdata>
+<ncdata hgrid="C24"  nlev="32"  aquaplanet="1"  >atm/cam/inic/fv3/aqua_0006-01-01_C24_L32_c200625.nc</ncdata>
+<ncdata hgrid="C24"  nlev="70"                  >atm/waccm/ic/f2000.waccm-mam3_C24_L70.cam2.i.0017-01-01_c200625.nc</ncdata>
+
+<ncdata hgrid="C48"  nlev="26"                  >atm/cam/inic/fv3/cami_0000-01-01_C48_L26_c200625.nc</ncdata>
+<ncdata hgrid="C48"  nlev="26"  aquaplanet="1"  >atm/cam/inic/fv3/aqua_0006-01-01_C48_L26_c200625.nc</ncdata>
+<ncdata hgrid="C48"  nlev="30"                  >atm/cam/inic/fv3/cami-mam3_0000-01-01_C48_L30_c200625.nc</ncdata>
+<ncdata hgrid="C48"  nlev="32"                  >atm/cam/inic/fv3/cami-mam3_0000-01-01_C48_L32_c200625.nc</ncdata>
+<ncdata hgrid="C48"  nlev="32"  aquaplanet="1"  >atm/cam/inic/fv3/aqua_0006-01-01_C48_L32_c200625.nc</ncdata>
+<ncdata hgrid="C48"  nlev="70"                  >atm/waccm/ic/f2000.waccm-mam3_C48_L70.cam2.i.0017-01-01_c200625.nc</ncdata>
+
+<ncdata hgrid="C96"  nlev="26"                  >atm/cam/inic/fv3/cami_0000-01-01_C96_L26_c200625.nc</ncdata>
+<ncdata hgrid="C96"  nlev="26"  aquaplanet="1"  >atm/cam/inic/fv3/aqua_0006-01-01_C96_L26_c200625.nc</ncdata>
+<ncdata hgrid="C96"  nlev="30"                  >atm/cam/inic/fv3/cami-mam3_0000-01-01_C96_L30_c200625.nc</ncdata>
+<ncdata hgrid="C96"  nlev="30"  aquaplanet="1"  >atm/cam/inic/fv3/aqua_0006-01-01_C96_L30_c161020.nc</ncdata>
+<ncdata hgrid="C96"  nlev="32"                  >atm/cam/inic/fv3/cami-mam3_0000-01-01_C96_L32_c200625.nc</ncdata>
+<ncdata hgrid="C96"  nlev="32"  aquaplanet="1"  >atm/cam/inic/fv3/aqua_0006-01-01_C96_L32_c200625.nc</ncdata>
+<ncdata hgrid="C96"  nlev="70"                  >atm/waccm/ic/f2000.waccm-mam3_C96_L70.cam2.i.0017-01-01_c200625.nc</ncdata>
+
+<ncdata hgrid="C192" nlev="26"                  >atm/cam/inic/fv3/cami_0000-01-01_C192_L26_c200625.nc</ncdata>
+<ncdata hgrid="C192" nlev="30"                  >atm/cam/inic/fv3/cami-mam3_0000-01-01_C192_L30_c200625.nc</ncdata>
+<ncdata hgrid="C192" nlev="32"                  >atm/cam/inic/fv3/cami-mam3_0000-01-01_C192_L32_c200625.nc</ncdata>
+<ncdata hgrid="C192" nlev="32"  aquaplanet="1"  >atm/cam/inic/fv3/aqua_0006-01-01_C192_L32_c200625.nc</ncdata>
+
+<ncdata hgrid="C384" nlev="26"                  >atm/cam/inic/fv3/cami_0000-01-01_C384_L26_c200625.nc</ncdata>
+<ncdata hgrid="C384" nlev="30"                  >atm/cam/inic/fv3/cami-mam3_0000-01-01_C384_L30_c200625.nc</ncdata>
+<ncdata hgrid="C384" nlev="32"                  >atm/cam/inic/fv3/cami-mam3_0000-01-01_C384_L32_c200625.nc</ncdata>
+<ncdata hgrid="C384" nlev="32"  aquaplanet="1"  >atm/cam/inic/fv3/aqua_0006-01-01_C384_L32_c200625.nc</ncdata>
+
+<!-- Topography -->
+<bnd_topo hgrid="0.23x0.31" >atm/cam/topo/USGS_gtopo30_0.23x0.31_remap_c061107.nc</bnd_topo>
+<bnd_topo hgrid="0.47x0.63" >atm/cam/topo/USGS_gtopo30_0.47x0.63_remap_c061106.nc</bnd_topo>
+<bnd_topo hgrid="0.47x0.63" phys="cam6">atm/cam/topo/fv_0.47x0.63_nc3000_Co030_Fi001_PF_nullRR_Nsw021_20171023.nc</bnd_topo>
+<bnd_topo hgrid="0.47x0.63" phys="cam7">atm/cam/topo/fv_0.47x0.63_nc3000_Co030_Fi001_PF_nullRR_Nsw021_20171023.nc</bnd_topo>
+<bnd_topo hgrid="0.5x0.625" >atm/cam/topo/topo-from-cami_0000-10-01_0.5x0.625_L26_c031204.nc</bnd_topo>
+<bnd_topo hgrid="0.9x1.25"  >atm/cam/topo/fv_0.9x1.25_nc3000_Nsw042_Nrs008_Co060_Fi001_ZR_sgh30_24km_GRNL_c170103.nc</bnd_topo>
+<bnd_topo hgrid="1.9x2.5"   >atm/cam/topo/fv_1.9x2.5_nc3000_Nsw084_Nrs016_Co120_Fi001_ZR_GRNL_c190405.nc</bnd_topo>
+<bnd_topo hgrid="2.5x3.33"  >atm/cam/topo/USGS-gtopo30_2.5x3.33_remap_c100204.nc</bnd_topo>
+<bnd_topo hgrid="4x5"       >atm/cam/topo/USGS-gtopo30_4x5_remap_c050520.nc</bnd_topo>
+<bnd_topo hgrid="10x15"     >atm/cam/topo/fv_10x15_nc0540_Nsw042_Nrs008_Co060_Fi001_20171220.nc</bnd_topo>
+
+<bnd_topo hgrid="C24"  >atm/cam/topo/fv3_C24_nc3000_Co180_Fi001_MulG_PF_nullRR_Nsw127_c200625.nc</bnd_topo>
+<bnd_topo hgrid="C48"  >atm/cam/topo/fv3_C48_nc3000_Co120_Fi001_MulG_PF_nullRR_Nsw085_c200625.nc</bnd_topo>
+<bnd_topo hgrid="C96"  >atm/cam/topo/fv3_C96_nc3000_Co060_Fi001_MulG_PF_nullRR_Nsw042_c200625.nc</bnd_topo>
+<bnd_topo hgrid="C192" >atm/cam/topo/fv3_C192_nc3000_Co030_Fi001_MulG_PF_Nsw021_c200625.nc</bnd_topo>
+<bnd_topo hgrid="C384" >atm/cam/topo/fv3_C384_nc3000_Co015_Fi001_MulG_PF_nullRR_Nsw011_c200625.nc</bnd_topo>
+
+<bnd_topo hgrid="ne3np4"          >atm/cam/topo/se/ne3np4_gmted2010_modis_bedmachine_nc0540_Laplace1000_noleak_20230717.nc</bnd_topo>
+<bnd_topo hgrid="ne5np4"          >atm/cam/topo/se/ne5np4_nc3000_Co360_Fi001_MulG_PF_nullRR_Nsw064_20170515.nc</bnd_topo>
+<bnd_topo hgrid="ne16np4"         >atm/cam/topo/se/ne16np4_nc3000_Co120_Fi001_PF_nullRR_Nsw084_20171012.nc</bnd_topo>
+<bnd_topo hgrid="ne30np4"         >atm/cam/topo/se/ne30np4_gmted2010_modis_bedmachine_nc3000_Laplace0100_noleak_greenlndantarcsgh30fac2.50_20250822.nc</bnd_topo>
+<bnd_topo hgrid="ne60np4"         >atm/cam/topo/se/ne60np4_nc3000_Co030_Fi001_PF_nullRR_Nsw021_20171012.nc</bnd_topo>
+<bnd_topo hgrid="ne120np4"        >atm/cam/topo/se/ne120np4_nc3000_Co015_Fi001_PF_nullRR_Nsw010_20171011.nc</bnd_topo>
+<bnd_topo hgrid="ne240np4"        >atm/cam/topo/se/ne240np4_nc3000_Co008_Fi001_PF_nullRR_Nsw005_20171014.nc</bnd_topo>
+
+<bnd_topo hgrid="ne5np4"   npg="2">atm/cam/topo/se/ne5pg2_nc3000_Co360_Fi001_MulG_PF_nullRR_Nsw060_20170706.nc</bnd_topo>
+<bnd_topo hgrid="ne30np4"  npg="2">atm/cam/topo/se/ne30pg2_gmted2010_modis_bedmachine_nc3000_Laplace0100_noleak_greenlndantarcsgh30fac2.50_20250825.nc</bnd_topo>
+<bnd_topo hgrid="ne60np4"  npg="2">atm/cam/topo/se/ne60pg2_nc3000_Co030_Fi001_PF_nullRR_Nsw021_20171014.nc</bnd_topo>
+<bnd_topo hgrid="ne120np4" npg="2">atm/cam/topo/se/ne120pg2_nc3000_Co015_Fi001_PF_nullRR_Nsw010_20171012.nc</bnd_topo>
+<bnd_topo hgrid="ne240np4" npg="2">atm/cam/topo/se/ne240pg2_nc3000_Co008_Fi001_PF_nullRR_Nsw005_20171014.nc</bnd_topo>
+<bnd_topo hgrid="ne3np4"          >atm/cam/topo/se/ne3np4_gmted2010_modis_bedmachine_nc0540_Laplace1000_noleak_20230717.nc</bnd_topo>
+<bnd_topo hgrid="ne3np4"   npg="3">atm/cam/topo/se/ne3pg3_gmted2010_modis_bedmachine_nc0540_Laplace1000_noleak_20230209.nc</bnd_topo>
+<bnd_topo hgrid="ne5np4"   npg="3">atm/cam/topo/se/ne5pg3_nc3000_Co360_Fi001_MulG_PF_nullRR_Nsw064_20170516.nc</bnd_topo>
+<bnd_topo hgrid="ne16np4"  npg="3">atm/cam/topo/se/ne16pg3_gmted2010_modis_bedmachine_nc3000_Laplace0200_noleak_greenlndantarcsgh30fac2.50_20250825.nc</bnd_topo>
+<bnd_topo hgrid="ne30np4"  npg="3">atm/cam/topo/se/ne30pg3_gmted2010_modis_bedmachine_nc3000_Laplace0100_noleak_greenlndantarcsgh30fac2.50_20250828.nc</bnd_topo>
+<bnd_topo hgrid="ne60np4"  npg="3">atm/cam/topo/se/ne60pg3_nc3000_Co030_Fi001_PF_nullRR_Nsw021_20171012.nc</bnd_topo>
+<bnd_topo hgrid="ne120np4" npg="3">atm/cam/topo/se/ne120pg3_nc3000_Co015_Fi001_PF_nullRR_Nsw010_20171014.nc</bnd_topo>
+<bnd_topo hgrid="ne240np4" npg="3">atm/cam/topo/se/ne240pg3_nc3000_Co008_Fi001_PF_nullRR_Nsw005_20171015.nc</bnd_topo>
+
+<bnd_topo hgrid="ne0np4CONUS.ne30x8"       >atm/cam/topo/se/ne30x8_CONUS_nc3000_Co060_Fi001_MulG_PF_RR_Nsw042_c200428.nc</bnd_topo>
+<bnd_topo hgrid="ne0np4.ARCTIC.ne30x4"     >atm/cam/topo/se/ne30x4_ARCTIC_nc3000_Co060_Fi001_MulG_PF_RR_Nsw042_c200428.nc</bnd_topo>
+<bnd_topo hgrid="ne0np4.ARCTICGRIS.ne30x8" >atm/cam/topo/se/ne30x8_ARCTICGRIS_nc3000_Co060_Fi001_MulG_PF_RR_Nsw042_c200428.nc</bnd_topo>
+<bnd_topo hgrid="ne0np4.POLARCAP.ne30x4"   >atm/cam/topo/se/POLARCAP_gmted2010_modis_bedmachine_nc3000_Laplace0100_noleak_20250322.nc</bnd_topo>
+<bnd_topo hgrid="ne0np4.NATL.ne30x8"       >atm/cam/topo/se/NATL.ne30x8_gmted2010_modis_bedmachine_nc3000_Laplace0100_noleak_20260225.nc</bnd_topo>
+
+<bnd_topo hgrid="mpasa480" >atm/cam/topo/mpas/mpasa480_gmted2010_modis_bedmachine_nc3000_Laplace0400_noleak_20240507.nc</bnd_topo>
+<bnd_topo hgrid="mpasa120" >atm/cam/topo/mpas/mpasa120_gmted2010_modis_bedmachine_nc3000_Laplace0100_noleak_20240507.nc</bnd_topo>
+<!-- Next entires are mostly used in EarthWorks, for real-data cases -->
+<bnd_topo hgrid="mpasa60" >atm/cam/topo/mpas/mpasa60_gmted2010_modis_bedmachine_nc3000_Laplace0050_noleak_20240507.nc</bnd_topo>
+<bnd_topo hgrid="mpasa30" >atm/cam/topo/mpas/mpasa30_gmted2010_modis_bedmachine_nc3000_Laplace0025_noleak_20240507.nc</bnd_topo>
+<bnd_topo hgrid="mpasa15" >atm/cam/topo/mpas/mpasa15_gmted2010_modis_bedmachine_nc3000_Laplace0013_noleak_20240507.nc</bnd_topo>
+<!-- END EarthWorks specific, for real-data cases -->
+
+<!-- Scale Dry Air Mass: 0=> no scaling / +nnn=>scale to nnn Pressure  -->
+<scale_dry_air_mass                                                                >      0.0D0 </scale_dry_air_mass>
+<scale_dry_air_mass aquaplanet="1"                                                 > 101080.0D0 </scale_dry_air_mass>
+<!-- Scale Dry Air Mass: for cases with topography -->
+<scale_dry_air_mass phys="cam4"                                                    >  98288.0D0 </scale_dry_air_mass>
+<scale_dry_air_mass phys="cam5"                                                    >  98288.0D0 </scale_dry_air_mass>
+<scale_dry_air_mass phys="cam6"                                                    >  98288.0D0 </scale_dry_air_mass>
+<scale_dry_air_mass phys="cam7"                                                    >  98288.0D0 </scale_dry_air_mass>
+
+<!-- Ridge parameterization (gamma) -->
+<bnd_rdggm hgrid="0.9x1.25">atm/cam/topo/fv_0.9x1.25_nc3000_Nsw006_Nrs002_Co008_Fi001_ZR_c160505.nc</bnd_rdggm>
+<bnd_rdggm hgrid="1.9x2.5" >atm/cam/topo/fv_1.9x2.5_nc3000_Nsw084_Nrs016_Co120_Fi001_ZR_061116.nc</bnd_rdggm>
+
+<!-- Sometimes, the default should be no topography file -->
+<use_topo_file                    > .true.  </use_topo_file>
+<use_topo_file aquaplanet="1"     > .false. </use_topo_file>
+<use_topo_file phys="held_suarez" > .false. </use_topo_file>
+<use_topo_file analytic_ic="1"    > .false. </use_topo_file>
+
+<!-- Mesh files for refined SE grids -->
+<se_mesh_file> none </se_mesh_file>
+<se_mesh_file hgrid="ne0np4CONUS.ne30x8"      >atm/cam/coords/ne0np4CONUS.ne30x8.g</se_mesh_file>
+<se_mesh_file hgrid="ne0np4TESTONLY.ne5x4"    >atm/cam/coords/ne0np4EQFACE.ne5x4.g</se_mesh_file>
+<se_mesh_file hgrid="ne0np4.ARCTIC.ne30x4"    >atm/cam/coords/ne30x4_EXODUS_ARCTIC_c191009.g</se_mesh_file>
+<se_mesh_file hgrid="ne0np4.ARCTICGRIS.ne30x8">atm/cam/coords/ne30x8_EXODUS_ARCTICGRIS_c191209.g</se_mesh_file>
+<se_mesh_file hgrid="ne0np4.POLARCAP.ne30x4"  >atm/cam/coords/POLARCAP_ne30x4_EXODUS_c220531.nc</se_mesh_file>
+<se_mesh_file hgrid="ne0np4.NATL.ne30x8"      >atm/cam/coords/NATL_ne30x8_EXODUS_c201016.nc</se_mesh_file>
+
+<!-- Analytic ICs  -->
+<analytic_ic_type                   > none </analytic_ic_type>
+<analytic_ic_type phys="adiabatic"  > held_suarez_1994 </analytic_ic_type>
+<analytic_ic_type phys="held_suarez"> held_suarez_1994 </analytic_ic_type>
+<analytic_ic_type phys="kessler"    > moist_baroclinic_wave_dcmip2016 </analytic_ic_type>
+<analytic_ic_type phys="tj2016"     > moist_baroclinic_wave_dcmip2016 </analytic_ic_type>
+<analytic_ic_type phys="grayrad"    > moist_baroclinic_wave_dcmip2016 </analytic_ic_type>
+
+<!-- Frierson Gray Radiation -->
+
+<frierson_Wind_min   phys="grayrad"   > 1.0d-5    </frierson_Wind_min>
+<frierson_Z0         phys="grayrad"   > 3.21d-5   </frierson_Z0>
+<frierson_Ri_c       phys="grayrad"   > 1.0d0     </frierson_Ri_c>
+<frierson_Fb         phys="grayrad"   > 0.1d0     </frierson_Fb>
+<frierson_Albedo     phys="grayrad"   > 0.310d0   </frierson_Albedo>
+<frierson_DeltaS     phys="grayrad"   > 1.4d0     </frierson_DeltaS>
+<frierson_Tau_eqtr   phys="grayrad"   > 6.0d0     </frierson_Tau_eqtr>
+<frierson_Tau_pole   phys="grayrad"   > 1.5d0     </frierson_Tau_pole>
+<frierson_LinFrac    phys="grayrad"   > 0.1d0     </frierson_LinFrac>
+<frierson_C0         phys="grayrad"   > 1.d7      </frierson_C0>
+<frierson_WetDryCoef phys="grayrad"   > 1.d0      </frierson_WetDryCoef>
+<frierson_Tmin       phys="grayrad"   > 271.d0    </frierson_Tmin>
+<frierson_Tdlt       phys="grayrad"   > 39.d0     </frierson_Tdlt>
+<frierson_Twidth     phys="grayrad"   > 26.d0     </frierson_Twidth>
+
+<!-- Bulk aerosol physical properties (includes optics) -->
+
+<!-- CAM-Chem bulk aerosols (different aerosol names used in prescribed and prognostic modes) -->
+<!-- Optics for CAM-RT -->
+<bam_sulf  rad="camrt">atm/cam/physprops/sulfate_camrt_c080918.nc</bam_sulf>
+<bam_SO4   rad="camrt">atm/cam/physprops/sulfate_camrt_c080918.nc</bam_SO4>
+<bam_dust1 rad="camrt">atm/cam/physprops/dust1_camrt_c120518.nc</bam_dust1>
+<bam_DST01 rad="camrt">atm/cam/physprops/dust1_camrt_c120518.nc</bam_DST01>
+<bam_dust2 rad="camrt">atm/cam/physprops/dust2_camrt_c120518.nc</bam_dust2>
+<bam_DST02 rad="camrt">atm/cam/physprops/dust2_camrt_c120518.nc</bam_DST02>
+<bam_dust3 rad="camrt">atm/cam/physprops/dust3_camrt_c120518.nc</bam_dust3>
+<bam_DST03 rad="camrt">atm/cam/physprops/dust3_camrt_c120518.nc</bam_DST03>
+<bam_dust4 rad="camrt">atm/cam/physprops/dust4_camrt_c120518.nc</bam_dust4>
+<bam_DST04 rad="camrt">atm/cam/physprops/dust4_camrt_c120518.nc</bam_DST04>
+<bam_bcar1 rad="camrt">atm/cam/physprops/bcpho_camrt_c080918.nc</bam_bcar1>
+<bam_CB1   rad="camrt">atm/cam/physprops/bcpho_camrt_c080918.nc</bam_CB1>
+<bam_bcar2 rad="camrt">atm/cam/physprops/bcphi_camrt_c080918.nc</bam_bcar2>
+<bam_CB2   rad="camrt">atm/cam/physprops/bcphi_camrt_c080918.nc</bam_CB2>
+<bam_ocar1 rad="camrt">atm/cam/physprops/ocpho_camrt_c080918.nc</bam_ocar1>
+<bam_OC1   rad="camrt">atm/cam/physprops/ocpho_camrt_c080918.nc</bam_OC1>
+<bam_ocar2 rad="camrt">atm/cam/physprops/ocphi_camrt_c080918.nc</bam_ocar2>
+<bam_OC2   rad="camrt">atm/cam/physprops/ocphi_camrt_c080918.nc</bam_OC2>
+<bam_SSLTA rad="camrt">atm/cam/physprops/ssam_camrt_c080918.nc</bam_SSLTA>
+<bam_SSLTC rad="camrt">atm/cam/physprops/sscm_camrt_c080918.nc</bam_SSLTC>
+
+<!-- CAM-Chem bulk aerosols (different names used in prescribed and prognostic modes) -->
+<!-- Optics for RRTMG -->
+<bam_sulf   rad="rrtmg">atm/cam/physprops/sulfate_rrtmg_c080918.nc</bam_sulf>
+<bam_SO4    rad="rrtmg">atm/cam/physprops/sulfate_rrtmg_c080918.nc</bam_SO4>
+<bam_dust1  rad="rrtmg">atm/cam/physprops/dust1_rrtmg_c080918.nc</bam_dust1>
+<bam_DST01  rad="rrtmg">atm/cam/physprops/dust1_rrtmg_c080918.nc</bam_DST01>
+<bam_dust2  rad="rrtmg">atm/cam/physprops/dust2_rrtmg_c080918.nc</bam_dust2>
+<bam_DST02  rad="rrtmg">atm/cam/physprops/dust2_rrtmg_c080918.nc</bam_DST02>
+<bam_dust3  rad="rrtmg">atm/cam/physprops/dust3_rrtmg_c080918.nc</bam_dust3>
+<bam_DST03  rad="rrtmg">atm/cam/physprops/dust3_rrtmg_c080918.nc</bam_DST03>
+<bam_dust4  rad="rrtmg">atm/cam/physprops/dust4_rrtmg_c080918.nc</bam_dust4>
+<bam_DST04  rad="rrtmg">atm/cam/physprops/dust4_rrtmg_c080918.nc</bam_DST04>
+<bam_bcar1  rad="rrtmg">atm/cam/physprops/bcpho_rrtmg_c080918.nc</bam_bcar1>
+<bam_CB1    rad="rrtmg">atm/cam/physprops/bcpho_rrtmg_c080918.nc</bam_CB1>
+<bam_bcar2  rad="rrtmg">atm/cam/physprops/bcphi_rrtmg_c080918.nc</bam_bcar2>
+<bam_CB2    rad="rrtmg">atm/cam/physprops/bcphi_rrtmg_c080918.nc</bam_CB2>
+<bam_ocar1  rad="rrtmg">atm/cam/physprops/ocpho_rrtmg_c080918.nc</bam_ocar1>
+<bam_OC1    rad="rrtmg">atm/cam/physprops/ocpho_rrtmg_c080918.nc</bam_OC1>
+<bam_ocar2  rad="rrtmg">atm/cam/physprops/ocphi_rrtmg_c080918.nc</bam_ocar2>
+<bam_OC2    rad="rrtmg">atm/cam/physprops/ocphi_rrtmg_c080918.nc</bam_OC2>
+<bam_sslt1  rad="rrtmg">atm/cam/physprops/seasalt1_rrtmg_c080918.nc</bam_sslt1>
+<bam_SSLT01 rad="rrtmg">atm/cam/physprops/seasalt1_rrtmg_c080918.nc</bam_SSLT01>
+<bam_sslt2  rad="rrtmg">atm/cam/physprops/seasalt2_rrtmg_c080918.nc</bam_sslt2>
+<bam_SSLT02 rad="rrtmg">atm/cam/physprops/seasalt2_rrtmg_c080918.nc</bam_SSLT02>
+<bam_sslt3  rad="rrtmg">atm/cam/physprops/seasalt3_rrtmg_c080918.nc</bam_sslt3>
+<bam_SSLT03 rad="rrtmg">atm/cam/physprops/seasalt3_rrtmg_c080918.nc</bam_SSLT03>
+<bam_sslt4  rad="rrtmg">atm/cam/physprops/seasalt4_rrtmg_c080918.nc</bam_sslt4>
+<bam_SSLT04 rad="rrtmg">atm/cam/physprops/seasalt4_rrtmg_c080918.nc</bam_SSLT04>
+<bam_SSLTA  rad="rrtmg">atm/cam/physprops/ssam_rrtmg_c080918.nc</bam_SSLTA>
+<bam_SSLTC  rad="rrtmg">atm/cam/physprops/sscm_rrtmg_c080918.nc</bam_SSLTC>
+
+<!-- Bulk aerosols for RRTMGP -->
+<bam_sulf   rad="rrtmgp">atm/cam/physprops/sulfate_rrtmg_c080918.nc</bam_sulf>
+<bam_SO4    rad="rrtmgp">atm/cam/physprops/sulfate_rrtmg_c080918.nc</bam_SO4>
+<bam_dust1  rad="rrtmgp">atm/cam/physprops/dust1_rrtmg_c080918.nc</bam_dust1>
+<bam_DST01  rad="rrtmgp">atm/cam/physprops/dust1_rrtmg_c080918.nc</bam_DST01>
+<bam_dust2  rad="rrtmgp">atm/cam/physprops/dust2_rrtmg_c080918.nc</bam_dust2>
+<bam_DST02  rad="rrtmgp">atm/cam/physprops/dust2_rrtmg_c080918.nc</bam_DST02>
+<bam_dust3  rad="rrtmgp">atm/cam/physprops/dust3_rrtmg_c080918.nc</bam_dust3>
+<bam_DST03  rad="rrtmgp">atm/cam/physprops/dust3_rrtmg_c080918.nc</bam_DST03>
+<bam_dust4  rad="rrtmgp">atm/cam/physprops/dust4_rrtmg_c080918.nc</bam_dust4>
+<bam_DST04  rad="rrtmgp">atm/cam/physprops/dust4_rrtmg_c080918.nc</bam_DST04>
+<bam_bcar1  rad="rrtmgp">atm/cam/physprops/bcpho_rrtmg_c080918.nc</bam_bcar1>
+<bam_CB1    rad="rrtmgp">atm/cam/physprops/bcpho_rrtmg_c080918.nc</bam_CB1>
+<bam_bcar2  rad="rrtmgp">atm/cam/physprops/bcphi_rrtmg_c080918.nc</bam_bcar2>
+<bam_CB2    rad="rrtmgp">atm/cam/physprops/bcphi_rrtmg_c080918.nc</bam_CB2>
+<bam_ocar1  rad="rrtmgp">atm/cam/physprops/ocpho_rrtmg_c080918.nc</bam_ocar1>
+<bam_OC1    rad="rrtmgp">atm/cam/physprops/ocpho_rrtmg_c080918.nc</bam_OC1>
+<bam_ocar2  rad="rrtmgp">atm/cam/physprops/ocphi_rrtmg_c080918.nc</bam_ocar2>
+<bam_OC2    rad="rrtmgp">atm/cam/physprops/ocphi_rrtmg_c080918.nc</bam_OC2>
+<bam_sslt1  rad="rrtmgp">atm/cam/physprops/seasalt1_rrtmg_c080918.nc</bam_sslt1>
+<bam_SSLT01 rad="rrtmgp">atm/cam/physprops/seasalt1_rrtmg_c080918.nc</bam_SSLT01>
+<bam_sslt2  rad="rrtmgp">atm/cam/physprops/seasalt2_rrtmg_c080918.nc</bam_sslt2>
+<bam_SSLT02 rad="rrtmgp">atm/cam/physprops/seasalt2_rrtmg_c080918.nc</bam_SSLT02>
+<bam_sslt3  rad="rrtmgp">atm/cam/physprops/seasalt3_rrtmg_c080918.nc</bam_sslt3>
+<bam_SSLT03 rad="rrtmgp">atm/cam/physprops/seasalt3_rrtmg_c080918.nc</bam_SSLT03>
+<bam_sslt4  rad="rrtmgp">atm/cam/physprops/seasalt4_rrtmg_c080918.nc</bam_sslt4>
+<bam_SSLT04 rad="rrtmgp">atm/cam/physprops/seasalt4_rrtmg_c080918.nc</bam_SSLT04>
+<bam_SSLTA  rad="rrtmgp">atm/cam/physprops/ssam_rrtmg_c080918.nc</bam_SSLTA>
+<bam_SSLTC  rad="rrtmgp">atm/cam/physprops/sscm_rrtmg_c080918.nc</bam_SSLTC>
+
+<!-- CAM-Chem modal aerosols (different names used in prescribed and prognostic modes) -->
+<!-- Optics for RRTMG -->
+<!-- modal aerosol properties files -->
+<mam_so4  rad="rrtmg">atm/cam/physprops/sulfate_rrtmg_c080918.nc</mam_so4>
+<mam_pom  rad="rrtmg" mam="3mode">atm/cam/physprops/ocpho_rrtmg_c101112.nc</mam_pom>
+<mam_pom  rad="rrtmg">atm/cam/physprops/ocpho_rrtmg_c130709.nc</mam_pom>
+<mam_soa  rad="rrtmg">atm/cam/physprops/ocphi_rrtmg_c100508.nc</mam_soa>
+<mam_bc   rad="rrtmg">atm/cam/physprops/bcpho_rrtmg_c100508.nc</mam_bc>
+<mam_ncl  rad="rrtmg">atm/cam/physprops/ssam_rrtmg_c100508.nc</mam_ncl>
+<mam_dst  rad="rrtmg">atm/cam/physprops/dust_aeronet_rrtmg_c141106.nc</mam_dst>
+<mam_nh4  rad="rrtmg">atm/cam/physprops/sulfate_rrtmg_c080918.nc</mam_nh4>
+
+<!-- Modal aerosol properties for RRTMGP -->
+<mam_so4  rad="rrtmgp">atm/cam/physprops/sulfate_rrtmg_c080918.nc</mam_so4>
+<mam_pom  rad="rrtmgp" mam="3mode">atm/cam/physprops/ocpho_rrtmg_c101112.nc</mam_pom>
+<mam_pom  rad="rrtmgp">atm/cam/physprops/ocpho_rrtmg_c130709.nc</mam_pom>
+<mam_soa  rad="rrtmgp">atm/cam/physprops/ocphi_rrtmg_c100508.nc</mam_soa>
+<mam_bc   rad="rrtmgp">atm/cam/physprops/bcpho_rrtmg_c100508.nc</mam_bc>
+<mam_ncl  rad="rrtmgp">atm/cam/physprops/ssam_rrtmg_c100508.nc</mam_ncl>
+<mam_dst  rad="rrtmgp">atm/cam/physprops/dust_aeronet_rrtmg_c141106.nc</mam_dst>
+<mam_nh4  rad="rrtmgp">atm/cam/physprops/sulfate_rrtmg_c080918.nc</mam_nh4>
+
+<!-- Eruptive volcanic aerosols  -->
+<VOLC_MMR                        rad="camrt">atm/cam/physprops/volc_camRT_byradius_sigma1.6_c130724.nc</VOLC_MMR>
+<VOLC_MMR chem="none"            rad="camrt">atm/cam/physprops/sulfuricacid_cam3_c080918.nc</VOLC_MMR>
+<VOLC_MMR rad="rrtmg">atm/cam/physprops/volc_camRRTMG_byradius_sigma1.6_c130724.nc</VOLC_MMR>
+<VOLC_MMR1 rad="rrtmg">atm/cam/physprops/volc_camRRTMG_byradius_sigma1.6_mode1_c210211.nc</VOLC_MMR1>
+<VOLC_MMR2 rad="rrtmg">atm/cam/physprops/volc_camRRTMG_byradius_sigma1.6_mode2_c210211.nc</VOLC_MMR2>
+<VOLC_MMR3 rad="rrtmg">atm/cam/physprops/volc_camRRTMG_byradius_sigma1.2_mode3_c210211.nc</VOLC_MMR3>
+
+<!-- Eruptive volcanic aerosols for RRTMGP -->
+<VOLC_MMR rad="rrtmgp">atm/cam/physprops/volc_camRRTMG_byradius_sigma1.6_c130724.nc</VOLC_MMR>
+<VOLC_MMR1 rad="rrtmgp">atm/cam/physprops/volc_camRRTMG_byradius_sigma1.6_mode1_c210211.nc</VOLC_MMR1>
+<VOLC_MMR2 rad="rrtmgp">atm/cam/physprops/volc_camRRTMG_byradius_sigma1.6_mode2_c210211.nc</VOLC_MMR2>
+<VOLC_MMR3 rad="rrtmgp">atm/cam/physprops/volc_camRRTMG_byradius_sigma1.2_mode3_c210211.nc</VOLC_MMR3>
+
+<!-- Modal optics calculations -->
+<mam3_mode1_file rad="rrtmg">atm/cam/physprops/mam4_mode1_rrtmg_aeronetdust_c141106.nc</mam3_mode1_file>
+<mam3_mode2_file rad="rrtmg">atm/cam/physprops/mam4_mode2_rrtmg_aitkendust_c141106.nc </mam3_mode2_file>
+<mam3_mode3_file rad="rrtmg">atm/cam/physprops/mam4_mode3_rrtmg_aeronetdust_c141106.nc</mam3_mode3_file>
+
+<mam3_mode1_file rad="rrtmg" ver="strat">atm/cam/physprops/mam4_mode1_rrtmg_aeronetdust_sig1.6_dgnh.48_c140304.nc</mam3_mode1_file>
+<mam3_mode3_file rad="rrtmg" ver="strat">atm/cam/physprops/mam4_mode3_rrtmg_aeronetdust_sig1.2_dgnl.40_c150219.nc</mam3_mode3_file>
+
+<mam4_mode1_file rad="rrtmg">atm/cam/physprops/mam4_mode1_rrtmg_aeronetdust_c141106.nc</mam4_mode1_file>
+<mam4_mode2_file rad="rrtmg">atm/cam/physprops/mam4_mode2_rrtmg_aitkendust_c141106.nc</mam4_mode2_file>
+<mam4_mode3_file rad="rrtmg">atm/cam/physprops/mam4_mode3_rrtmg_aeronetdust_c141106.nc</mam4_mode3_file>
+<mam4_mode4_file rad="rrtmg">atm/cam/physprops/mam4_mode4_rrtmg_c130628.nc</mam4_mode4_file>
+
+<mam4_mode1_file rad="rrtmg" ver="strat">atm/cam/physprops/mam4_mode1_rrtmg_aeronetdust_sig1.6_dgnh.48_c140304.nc</mam4_mode1_file>
+<mam4_mode3_file rad="rrtmg" ver="strat" phys="cam6">atm/cam/physprops/mam4_mode3_rrtmg_aeronetdust_sig1.2_dgnl.40_c150219.nc</mam4_mode3_file>
+
+<mam5_mode1_file rad="rrtmg" ver="strat">atm/cam/physprops/mam4_mode1_rrtmg_aeronetdust_sig1.6_dgnh.48_c140304.nc</mam5_mode1_file>
+<mam5_mode2_file rad="rrtmg" ver="strat">atm/cam/physprops/mam4_mode2_rrtmg_aitkendust_c141106.nc</mam5_mode2_file>
+<mam5_mode3_file rad="rrtmg" ver="strat">atm/cam/physprops/mam4_mode3_rrtmg_aeronetdust_c141106.nc</mam5_mode3_file>
+<mam5_mode4_file rad="rrtmg" ver="strat">atm/cam/physprops/mam4_mode4_rrtmg_c130628.nc</mam5_mode4_file>
+<mam5_mode5_file rad="rrtmg" ver="strat">atm/cam/physprops/mam4_mode3_rrtmg_aeronetdust_sig1.2_dgnl.40_c150219.nc</mam5_mode5_file>
+
+<mam7_mode1_file rad="rrtmg">atm/cam/physprops/mam7_mode1_rrtmg_c120904.nc</mam7_mode1_file>
+<mam7_mode2_file rad="rrtmg">atm/cam/physprops/mam7_mode2_rrtmg_c120904.nc</mam7_mode2_file>
+<mam7_mode3_file rad="rrtmg">atm/cam/physprops/mam7_mode3_rrtmg_c120904.nc</mam7_mode3_file>
+<mam7_mode4_file rad="rrtmg">atm/cam/physprops/mam7_mode4_rrtmg_c120904.nc</mam7_mode4_file>
+<mam7_mode5_file rad="rrtmg">atm/cam/physprops/mam7_mode5_rrtmg_c120904.nc</mam7_mode5_file>
+<mam7_mode6_file rad="rrtmg">atm/cam/physprops/mam7_mode6_rrtmg_c120904.nc</mam7_mode6_file>
+<mam7_mode7_file rad="rrtmg">atm/cam/physprops/mam7_mode7_rrtmg_c120904.nc</mam7_mode7_file>
+
+<!-- Modal optics for RRTMGP -->
+<mam3_mode1_file rad="rrtmgp">atm/cam/physprops/mam4_mode1_rrtmg_aeronetdust_c141106.nc</mam3_mode1_file>
+<mam3_mode2_file rad="rrtmgp">atm/cam/physprops/mam4_mode2_rrtmg_aitkendust_c141106.nc </mam3_mode2_file>
+<mam3_mode3_file rad="rrtmgp">atm/cam/physprops/mam4_mode3_rrtmg_aeronetdust_c141106.nc</mam3_mode3_file>
+
+<mam3_mode1_file rad="rrtmgp" ver="strat">atm/cam/physprops/mam4_mode1_rrtmg_aeronetdust_sig1.6_dgnh.48_c140304.nc</mam3_mode1_file>
+<mam3_mode3_file rad="rrtmgp" ver="strat">atm/cam/physprops/mam4_mode3_rrtmg_aeronetdust_sig1.2_dgnl.40_c150219.nc</mam3_mode3_file>
+
+<mam4_mode1_file rad="rrtmgp">atm/cam/physprops/mam4_mode1_rrtmg_aeronetdust_c141106.nc</mam4_mode1_file>
+<mam4_mode2_file rad="rrtmgp">atm/cam/physprops/mam4_mode2_rrtmg_aitkendust_c141106.nc</mam4_mode2_file>
+<mam4_mode3_file rad="rrtmgp">atm/cam/physprops/mam4_mode3_rrtmg_aeronetdust_c141106.nc</mam4_mode3_file>
+<mam4_mode4_file rad="rrtmgp">atm/cam/physprops/mam4_mode4_rrtmg_c130628.nc</mam4_mode4_file>
+
+<mam4_mode1_file rad="rrtmgp" ver="strat">atm/cam/physprops/mam4_mode1_rrtmg_aeronetdust_sig1.6_dgnh.48_c140304.nc</mam4_mode1_file>
+<mam4_mode3_file rad="rrtmgp" ver="strat" phys="cam6">atm/cam/physprops/mam4_mode3_rrtmg_aeronetdust_sig1.2_dgnl.40_c150219.nc</mam4_mode3_file>
+
+<mam5_mode1_file rad="rrtmgp" ver="strat">atm/cam/physprops/mam4_mode1_rrtmg_aeronetdust_sig1.6_dgnh.48_c140304.nc</mam5_mode1_file>
+<mam5_mode2_file rad="rrtmgp" ver="strat">atm/cam/physprops/mam4_mode2_rrtmg_aitkendust_c141106.nc</mam5_mode2_file>
+<mam5_mode3_file rad="rrtmgp" ver="strat">atm/cam/physprops/mam4_mode3_rrtmg_aeronetdust_c141106.nc</mam5_mode3_file>
+<mam5_mode4_file rad="rrtmgp" ver="strat">atm/cam/physprops/mam4_mode4_rrtmg_c130628.nc</mam5_mode4_file>
+<mam5_mode5_file rad="rrtmgp" ver="strat">atm/cam/physprops/mam4_mode3_rrtmg_aeronetdust_sig1.2_dgnl.40_c150219.nc</mam5_mode5_file>
+
+<mam7_mode1_file rad="rrtmgp">atm/cam/physprops/mam7_mode1_rrtmg_c120904.nc</mam7_mode1_file>
+<mam7_mode2_file rad="rrtmgp">atm/cam/physprops/mam7_mode2_rrtmg_c120904.nc</mam7_mode2_file>
+<mam7_mode3_file rad="rrtmgp">atm/cam/physprops/mam7_mode3_rrtmg_c120904.nc</mam7_mode3_file>
+<mam7_mode4_file rad="rrtmgp">atm/cam/physprops/mam7_mode4_rrtmg_c120904.nc</mam7_mode4_file>
+<mam7_mode5_file rad="rrtmgp">atm/cam/physprops/mam7_mode5_rrtmg_c120904.nc</mam7_mode5_file>
+<mam7_mode6_file rad="rrtmgp">atm/cam/physprops/mam7_mode6_rrtmg_c120904.nc</mam7_mode6_file>
+<mam7_mode7_file rad="rrtmgp">atm/cam/physprops/mam7_mode7_rrtmg_c120904.nc</mam7_mode7_file>
+
+<water_refindex_file>atm/cam/physprops/water_refindex_rrtmg_c080910.nc</water_refindex_file>
+
+<modal_accum_coarse_exch               >.false.</modal_accum_coarse_exch>
+<modal_accum_coarse_exch phys="cam6"   >.true.</modal_accum_coarse_exch>
+<modal_accum_coarse_exch phys="cam7"   >.true.</modal_accum_coarse_exch>
+
+<!-- Cloud optics for RRTMG -->
+<liqcldoptics  rad="rrtmg" microphys="rk">slingo</liqcldoptics>
+<icecldoptics  rad="rrtmg" microphys="rk">ebertcurry</icecldoptics>
+<liqcldoptics  rad="rrtmg">gammadist</liqcldoptics>
+<icecldoptics  rad="rrtmg">mitchell</icecldoptics>
+<iceopticsfile rad="rrtmg">atm/cam/physprops/iceoptics_c080917.nc</iceopticsfile>
+<liqopticsfile rad="rrtmg">atm/cam/physprops/F_nwvl200_mu20_lam50_res64_t298_c080428.nc</liqopticsfile>
+
+<!-- RRTMGP -->
+<liqcldoptics  rad="rrtmgp">gammadist</liqcldoptics>
+<icecldoptics  rad="rrtmgp">mitchell</icecldoptics>
+<iceopticsfile rad="rrtmgp">atm/cam/physprops/iceoptics_c080917.nc</iceopticsfile>
+<liqopticsfile rad="rrtmgp">atm/cam/physprops/F_nwvl200_mu20_lam50_res64_t298_c080428.nc</liqopticsfile>
+
+<rrtmgp_coefs_lw_file>src/physics/rrtmgp/data/rrtmgp-gas-lw-g128.nc</rrtmgp_coefs_lw_file>
+<rrtmgp_coefs_sw_file>src/physics/rrtmgp/data/rrtmgp-gas-sw-g112.nc</rrtmgp_coefs_sw_file>
+
+<!-- Top valid pressure (Pa) top for LTE radiation scheme -->
+<p_top_for_equil_rad>                  0.D0 </p_top_for_equil_rad>
+<p_top_for_equil_rad  waccmx="1" >     1.D0 </p_top_for_equil_rad>
+<p_top_for_equil_rad  waccm_phys="1" > 1.D0 </p_top_for_equil_rad>
+<p_top_for_equil_rad  rad="rrtmgp">    5.D0 </p_top_for_equil_rad>
+
+<!-- Top pressure (Pa) for non-LTE/LTE merger region -->
+<p_top_for_radmrg>                     0.D0 </p_top_for_radmrg>
+<p_top_for_radmrg  rad="rrtmgp">       6.1D0 </p_top_for_radmrg>
+
+<!-- Bottom pressure (Pa) for non-LTE/LTE merger region -->
+<p_bot_for_radmrg>                     1.D0 </p_bot_for_radmrg>
+<p_bot_for_radmrg  rad="rrtmgp">       20.D0 </p_bot_for_radmrg>
+
+<!-- Scaling factor for simplified QRS MLT heating in CAM -->
+<qrsmlt_scaling>                     1.D0 </qrsmlt_scaling>
+
+<!-- CAM-RT absorptivity/emissivity lookup table -->
+<absems_data rad="camrt">atm/cam/rad/abs_ems_factors_fastvx.c030508.nc</absems_data>
+
+<!-- CARMA file paths -->
+<carma_emis_file        carma="meteor_smoke">atm/waccm/emis/meteor_smoke_kalashnikova.nc</carma_emis_file>
+<carma_escale_file      carma="meteor_smoke">atm/waccm/emis/smoke_grf_frentzke.nc</carma_escale_file>
+<carma_emis_file        carma="mixed_sulfate">atm/waccm/emis/meteor_smoke_kalashnikova.nc</carma_emis_file>
+<carma_escale_file      carma="mixed_sulfate">atm/waccm/emis/smoke_grf_frentzke.nc</carma_escale_file>
+<carma_emis_file        carma="pmc">atm/waccm/emis/meteor_smoke_kalashnikova.nc</carma_emis_file>
+<carma_escale_file      carma="pmc">atm/waccm/emis/smoke_grf_frentzke.nc</carma_escale_file>
+<carma_mice_file        carma="pmc">atm/cam/physprops/mice_warren2008.nc</carma_mice_file>
+<carma_emis_file        carma="pmc_sulfate">atm/waccm/emis/meteor_smoke_kalashnikova.nc</carma_emis_file>
+<carma_escale_file      carma="pmc_sulfate">atm/waccm/emis/smoke_grf_frentzke.nc</carma_escale_file>
+<carma_mice_file        carma="pmc_sulfate">atm/cam/physprops/mice_warren2008.nc</carma_mice_file>
+<carma_soilerosion_file carma="cirrus_dust">atm/cam/dst/soil_erosion_factor_1x1_c120907.nc</carma_soilerosion_file>
+<carma_soilerosion_file carma="trop_strat_soa1">atm/cam/dst/soil_erosion_factor_1x1_c120907.nc</carma_soilerosion_file>
+<carma_soilerosion_file carma="trop_strat_soa5">atm/cam/dst/soil_erosion_factor_1x1_c120907.nc</carma_soilerosion_file>
+<carma_soilerosion_file carma="dust">atm/cam/dst/soil_erosion_factor_1x1_c120907.nc</carma_soilerosion_file>
+<carma_emis_file        carma="tholin">atm/waccm/emis/early_earth_haze.nc</carma_emis_file>
+
+<!-- CAM-Chem ozone (2000 climatology) -->
+<prescribed_ozone_datapath>atm/cam/ozone</prescribed_ozone_datapath>
+<prescribed_ozone_file>ozone_1.9x2.5_L26_2000clim_c091112.nc</prescribed_ozone_file>
+<prescribed_ozone_name>O3</prescribed_ozone_name>
+<prescribed_ozone_type>CYCLICAL</prescribed_ozone_type>
+<prescribed_ozone_cycle_yr>2000</prescribed_ozone_cycle_yr>
+
+<!-- Smaller ozone files used when running SCAM and asking for a CAMIOP file) -->
+<prescribed_ozone_file    phys="cam6"    scam="1" >ozone_strataero_CAM6chem_2000climo_zm_5day_c171004.nc</prescribed_ozone_file>
+<prescribed_ozone_file    phys="cam7"    scam="1" >ozone_strataero_CAM6chem_2000climo_zm_5day_c171004.nc</prescribed_ozone_file>
+<prescribed_ozone_file    phys="cam6"    camiop="1" >ozone_strataero_CAM6chem_2000climo_zm_5day_c171004.nc</prescribed_ozone_file>
+<prescribed_ozone_file    phys="cam7"    camiop="1" >ozone_strataero_CAM6chem_2000climo_zm_5day_c171004.nc</prescribed_ozone_file>
+
+<prescribed_ozone_file chem="waccm_sc">waccm_ozone_c121126.nc</prescribed_ozone_file>
+<prescribed_ozone_cycle_yr chem="waccm_sc">0</prescribed_ozone_cycle_yr>
+<prescribed_ozone_file  chem="waccm_sc_mam4">ozone_strataero_WACCM6_L70_zm5day_19750101-20141229_c180216.nc</prescribed_ozone_file>
+<prescribed_ozone_datapath chem="waccm_sc_mam4">atm/cam/ozone_strataero</prescribed_ozone_datapath>
+
+<!-- CAM-Chem aerosols (2000 climatology) -->
+<prescribed_aero_datapath  aer_model='bam'  >atm/cam/chem/trop_mozart_aero/aero</prescribed_aero_datapath>
+<prescribed_aero_file      aer_model='bam'  >aero_1.9x2.5_L26_2000clim_c091112.nc</prescribed_aero_file>
+<prescribed_aero_type      aer_model='bam'  >CYCLICAL</prescribed_aero_type>
+<prescribed_aero_cycle_yr  aer_model='bam'  >2000</prescribed_aero_cycle_yr>
+<prescribed_aero_filelist  aer_model='bam'  >aero_1.9x2.5_L26_list_c070514.txt</prescribed_aero_filelist>
+<prescribed_aero_datapath  aer_model='mam'  >atm/cam/chem/trop_mam/aero</prescribed_aero_datapath>
+<prescribed_aero_file      aer_model='mam'  >mam3_1.9x2.5_L30_2000clim_c130319.nc</prescribed_aero_file>
+<prescribed_aero_type      aer_model='mam'  >CYCLICAL</prescribed_aero_type>
+<prescribed_aero_cycle_yr  aer_model='mam'  >2000</prescribed_aero_cycle_yr>
+<prescribed_aero_filelist  aer_model='mam'  >aero_1.9x2.5_L26_list_c070514.txt</prescribed_aero_filelist>
+
+<!-- aerosol deposition (2000 climatology) -->
+<aerodep_flx_datapath  aer_model='bam'  >atm/cam/chem/trop_mozart_aero/aero</aerodep_flx_datapath>
+<aerodep_flx_file      aer_model='bam'  >aerosoldep_monthly_1849-2006_1.9x2.5_c090803.nc</aerodep_flx_file>
+<aerodep_flx_type      aer_model='bam'  >CYCLICAL</aerodep_flx_type>
+<aerodep_flx_cycle_yr  aer_model='bam'  >2000</aerodep_flx_cycle_yr>
+<aerodep_flx_datapath  aer_model='mam'  >atm/cam/chem/trop_mam/aero</aerodep_flx_datapath>
+<aerodep_flx_file      aer_model='mam'  >mam3_1.9x2.5_L30_2000clim_c130319.nc</aerodep_flx_file>
+<aerodep_flx_type      aer_model='mam'  >CYCLICAL</aerodep_flx_type>
+<aerodep_flx_cycle_yr  aer_model='mam'  >2000</aerodep_flx_cycle_yr>
+
+<!-- Volcanic Aerosol Mass -->
+<bndtvvolc>atm/cam/rad/VolcanicMass_1870-1999_64x1_L18_c040115.nc</bndtvvolc>
+
+<!-- Tropopause climatology -->
+<tropopause_climo_file>atm/cam/chem/trop_mozart/ub/clim_p_trop.nc</tropopause_climo_file>
+
+
+<!-- Solar constant -->
+<solar_const>1361.27</solar_const>
+<solar_irrad_data_file phys="cam4"               >atm/cam/solar/solar_ave_sc19-sc23.c090810.nc</solar_irrad_data_file>
+<solar_irrad_data_file phys="cam5"               >atm/cam/solar/solar_ave_sc19-sc23.c090810.nc</solar_irrad_data_file>
+<solar_irrad_data_file phys="cam4" waccm_phys="1">atm/cam/solar/spectral_irradiance_Lean_1610-2009_ann_c100405.nc</solar_irrad_data_file>
+<solar_irrad_data_file phys="cam5" waccm_phys="1">atm/cam/solar/spectral_irradiance_Lean_1610-2009_ann_c100405.nc</solar_irrad_data_file>
+<solar_irrad_data_file                           >atm/cam/solar/SolarForcing1995-2005avg_c160929.nc</solar_irrad_data_file>
+<solar_irrad_data_file             waccm_phys="1">atm/cam/solar/SolarForcing1995-2005avg_c160929.nc</solar_irrad_data_file>
+
+
+<!-- GHG values for 2000 from ghg_hist_1850-2005_c090419.nc -->
+<co2vmr>367.0e-6</co2vmr>
+<ch4vmr>1760.0e-9</ch4vmr>
+<n2ovmr>316.0e-9</n2ovmr>
+<f11vmr>653.45e-12</f11vmr>
+<f12vmr>535.0e-12</f12vmr>
+
+<!-- Time-variant chemistry surface values -->
+<bndtvghg>atm/cam/ggas/ghg_hist_1765-2005_c091218.nc</bndtvghg>
+<flbc_file>atm/waccm/lb/LBC_1765-2100_1.9x2.5_CCMI_RCP60_za_RNOCStrend_c141002.nc</flbc_file>
+<flbc_file chem="ghg_mam4" phys="cam6">atm/waccm/lb/LBC_17500116-20150116_CMIP6_0p5degLat_c180905.nc</flbc_file>
+<flbc_file                 phys="cam7">atm/waccm/lb/CMIP7/LBC_17500116-20221216_CMIP7_0p5degLat_OCSupdate_c250523.nc</flbc_file>
+
+<!-- Time-variant CO2 fossil fuel emissions -->
+<co2flux_fuel_file hgrid="0.9x1.25" sim_year="1850-2015">atm/cam/ggas/emissions-cmip6_CO2_anthro_surface_175001-201512_fv_0.9x1.25_c20181011.nc</co2flux_fuel_file>
+<co2flux_fuel_file hgrid="1.9x2.5"  sim_year="1850-2015">atm/cam/ggas/emissions-cmip6_CO2_anthro_surface_175001-201512_fv_1.9x2.5_c20181011.nc</co2flux_fuel_file>
+<co2flux_fuel_file hgrid="C384" sim_year="1850-2015">atm/cam/ggas/emissions-cmip6_CO2_anthro_surface_175001-201512_fv_0.9x1.25_c20181011.nc</co2flux_fuel_file>
+<co2flux_fuel_file hgrid="C192" sim_year="1850-2015">atm/cam/ggas/emissions-cmip6_CO2_anthro_surface_175001-201512_fv_0.9x1.25_c20181011.nc</co2flux_fuel_file>
+<co2flux_fuel_file hgrid="C96" sim_year="1850-2015">atm/cam/ggas/emissions-cmip6_CO2_anthro_surface_175001-201512_fv_0.9x1.25_c20181011.nc</co2flux_fuel_file>
+<co2flux_fuel_file hgrid="C48" sim_year="1850-2015">atm/cam/ggas/emissions-cmip6_CO2_anthro_surface_175001-201512_fv_1.9x2.5_c20181011.nc</co2flux_fuel_file>
+<co2flux_fuel_file hgrid="C24" sim_year="1850-2015">atm/cam/ggas/emissions-cmip6_CO2_anthro_surface_175001-201512_fv_1.9x2.5_c20181011.nc</co2flux_fuel_file>
+
+<ac_CO2_emis hgrid="0.9x1.25">ac_CO2_filelist_175001-201512_fv_0.9x1.25_c20181011.txt</ac_CO2_emis>
+<ac_CO2_emis hgrid="1.9x2.5" >ac_CO2_filelist_175001-201512_fv_1.9x2.5_c20181011.txt</ac_CO2_emis>
+<ac_CO2_emis hgrid="C384">ac_CO2_filelist_175001-201512_fv_0.9x1.25_c20181011.txt</ac_CO2_emis>
+<ac_CO2_emis hgrid="C192">ac_CO2_filelist_175001-201512_fv_0.9x1.25_c20181011.txt</ac_CO2_emis>
+<ac_CO2_emis hgrid="C96">ac_CO2_filelist_175001-201512_fv_0.9x1.25_c20181011.txt</ac_CO2_emis>
+<ac_CO2_emis hgrid="C48" >ac_CO2_filelist_175001-201512_fv_1.9x2.5_c20181011.txt</ac_CO2_emis>
+<ac_CO2_emis hgrid="C24" >ac_CO2_filelist_175001-201512_fv_1.9x2.5_c20181011.txt</ac_CO2_emis>
+<aircraft_datapath >atm/cam/ggas</aircraft_datapath>
+<aircraft_type     >SERIAL</aircraft_type>
+<!-- These CO2 aircraft emission files are the same as in the aircraft_specifier file above (for cam.input_data_list) -->
+<aircraft_co2_file  hgrid="0.9x1.25">atm/cam/ggas/emissions-cmip6_CO2_anthro_ac_175001-201512_fv_0.9x1.25_c20181011.nc</aircraft_co2_file>
+<aircraft_co2_file  hgrid="1.9x2.5" >atm/cam/ggas/emissions-cmip6_CO2_anthro_ac_175001-201512_fv_1.9x2.5_c20181011.nc</aircraft_co2_file>
+<aircraft_co2_file  hgrid="C384">atm/cam/ggas/emissions-cmip6_CO2_anthro_ac_175001-201512_fv_0.9x1.25_c20181011.nc</aircraft_co2_file>
+<aircraft_co2_file  hgrid="C192">atm/cam/ggas/emissions-cmip6_CO2_anthro_ac_175001-201512_fv_0.9x1.25_c20181011.nc</aircraft_co2_file>
+<aircraft_co2_file  hgrid="C96">atm/cam/ggas/emissions-cmip6_CO2_anthro_ac_175001-201512_fv_0.9x1.25_c20181011.nc</aircraft_co2_file>
+<aircraft_co2_file  hgrid="C48" >atm/cam/ggas/emissions-cmip6_CO2_anthro_ac_175001-201512_fv_1.9x2.5_c20181011.nc</aircraft_co2_file>
+<aircraft_co2_file  hgrid="C24" >atm/cam/ggas/emissions-cmip6_CO2_anthro_ac_175001-201512_fv_1.9x2.5_c20181011.nc</aircraft_co2_file>
+
+<!-- Greenhouse gas production/loss rates -->
+<bndtvg>atm/cam/ggas/noaamisc.r8.nc</bndtvg>
+
+<!-- WACCM_GHG H2O production/loss rates -->
+<h2orates chem="waccm_sc"     >atm/waccm/phot/xh2o_c080826.nc</h2orates>
+<h2orates chem="waccm_sc_mam4">atm/waccm/phot/xh2o_c080826.nc</h2orates>
+<h2orates chem="ghg_mam4"     >atm/waccm/phot/xh2o_c080826.nc</h2orates>
+
+<!-- Constituents for non-LTE calculations and heating rates below 200 nm -->
+<waccm_forcing_datapath chem="waccm_sc">atm/waccm/ub</waccm_forcing_datapath>
+<waccm_forcing_file     chem="waccm_sc">ghg_forcing_2000_c110321.nc</waccm_forcing_file>
+<waccm_forcing_cycle_yr chem="waccm_sc">0</waccm_forcing_cycle_yr>
+<waccm_forcing_datapath chem="waccm_sc_mam4">atm/waccm/waccm_forcing</waccm_forcing_datapath>
+<waccm_forcing_file     chem="waccm_sc_mam4">SCWACCM_forcing_WACCM6_zm_5day_L70_1975-2014_c191121.nc</waccm_forcing_file>
+<waccm_forcing_cycle_yr chem="waccm_sc_mam4">2000</waccm_forcing_cycle_yr>
+
+<!-- Waccm electric field parameters -->
+<efield_lflux_file >atm/waccm/efld/coeff_lflux.dat</efield_lflux_file>
+<efield_hflux_file >atm/waccm/efld/coeff_hflux.dat</efield_hflux_file>
+
+<!-- International Geomagnetic Reference Field coefficients -->
+<igrf_geomag_coefs_file>atm/waccm/geomag/IGRF14_coeffs_c250130.nc</igrf_geomag_coefs_file>
+
+<!-- Waccm aurora and euv parameters -->
+<photon_file    >atm/waccm/phot/photon_c130710.dat</photon_file>
+<electron_file  >atm/waccm/phot/electron_121129.dat</electron_file>
+<euvac_file     >atm/waccm/phot/EUVAC_reference_c170222.nc</euvac_file>
+
+<!-- Waccm solar variability parameters -->
+<solar_parms_data_file               >atm/waccm/phot/wasolar_ave.nc</solar_parms_data_file>
+
+<solar_parms_data_file phys="cam4" waccm_phys="1">atm/waccm/solar/wasolar_c140408.nc</solar_parms_data_file>
+<solar_parms_data_file phys="cam5" waccm_phys="1">atm/waccm/solar/wasolar_c140408.nc</solar_parms_data_file>
+<solar_parms_data_file             waccm_phys="1">atm/cam/solar/SolarForcing1995-2005avg_c160929.nc</solar_parms_data_file>
+
+<solar_wind_data_file>atm/waccm/solar/solar_wind_imf_OMNI_WACCMX_2000001-2017365_c180731.nc</solar_wind_data_file>
+
+<!-- Default bounce cone loss angle (degrees) for medium-energy electrons
+  80 degrees is the value used to generate CMIP6 MEE forcings provided by SOLARISHEPPA (http://solarisheppa.geomar.de).
+  (Recommendations for CMIP6 solar forcing data, Geosci. Model Dev., 10, doi:10.5194/gmd-10-2247-2017)
+  (Private communication with Pekka Verronen)
+-->
+<mee_ion_blc>80.D0</mee_ion_blc>
+
+<!-- nudged QBO  -->
+<qbo_forcing_file>atm/waccm/qbo/qbocoefficients_c151023.nc</qbo_forcing_file>
+
+<!-- Gravity wave settings for WACCM -->
+<effgw_oro>0.125D0</effgw_oro>
+
+<effgw_cm>1.D0</effgw_cm>
+
+<taubgnd                 >1.5D-3</taubgnd>
+<taubgnd hgrid="4x5"     >1.0D-3</taubgnd>
+<taubgnd hgrid="0.9x1.25">2.5D-3</taubgnd>
+<taubgnd hgrid="ne30np4" >1.25D-3</taubgnd>
+
+<effgw_cm_igw>0.1D0</effgw_cm_igw>
+<taubgnd_igw>12.0D-3</taubgnd_igw>
+
+<frontgfc                 >1.25D-15</frontgfc>
+<frontgfc hgrid="ne30np4" >3.00D-15</frontgfc>
+<frontgfc hgrid="4x5"     >7.5D-16</frontgfc>
+<frontgfc hgrid="0.9x1.25">3.0D-15</frontgfc>
+<front_gaussian_width> 30.D0 </front_gaussian_width>
+
+<!-- Polar taper is needed for stability in FV, possibly because grid -->
+<!-- points become too dense near the poles. -->
+<gw_polar_taper>.false.</gw_polar_taper>
+<gw_polar_taper dyn="fv">.true.</gw_polar_taper>
+
+<gw_top_taper>.false.</gw_top_taper>
+<gw_top_taper waccmx="1">.true.</gw_top_taper>
+
+<pgwv>32</pgwv>
+<pgwv waccmx="1">18</pgwv>
+
+<!-- gravity wave settings -->
+
+<effgw_beres_dp                                               >0.7D0</effgw_beres_dp>
+<effgw_beres_dp model_top="lt"                                >0.15D0</effgw_beres_dp>
+<effgw_beres_dp model_top="mt"  waccm_phys="1"                >0.15D0</effgw_beres_dp>
+<effgw_beres_dp model_top="mt"                                >0.15D0</effgw_beres_dp>
+<effgw_beres_dp model_top="ht" phys="cam7"                    >0.25D0</effgw_beres_dp>
+<effgw_beres_dp model_top="xt" phys="cam7"                    >0.25D0</effgw_beres_dp>
+<effgw_beres_dp hgrid="0.9x1.25"                              >0.4D0</effgw_beres_dp>
+<effgw_beres_dp waccm_phys="0"                                >0.55D0</effgw_beres_dp>
+<effgw_beres_dp waccm_phys="1" hgrid="0.9x1.25"               >0.5D0</effgw_beres_dp>
+<effgw_beres_dp waccm_phys="1" hgrid="ne30np4"                >0.5D0</effgw_beres_dp>
+<effgw_beres_dp chem="geoschem_mam4" hgrid="0.9x1.25"         >0.5D0</effgw_beres_dp>
+<effgw_beres_dp chem="trop_strat_mam5_t1s1" hgrid="0.9x1.25"   >0.5D0</effgw_beres_dp>
+<effgw_beres_dp chem="trop_strat_mam5_vbsext" hgrid="0.9x1.25">0.5D0</effgw_beres_dp>
+<effgw_beres_dp chem="trop_strat_mam5_slh" hgrid="0.9x1.25"   >0.5D0</effgw_beres_dp>
+<effgw_beres_dp carma="trop_strat_soa1" hgrid="0.9x1.25"      >0.5D0</effgw_beres_dp>
+<effgw_beres_dp carma="trop_strat_soa5" hgrid="0.9x1.25"      >0.5D0</effgw_beres_dp>
+
+<effgw_rdg_resid                   >1.0D0</effgw_rdg_resid>
+
+<effgw_rdg_beta                    >1.0D0</effgw_rdg_beta>
+<effgw_rdg_beta model_top="lt"     >0.75D0</effgw_rdg_beta>
+<effgw_rdg_beta model_top="mt"     >0.75D0</effgw_rdg_beta>
+
+<effgw_rdg_beta_max                >1.0D0</effgw_rdg_beta_max>
+<effgw_rdg_beta_max model_top="lt" >0.75D0</effgw_rdg_beta_max>
+<effgw_rdg_beta_max model_top="mt" >0.75D0</effgw_rdg_beta_max>
+
+<!-- setting for gravity waves from shallow convection. -->
+<effgw_beres_sh>0.03D0</effgw_beres_sh>
+
+<!-- gravity wave options -->
+<gw_drag_file>atm/waccm/gw/newmfspectra40_dc25.nc</gw_drag_file>
+<gw_drag_file_sh>atm/waccm/gw/mfspectra_shallow_c140530.nc</gw_drag_file_sh>
+<gw_drag_file_mm>atm/waccm/gw/mfc0lookup_mm.nc</gw_drag_file_mm>
+<gw_prndl                               >0.25d0 </gw_prndl>
+<gw_prndl                 waccm_phys="1">0.5d0  </gw_prndl>
+<gw_prndl     chem="geoschem_mam4">0.5d0  </gw_prndl>
+<gw_prndl     chem="trop_strat_mam4_vbs">0.5d0  </gw_prndl>
+<gw_prndl     chem="trop_strat_mam4_vbsext">0.5d0  </gw_prndl>
+<gw_prndl     chem="trop_strat_mam5_t1s1">0.5d0  </gw_prndl>
+<gw_prndl     chem="trop_strat_mam5_vbsext">0.5d0  </gw_prndl>
+<gw_prndl     chem="trop_strat_mam4_slh">0.5d0  </gw_prndl>
+<gw_prndl     chem="trop_strat_mam5_slh">0.5d0  </gw_prndl>
+<gw_oro_south_fac                       >1.d0   </gw_oro_south_fac>
+<gw_oro_south_fac         model_top="mt">1.d0   </gw_oro_south_fac>
+<gw_oro_south_fac         waccm_phys="1">2.d0   </gw_oro_south_fac>
+<gw_oro_south_fac         model_top="ht">2.d0   </gw_oro_south_fac>
+<gw_oro_south_fac chem="geoschem_mam4">2.d0   </gw_oro_south_fac>
+<gw_oro_south_fac chem="trop_strat_mam4_vbs">2.d0   </gw_oro_south_fac>
+<gw_oro_south_fac chem="trop_strat_mam4_vbsext">2.d0   </gw_oro_south_fac>
+<gw_oro_south_fac chem="trop_strat_mam4_slh">2.d0   </gw_oro_south_fac>
+<gw_oro_south_fac chem="trop_strat_mam5_slh">2.d0   </gw_oro_south_fac>
+<gw_oro_south_fac chem="trop_strat_mam5_t1s1">2.d0   </gw_oro_south_fac>
+<gw_oro_south_fac chem="trop_strat_mam5_vbsext">2.d0   </gw_oro_south_fac>
+<gw_oro_south_fac carma="trop_strat_soa1">2.D0</gw_oro_south_fac>
+<gw_oro_south_fac carma="trop_strat_soa5">2.D0</gw_oro_south_fac>
+<gw_lndscl_sgh                          >.true. </gw_lndscl_sgh>
+<gw_lndscl_sgh            model_top="mt">.true. </gw_lndscl_sgh>
+<gw_lndscl_sgh            waccm_phys="1">.false.</gw_lndscl_sgh>
+<gw_lndscl_sgh            model_top="ht">.false.</gw_lndscl_sgh>
+<gw_lndscl_sgh chem="geoschem_mam4">.false.</gw_lndscl_sgh>
+<gw_lndscl_sgh chem="trop_strat_mam4_vbs">.false.</gw_lndscl_sgh>
+<gw_lndscl_sgh chem="trop_strat_mam4_vbsext">.false.</gw_lndscl_sgh>
+<gw_lndscl_sgh chem="trop_strat_mam4_slh">.false.</gw_lndscl_sgh>
+<gw_lndscl_sgh chem="trop_strat_mam5_slh">.false.</gw_lndscl_sgh>
+<gw_lndscl_sgh chem="trop_strat_mam5_t1s1">.false.</gw_lndscl_sgh>
+<gw_lndscl_sgh chem="trop_strat_mam5_vbsext">.false.</gw_lndscl_sgh>
+<gw_lndscl_sgh carma="trop_strat_soa1">.false.</gw_lndscl_sgh>
+<gw_lndscl_sgh carma="trop_strat_soa5">.false.</gw_lndscl_sgh>
+<gw_apply_tndmax                          >.true. </gw_apply_tndmax>
+<gw_apply_tndmax chem="geoschem_mam4"     >.false.</gw_apply_tndmax>
+<gw_apply_tndmax phys="cam7"              >.false.</gw_apply_tndmax>
+<gw_apply_tndmax            waccm_phys="1">.false.</gw_apply_tndmax>
+<gw_apply_tndmax chem="trop_strat_mam4_vbs">.false.</gw_apply_tndmax>
+<gw_apply_tndmax chem="trop_strat_mam4_vbsext">.false.</gw_apply_tndmax>
+<gw_apply_tndmax chem="trop_strat_mam4_slh">.false.</gw_apply_tndmax>
+<gw_apply_tndmax chem="trop_strat_mam5_slh">.false.</gw_apply_tndmax>
+<gw_apply_tndmax chem="trop_strat_mam5_t1s1">.false.</gw_apply_tndmax>
+<gw_apply_tndmax chem="trop_strat_mam5_vbsext">.false.</gw_apply_tndmax>
+<gw_apply_tndmax carma="trop_strat_soa1">.false.</gw_apply_tndmax>
+<gw_apply_tndmax carma="trop_strat_soa5">.false.</gw_apply_tndmax>
+
+<!-- gravity wave drag options -->
+<gw_rdg_do_divstream                    >.true.  </gw_rdg_do_divstream>
+<gw_rdg_do_smooth_regimes               >.false. </gw_rdg_do_smooth_regimes>
+<gw_rdg_do_adjust_tauoro                >.true.  </gw_rdg_do_adjust_tauoro>
+<gw_rdg_C_BetaMax_DS                    > 0.0d0  </gw_rdg_C_BetaMax_DS>
+<gw_rdg_C_GammaMax                      > 2.0d0  </gw_rdg_C_GammaMax>
+<gw_rdg_Frx0                            > 2.0d0  </gw_rdg_Frx0>
+<gw_rdg_Frx1                            > 3.0d0  </gw_rdg_Frx1>
+<gw_rdg_C_BetaMax_SM                    > 2.0d0  </gw_rdg_C_BetaMax_SM>
+<gw_rdg_orohmin                         > 0.01d0 </gw_rdg_orohmin>
+<gw_rdg_orovmin                         > 1.0d-3 </gw_rdg_orovmin>
+<gw_rdg_orostratmin                     > 0.002d0</gw_rdg_orostratmin>
+<gw_rdg_orom2min                        > 0.1d0  </gw_rdg_orom2min>
+<alpha_gw_movmtn                        > 0.01d0  </alpha_gw_movmtn>
+<effgw_movmtn_pbl                       > 1.0d0   </effgw_movmtn_pbl>
+<effgw_movmtn_pbl phys="cam7"           > 1.5d0   </effgw_movmtn_pbl>
+<movmtn_psteer                          > 65000.0d0  </movmtn_psteer>
+<movmtn_plaunch                         > 32500.0d0  </movmtn_plaunch>
+<movmtn_source                          > 1       </movmtn_source>
+
+
+<!-- Dry Convective Adjustment options -->
+<dadadj_niter>15</dadadj_niter>
+<dadadj_niter hgrid="0.47x0.63" waccmx="1">100</dadadj_niter>
+
+<!-- Waccm-x runtime options -->
+<waccmx_opt                             >off</waccmx_opt>
+<waccmx_opt waccmx="1"                  >ionosphere</waccmx_opt>
+<waccmx_opt waccmx="1" ionosphere="none">neutral</waccmx_opt>
+<ionos_epotential_model>heelis</ionos_epotential_model>
+<wei05_coefs_file>atm/waccm/efld/wei05sc_c080415.nc</wei05_coefs_file>
+<ionos_xport_nsplit waccmx="1">5</ionos_xport_nsplit>
+<ionos_xport_nsplit hgrid="0.9x1.25" waccmx="1">30</ionos_xport_nsplit>
+<ionos_xport_nsplit hgrid="ne30np4"  waccmx="1">30</ionos_xport_nsplit>
+<ionos_xport_nsplit hgrid="0.47x0.63" waccmx="1">90</ionos_xport_nsplit>
+<ionos_xport_nsplit hgrid="ne120np4"  waccmx="1">180</ionos_xport_nsplit>
+<oplus_ring_polar_filter>.true.</oplus_ring_polar_filter>
+<oplus_shapiro_const                 >3.d-2</oplus_shapiro_const>
+<oplus_shapiro_const hgrid="ne120np4">6.d-3</oplus_shapiro_const>
+
+<!-- Oplus transport grid configuration -->
+<oplus_grid> 144,96 </oplus_grid>
+<oplus_grid hgrid="ne16np4"> 144,96 </oplus_grid>
+<oplus_grid hgrid="ne30np4"> 288,192 </oplus_grid>
+<oplus_grid hgrid="0.9x1.25"> 288,192 </oplus_grid>
+<oplus_grid hgrid="0.47x0.63"> 576,384 </oplus_grid>
+<oplus_grid hgrid="ne120np4"> 576,384 </oplus_grid>
+<!-- Magnetic grid resolution -->
+<edyn_grid>80x97</edyn_grid>
+<edyn_grid hgrid="0.9x1.25">160x193</edyn_grid>
+<edyn_grid hgrid="ne30np4" >160x193</edyn_grid>
+<edyn_grid hgrid="0.47x0.63">320x385</edyn_grid>
+<edyn_grid hgrid="ne120np4" >320x385</edyn_grid>
+
+<!-- For ESMF regrid zonal-mean TEM diagnostics -->
+<ctem_diags_numlats>0</ctem_diags_numlats>
+<ctem_diags_numlats hgrid="ne16np4">90</ctem_diags_numlats>
+<ctem_diags_numlats hgrid="ne30np4">180</ctem_diags_numlats>
+
+<!-- For scaling lightning sources of NOx -->
+<lght_no_prd_factor                                              >1.00D0</lght_no_prd_factor>
+<lght_no_prd_factor                hgrid="ne30np4"                  >1.80D0</lght_no_prd_factor>
+<lght_no_prd_factor                hgrid="ne0np4CONUS.ne30x8"       >1.80D0</lght_no_prd_factor>
+<lght_no_prd_factor phys="cam6"    hgrid="0.9x1.25"                 >1.50D0</lght_no_prd_factor>
+<lght_no_prd_factor phys="cam6"                      offline_dyn="1">1.30D0</lght_no_prd_factor>
+<lght_no_prd_factor phys="cam6"    hgrid="0.9x1.25"  offline_dyn="1">1.60D0</lght_no_prd_factor>
+<lght_no_prd_factor phys="cam6"    hgrid="0.47x0.63" offline_dyn="1">0.32D0</lght_no_prd_factor>
+<lght_no_prd_factor phys="cam7"    hgrid="0.9x1.25"                 >1.50D0</lght_no_prd_factor>
+<lght_no_prd_factor phys="cam7"                      offline_dyn="1">1.30D0</lght_no_prd_factor>
+<lght_no_prd_factor phys="cam7"    hgrid="0.9x1.25"  offline_dyn="1">1.60D0</lght_no_prd_factor>
+<lght_no_prd_factor phys="cam7"    hgrid="0.47x0.63" offline_dyn="1">0.32D0</lght_no_prd_factor>
+
+<!-- For MEGAN VOCs -->
+<megan_factors_file>atm/cam/chem/trop_mozart/emis/megan21_emis_factors_78pft_c20161108.nc</megan_factors_file>
+<!-- For ocean emissions -->
+<ocean_salinity_file>atm/cam/chem/ocnexch/SSS_climatology_f09f09_c20230110.nc</ocean_salinity_file>
+<dms_ocn_emis_file>atm/cam/chem/ocnexch/Csw_DMS_Lana2011_f09f09_1750_2100_20200717a.nc</dms_ocn_emis_file>
+
+<!-- Airplane emissions -->
+<airpl_emis_file>atm/cam/chem/trop_mozart/emis/emissions.aircraft.T42LR.nc</airpl_emis_file>
+<no2_aircraft_emis_file>atm/cam/chem/1850-2000_emis/IPCC_emissions_aircraft_NO2_1850-2000_1.9x2.5_c090729.nc</no2_aircraft_emis_file>
+<bc_aircraft_emis_file>atm/cam/chem/1850-2000_emis/IPCC_emissions_aircraft_BC_1850-2000_1.9x2.5.c090729.nc</bc_aircraft_emis_file>
+
+<co_aircraft_emis  >atm/cam/chem/trop_mozart/emis/extfrc.CO.1.9x2.5_c101206.nc</co_aircraft_emis>
+<no_aircraft_emis  >atm/cam/chem/trop_mozart/emis/extfrc.NO.1.9x2.5_c101206.nc</no_aircraft_emis>
+<so2_aircraft_emis >atm/cam/chem/trop_mozart/emis/extfrc.SO2.1.9x2.5_c101206.nc</so2_aircraft_emis>
+
+<!-- Trop chem emissions (default emis files) -->
+<bigalk_emis_file      >atm/cam/chem/emis/1992-2010/emissions.BIGALK.surface.1.9x2.5_c110426.nc</bigalk_emis_file>
+<bigene_emis_file      >atm/cam/chem/emis/1992-2010/emissions.BIGENE.surface.1.9x2.5_c110426.nc</bigene_emis_file>
+<c10h16_emis_file      >atm/cam/chem/emis/1992-2010/emissions.C10H16.surface.1.9x2.5_c110426.nc</c10h16_emis_file>
+<c2h2_emis_file        >atm/cam/chem/emis/1992-2010/emissions.C2H2.surface.1.9x2.5_c110426.nc</c2h2_emis_file>
+<c2h4_emis_file        >atm/cam/chem/emis/1992-2010/emissions.C2H4.surface.1.9x2.5_c110426.nc</c2h4_emis_file>
+<c2h5oh_emis_file      >atm/cam/chem/emis/1992-2010/emissions.C2H5OH.surface.1.9x2.5_c110426.nc</c2h5oh_emis_file>
+<c2h6_emis_file        >atm/cam/chem/emis/1992-2010/emissions.C2H6.surface.1.9x2.5_c110426.nc</c2h6_emis_file>
+<c3h6_emis_file        >atm/cam/chem/emis/1992-2010/emissions.C3H6.surface.1.9x2.5_c110426.nc</c3h6_emis_file>
+<c3h8_emis_file        >atm/cam/chem/emis/1992-2010/emissions.C3H8.surface.1.9x2.5_c110426.nc</c3h8_emis_file>
+<cb1_emis_file         >atm/cam/chem/emis/1992-2010/emissions.CB1.surface.1.9x2.5_c110426.nc</cb1_emis_file>
+<cb2_emis_file         >atm/cam/chem/emis/1992-2010/emissions.CB2.surface.1.9x2.5_c110426.nc</cb2_emis_file>
+<ch2o_emis_file        >atm/cam/chem/emis/1992-2010/emissions.CH2O.surface.1.9x2.5_c110426.nc</ch2o_emis_file>
+<ch3cho_emis_file      >atm/cam/chem/emis/1992-2010/emissions.CH3CHO.surface.1.9x2.5_c110426.nc</ch3cho_emis_file>
+<ch3cn_emis_file       >atm/cam/chem/emis/1992-2010/emissions.CH3CN.surface.1.9x2.5_c110426.nc</ch3cn_emis_file>
+<ch3coch3_emis_file    >atm/cam/chem/emis/1992-2010/emissions.CH3COCH3.surface.1.9x2.5_c110426.nc</ch3coch3_emis_file>
+<acetone_emis_file     >atm/cam/chem/emis/1992-2010/emissions.CH3COCH3.surface.1.9x2.5_c110426.nc</acetone_emis_file>
+<ch3cooh_emis_file     >atm/cam/chem/emis/1992-2010/emissions.CH3COOH.surface.1.9x2.5_c110426.nc</ch3cooh_emis_file>
+<ch3oh_emis_file       >atm/cam/chem/emis/1992-2010/emissions.CH3OH.surface.1.9x2.5_c110426.nc</ch3oh_emis_file>
+<co_emis_file          >atm/cam/chem/emis/1992-2010/emissions.CO.surface.1.9x2.5_c110426.nc</co_emis_file>
+<dms_emis_file         >atm/cam/chem/emis/1992-2010/emissions.DMS.surface.1.9x2.5_c110426.nc</dms_emis_file>
+<hcn_emis_file         >atm/cam/chem/emis/1992-2010/emissions.HCN.surface.1.9x2.5_c110426.nc</hcn_emis_file>
+<hcooh_emis_file       >atm/cam/chem/emis/1992-2010/emissions.HCOOH.surface.1.9x2.5_c110426.nc</hcooh_emis_file>
+<isop_emis_file        >atm/cam/chem/emis/1992-2010/emissions.ISOP.surface.1.9x2.5_c110426.nc</isop_emis_file>
+<mek_emis_file         >atm/cam/chem/emis/1992-2010/emissions.MEK.surface.1.9x2.5_c110426.nc</mek_emis_file>
+<nh3_emis_file         >atm/cam/chem/emis/1992-2010/emissions.NH3.surface.1.9x2.5_c110426.nc</nh3_emis_file>
+<no_emis_file          >atm/cam/chem/emis/1992-2010/emissions.NO.surface.1.9x2.5_c110426.nc</no_emis_file>
+<nox_emis_file         >atm/cam/chem/emis/1992-2010/emissions.NO.surface.1.9x2.5_c110426.nc</nox_emis_file>
+<oc1_emis_file         >atm/cam/chem/emis/1992-2010/emissions.OC1.surface.1.9x2.5_c110426.nc</oc1_emis_file>
+<oc2_emis_file         >atm/cam/chem/emis/1992-2010/emissions.OC1.surface.1.9x2.5_c110426.nc</oc2_emis_file>
+<so2_emis_file         >atm/cam/chem/emis/1992-2010/emissions.SO2.surface.1.9x2.5_c110426.nc</so2_emis_file>
+<toluene_emis_file     >atm/cam/chem/emis/1992-2010/emissions.TOLUENE.surface.1.9x2.5_c110426.nc</toluene_emis_file>
+<soa_benzene_emis_file >atm/cam/chem/emis/1992-2010/emissions.SOA_BENZENE.surface.1.9x2.5_c120313.nc</soa_benzene_emis_file>
+<soa_xylene_emis_file  >atm/cam/chem/emis/1992-2010/emissions.SOA_XYLENE.surface.1.9x2.5_c120313.nc</soa_xylene_emis_file>
+<soa_toluene_emis_file >atm/cam/chem/emis/1992-2010/emissions.SOA_TOLUENE.surface.1.9x2.5_c120313.nc</soa_toluene_emis_file>
+<benzene_emis_file     >atm/cam/chem/2000_emis/IPCC_emissions_houw_BENZENE_2000_1.9x2.5_c120227.nc</benzene_emis_file>
+<xylene_emis_file      >atm/cam/chem/2000_emis/IPCC_emissions_houw_XYLENE_2000_1.9x2.5_c120227.nc</xylene_emis_file>
+
+<!-- WACCM emissions -->
+<nox_emis_file  chem="waccm_ma">atm/cam/chem/1850-2000_emis/IPCC_emissions_houw_NOx_1850-2000_1.9x2.5.c090728.nc</nox_emis_file>
+<co_emis_file   chem="waccm_ma">atm/cam/chem/1850-2000_emis/IPCC_emissions_houw_CO_1850-2000_1.9x2.5.c090728.nc</co_emis_file>
+<ch2o_emis_file chem="waccm_ma">atm/cam/chem/1850-2000_emis/IPCC_emissions_houw_CH2O_1850-2000_1.9x2.5.c090728.nc</ch2o_emis_file>
+<so2_emis_file  chem="waccm_ma">atm/cam/chem/1850-2000_emis/IPCC_emissions_houw_SO2_1850-2000_1.9x2.5.c090522.nc</so2_emis_file>
+
+<nox_emis_file  chem="waccm_ma_sulfur">atm/cam/chem/1850-2000_emis/IPCC_emissions_houw_NOx_1850-2000_1.9x2.5.c090728.nc</nox_emis_file>
+<co_emis_file   chem="waccm_ma_sulfur">atm/cam/chem/1850-2000_emis/IPCC_emissions_houw_CO_1850-2000_1.9x2.5.c090728.nc</co_emis_file>
+<ch2o_emis_file chem="waccm_ma_sulfur">atm/cam/chem/1850-2000_emis/IPCC_emissions_houw_CH2O_1850-2000_1.9x2.5.c090728.nc</ch2o_emis_file>
+<so2_emis_file  chem="waccm_ma_sulfur">atm/cam/chem/1850-2000_emis/IPCC_emissions_houw_SO2_1850-2000_1.9x2.5.c090522.nc</so2_emis_file>
+
+<!-- BAM and MAM aerosol emissions -->
+<dms_emis_bam      >atm/cam/chem/trop_mozart_aero/emis/aerocom_DMS_2000.c080417.nc</dms_emis_bam>
+<cb1_emis_bam      >atm/cam/chem/trop_mozart_aero/emis/aerocom_CB1_2000.c080807.nc</cb1_emis_bam>
+<oc1_emis_bam      >atm/cam/chem/trop_mozart_aero/emis/aerocom_OC1_2000.nosoa.c080807.nc</oc1_emis_bam>
+<so2_emis_bam      >atm/cam/chem/trop_mozart_aero/emis/aerocom_SO2_surface_2000.c080807.nc</so2_emis_bam>
+<so4_emis_bam      >atm/cam/chem/trop_mozart_aero/emis/aerocom_SO4_surface_2000.c080807.nc</so4_emis_bam>
+
+<so2_vrt_emis_file >atm/cam/chem/trop_mozart_aero/emis/aerocom_SO2_vertical_2000.c080807.nc</so2_vrt_emis_file>
+<so4_vrt_emis_file >atm/cam/chem/trop_mozart_aero/emis/aerocom_SO4_vertical_2000.c080807.nc</so4_vrt_emis_file>
+
+<!-- SLH chemistry emissions -->
+<c2cl4_slh_emis_file  >atm/cam/chem/emis/EMIS_SLH/flxSLH1p15/emissions_C2Cl4_NoNeg_surface_Claxton2020_flx1p15_serial_1750-2100_1.9x2.5_c251203.nc</c2cl4_slh_emis_file>
+<ch2br2_slh_emis_file >atm/cam/chem/emis/EMIS_SLH/flxSLH1p15/emissions_CH2Br2_chlorophyll_surface_Ordonez2012_flx1p15_cyclical_1750-2100_1.9x2.5_c251204.nc</ch2br2_slh_emis_file>
+<ch2brcl_slh_emis_file>atm/cam/chem/emis/EMIS_SLH/flxSLH1p15/emissions_CH2BrCl_chlorophyll_surface_Ordonez2012_flx1p15_cyclical_1750-2100_1.9x2.5_c251204.nc</ch2brcl_slh_emis_file>
+<ch2cl2_slh_emis_file >atm/cam/chem/emis/EMIS_SLH/flxSLH1p15/emissions_CH2Cl2_NoNeg_surface_Claxton2020_flx1p15_serial_1750-2100_1.9x2.5_c251203.nc</ch2cl2_slh_emis_file>
+<ch2i2_slh_emis_file  >atm/cam/chem/emis/EMIS_SLH/emissions_CH2I2_chlorophyll_surface_Ordonez2012_cyclical_1750-2100_1.9x2.5_c251204.nc</ch2i2_slh_emis_file>
+<ch2ibr_slh_emis_file >atm/cam/chem/emis/EMIS_SLH/emissions_CH2IBr_chlorophyll_surface_Ordonez2012_cyclical_1750-2100_1.9x2.5_c251204.nc</ch2ibr_slh_emis_file>
+<ch2icl_slh_emis_file >atm/cam/chem/emis/EMIS_SLH/emissions_CH2ICl_chlorophyll_surface_Ordonez2012_cyclical_1750-2100_1.9x2.5_c251204.nc</ch2icl_slh_emis_file>
+<ch3i_slh_emis_file   >atm/cam/chem/emis/EMIS_SLH/emissions_CH3I_chlorophyll_surface_Ordonez2012_cyclical_1750-2100_1.9x2.5_c251204.nc</ch3i_slh_emis_file>
+<chbr2cl_slh_emis_file>atm/cam/chem/emis/EMIS_SLH/flxSLH1p15/emissions_CHBr2Cl_chlorophyll_surface_Ordonez2012_flx1p15_cyclical_1750-2100_1.9x2.5_c251204.nc</chbr2cl_slh_emis_file>
+<chbr3_slh_emis_file  >atm/cam/chem/emis/EMIS_SLH/flxSLH1p15/emissions_CHBr3_chlorophyll_surface_Ordonez2012_flx1p15_cyclical_1750-2100_1.9x2.5_c251204.nc</chbr3_slh_emis_file>
+<chbrcl2_slh_emis_file>atm/cam/chem/emis/EMIS_SLH/flxSLH1p15/emissions_CHBrCl2_chlorophyll_surface_Ordonez2012_flx1p15_cyclical_1750-2100_1.9x2.5_c251204.nc</chbrcl2_slh_emis_file>
+<hoi_slh_emis_file    >atm/cam/chem/emis/EMIS_SLH/emissions_HOI_ocean_surface_PradosRoman2015_online_1750-2100_1.9x2.5_c251204.nc</hoi_slh_emis_file>
+<i2_slh_emis_file     >atm/cam/chem/emis/EMIS_SLH/emissions_I2_ocean_surface_PradosRoman2015_online_1750-2100_1.9x2.5_c251204.nc</i2_slh_emis_file>
+
+<!-- modal aerosol emissions -->
+<nh3_emis_file     ver="mam">atm/cam/chem/trop_mozart_aero/emis/emis_NH3_2000_c111014.nc</nh3_emis_file>
+<dms_emis_file	   ver="mam">atm/cam/chem/trop_mozart_aero/emis/aerocom_mam3_dms_surf_2000_c120315.nc</dms_emis_file>
+<so2_emis_file	   ver="mam">atm/cam/chem/trop_mozart_aero/emis/ar5_mam3_so2_surf_2000_c120315.nc</so2_emis_file>
+<soag_emis_file	   ver="mam">atm/cam/chem/trop_mozart_aero/emis/ar5_mam3_soag_1.5_surf_2000_c130422.nc</soag_emis_file>
+<bc_a1_emis_file   ver="mam">atm/cam/chem/trop_mozart_aero/emis/ar5_mam3_bc_surf_2000_c120315.nc</bc_a1_emis_file>
+<bc_a3_emis_file   ver="mam">atm/cam/chem/trop_mozart_aero/emis/ar5_mam3_bc_surf_2000_c120315.nc</bc_a3_emis_file>
+<bc_a4_emis_file   ver="mam">atm/cam/chem/trop_mozart_aero/emis/ar5_mam3_bc_surf_2000_c120315.nc</bc_a4_emis_file>
+<pom_a1_emis_file  ver="mam">atm/cam/chem/trop_mozart_aero/emis/ar5_mam3_pom_surf_2000_c130422.nc</pom_a1_emis_file>
+<pom_a3_emis_file  ver="mam">atm/cam/chem/trop_mozart_aero/emis/ar5_mam3_pom_surf_2000_c130422.nc</pom_a3_emis_file>
+<pom_a4_emis_file  ver="mam">atm/cam/chem/trop_mozart_aero/emis/ar5_mam3_pom_surf_2000_c130422.nc</pom_a4_emis_file>
+
+<so4_a1_emis_file  ver="mam">atm/cam/chem/trop_mozart_aero/emis/ar5_mam3_so4_a1_surf_2000_c120315.nc</so4_a1_emis_file>
+<so4_a2_emis_file  ver="mam">atm/cam/chem/trop_mozart_aero/emis/ar5_mam3_so4_a2_surf_2000_c120315.nc</so4_a2_emis_file>
+<num_a1_emis_file  ver="mam">atm/cam/chem/trop_mozart_aero/emis/ar5_mam3_num_a1_surf_2000_c120315.nc</num_a1_emis_file>
+<num_a2_emis_file  ver="mam">atm/cam/chem/trop_mozart_aero/emis/ar5_mam3_num_a2_surf_2000_c120315.nc</num_a2_emis_file>
+
+<so2_ext_file      ver="mam">atm/cam/chem/trop_mozart_aero/emis/ar5_mam3_so2_elev_2000_c120315.nc </so2_ext_file>
+<so4_a1_ext_file   ver="mam">atm/cam/chem/trop_mozart_aero/emis/ar5_mam3_so4_a1_elev_2000_c120315.nc</so4_a1_ext_file>
+<so4_a2_ext_file   ver="mam">atm/cam/chem/trop_mozart_aero/emis/ar5_mam3_so4_a2_elev_2000_c120315.nc</so4_a2_ext_file>
+<num_a1_ext_file   ver="mam">atm/cam/chem/trop_mozart_aero/emis/ar5_mam3_num_a1_elev_2000_c120315.nc</num_a1_ext_file>
+<num_a2_ext_file   ver="mam">atm/cam/chem/trop_mozart_aero/emis/ar5_mam3_num_a2_elev_2000_c120315.nc</num_a2_ext_file>
+<pom_a1_ext_file   ver="mam">atm/cam/chem/trop_mozart_aero/emis/ar5_mam3_pom_elev_2000_c130422.nc </pom_a1_ext_file>
+<pom_a3_ext_file   ver="mam">atm/cam/chem/trop_mozart_aero/emis/ar5_mam3_pom_elev_2000_c130422.nc </pom_a3_ext_file>
+<pom_a4_ext_file   ver="mam">atm/cam/chem/trop_mozart_aero/emis/ar5_mam3_pom_elev_2000_c130422.nc </pom_a4_ext_file>
+<bc_a1_ext_file    ver="mam">atm/cam/chem/trop_mozart_aero/emis/ar5_mam3_bc_elev_2000_c120315.nc </bc_a1_ext_file>
+<bc_a3_ext_file    ver="mam">atm/cam/chem/trop_mozart_aero/emis/ar5_mam3_bc_elev_2000_c120315.nc </bc_a3_ext_file>
+<bc_a4_ext_file    ver="mam">atm/cam/chem/trop_mozart_aero/emis/ar5_mam3_bc_elev_2000_c120315.nc </bc_a4_ext_file>
+
+<!-- CAM6 emissions -->
+
+<dms_ot_srf_file     ver="cam6">atm/cam/chem/emis/CMIP6_emissions_1750_2015/emissions-cmip6_DMS_other_surface_1750-2015_0.9x1.25_c20170322.nc</dms_ot_srf_file>
+<dms_bb_srf_file     ver="cam6">atm/cam/chem/emis/CMIP6_emissions_1750_2015/emissions-cmip6_DMS_bb_surface_1750-2015_0.9x1.25_c20170322.nc</dms_bb_srf_file>
+<so2_ag_sh_file      ver="cam6">atm/cam/chem/emis/CMIP6_emissions_1750_2015/emissions-cmip6_SO2_anthro-ag-ship-res_surface_1750-2015_0.9x1.25_c20170616.nc</so2_ag_sh_file>
+<so2_an_srf_file     ver="cam6">atm/cam/chem/emis/CMIP6_emissions_1750_2015/emissions-cmip6_SO2_anthro-ene_surface_1750-2015_0.9x1.25_c20170616.nc</so2_an_srf_file>
+<so2_bb_srf_file     ver="cam6">atm/cam/chem/emis/CMIP6_emissions_1750_2015/emissions-cmip6_SO2_bb_surface_1750-2015_0.9x1.25_c20170322.nc</so2_bb_srf_file>
+<so4_a1_an_srf_file  ver="cam6">atm/cam/chem/emis/CMIP6_emissions_1750_2015/emissions-cmip6_so4_a1_anthro-ag-ship_surface_1750-2015_0.9x1.25_c20170616.nc</so4_a1_an_srf_file>
+<so4_a1_bb_srf_file  ver="cam6">atm/cam/chem/emis/CMIP6_emissions_1750_2015/emissions-cmip6_so4_a1_bb_surface_1750-2015_0.9x1.25_c20170322.nc</so4_a1_bb_srf_file>
+<so4_a2_an_srf_file  ver="cam6">atm/cam/chem/emis/CMIP6_emissions_1750_2015/emissions-cmip6_so4_a2_anthro-res_surface_1750-2015_0.9x1.25_c20170616.nc</so4_a2_an_srf_file>
+<num_a1_sh_srf_file  ver="cam6">atm/cam/chem/emis/CMIP6_emissions_1750_2015/emissions-cmip6_num_so4_a1_anthro-ag-ship_surface_1750-2015_0.9x1.25_c20170616.nc</num_a1_sh_srf_file>
+<num_a2_an_srf_file  ver="cam6">atm/cam/chem/emis/CMIP6_emissions_1750_2015/emissions-cmip6_num_so4_a2_anthro-res_surface_1750-2015_0.9x1.25_c20170616.nc</num_a2_an_srf_file>
+<bc_a4_an_srf_file   ver="cam6">atm/cam/chem/emis/CMIP6_emissions_1750_2015/emissions-cmip6_bc_a4_anthro_surface_1750-2015_0.9x1.25_c20170608.nc</bc_a4_an_srf_file>
+<num_a4_bc_srf_file  ver="cam6">atm/cam/chem/emis/CMIP6_emissions_1750_2015/emissions-cmip6_num_bc_a4_anthro_surface_1750-2015_0.9x1.25_c20170608.nc</num_a4_bc_srf_file>
+<pom_a4_an_srf_file  ver="cam6">atm/cam/chem/emis/CMIP6_emissions_1750_2015/emissions-cmip6_pom_a4_anthro_surface_1750-2015_0.9x1.25_c20170608.nc</pom_a4_an_srf_file>
+<num_a4_oc_srf_file  ver="cam6">atm/cam/chem/emis/CMIP6_emissions_1750_2015/emissions-cmip6_num_pom_a4_anthro_surface_1750-2015_0.9x1.25_c20170608.nc</num_a4_oc_srf_file>
+<num_a1_bb_srf_file  ver="cam6">atm/cam/chem/emis/CMIP6_emissions_1750_2015/emissions-cmip6_num_so4_a1_bb_surface_1750-2015_0.9x1.25_c20170322.nc</num_a1_bb_srf_file>
+<bc_a4_bb_srf_file   ver="cam6">atm/cam/chem/emis/CMIP6_emissions_1750_2015/emissions-cmip6_bc_a4_bb_surface_1750-2015_0.9x1.25_c20170322.nc</bc_a4_bb_srf_file>
+<num_a4_bb_srf_file  ver="cam6">atm/cam/chem/emis/CMIP6_emissions_1750_2015/emissions-cmip6_num_bc_a4_bb_surface_1750-2015_0.9x1.25_c20170322.nc</num_a4_bb_srf_file>
+<pom_a4_bb_srf_file  ver="cam6">atm/cam/chem/emis/CMIP6_emissions_1750_2015/emissions-cmip6_pom_a4_bb_surface_1750-2015_0.9x1.25_c20170322.nc</pom_a4_bb_srf_file>
+<num_pom_bb_srf_file ver="cam6">atm/cam/chem/emis/CMIP6_emissions_1750_2015/emissions-cmip6_num_pom_a4_bb_surface_1750-2015_0.9x1.25_c20170509.nc</num_pom_bb_srf_file>
+<soag_an_srf_file    ver="cam6">atm/cam/chem/emis/CMIP6_emissions_1750_2015/emissions-cmip6_SOAGx1.5_anthro_surface_1750-2015_0.9x1.25_c20170608.nc</soag_an_srf_file>
+<soag_bg_srf_file    ver="cam6">atm/cam/chem/emis/CMIP6_emissions_1750_2015/emissions-cmip6_SOAGx1.5_biogenic_surface_1750-2015_0.9x1.25_c20170322.nc</soag_bg_srf_file>
+<soag_bb_srf_file    ver="cam6">atm/cam/chem/emis/CMIP6_emissions_1750_2015/emissions-cmip6_SOAGx1.5_bb_surface_1750-2015_0.9x1.25_c20170322.nc</soag_bb_srf_file>
+
+<bc_a4_an_srf_file   ver="2000cam6">atm/cam/chem/emis/CMIP6_emissions_2000climo/emissions-cmip6_bc_a4_anthro_surface_2000climo_0.9x1.25_c20170608.nc</bc_a4_an_srf_file>
+<bc_a4_bb_srf_file   ver="2000cam6">atm/cam/chem/emis/CMIP6_emissions_2000climo/emissions-cmip6_bc_a4_bb_surface_2000climo_0.9x1.25_c20170322.nc</bc_a4_bb_srf_file>
+<pom_a4_an_srf_file  ver="2000cam6">atm/cam/chem/emis/CMIP6_emissions_2000climo/emissions-cmip6_pom_a4_anthro_surface_2000climo_0.9x1.25_c20170608.nc</pom_a4_an_srf_file>
+<pom_a4_bb_srf_file  ver="2000cam6">atm/cam/chem/emis/CMIP6_emissions_2000climo/emissions-cmip6_pom_a4_bb_surface_2000climo_0.9x1.25_c20170322.nc</pom_a4_bb_srf_file>
+
+<BENZENE_an_srf_file  ver="cam6">atm/cam/chem/emis/CMIP6_emissions_1750_2015/emissions-cmip6_BENZENE_anthro_surface_1750-2015_0.9x1.25_c20170608.nc</BENZENE_an_srf_file>
+<BENZENE_bb_srf_file  ver="cam6">atm/cam/chem/emis/CMIP6_emissions_1750_2015/emissions-cmip6_BENZENE_bb_surface_1750-2015_0.9x1.25_c20170322.nc</BENZENE_bb_srf_file>
+<BIGALK_an_srf_file   ver="cam6">atm/cam/chem/emis/CMIP6_emissions_1750_2015/emissions-cmip6_BIGALK_anthro_surface_1750-2015_0.9x1.25_c20170608.nc</BIGALK_an_srf_file>
+<BIGALK_bb_srf_file   ver="cam6">atm/cam/chem/emis/CMIP6_emissions_1750_2015/emissions-cmip6_BIGALK_bb_surface_1750-2015_0.9x1.25_c20180611.nc</BIGALK_bb_srf_file>
+<BIGENE_an_srf_file   ver="cam6">atm/cam/chem/emis/CMIP6_emissions_1750_2015/emissions-cmip6_BIGENE_anthro_surface_1750-2015_0.9x1.25_c20170608.nc</BIGENE_an_srf_file>
+<BIGENE_bb_srf_file   ver="cam6">atm/cam/chem/emis/CMIP6_emissions_1750_2015/emissions-cmip6_BIGENE_bb_surface_1750-2015_0.9x1.25_c20180611.nc</BIGENE_bb_srf_file>
+<C2H2_an_srf_file     ver="cam6">atm/cam/chem/emis/CMIP6_emissions_1750_2015/emissions-cmip6_C2H2_anthro_surface_1750-2015_0.9x1.25_c20170608.nc</C2H2_an_srf_file>
+<C2H2_bb_srf_file     ver="cam6">atm/cam/chem/emis/CMIP6_emissions_1750_2015/emissions-cmip6_C2H2_bb_surface_1750-2015_0.9x1.25_c20170322.nc</C2H2_bb_srf_file>
+<C2H4_an_srf_file     ver="cam6">atm/cam/chem/emis/CMIP6_emissions_1750_2015/emissions-cmip6_C2H4_anthro_surface_1750-2015_0.9x1.25_c20170608.nc</C2H4_an_srf_file>
+<C2H4_bb_srf_file     ver="cam6">atm/cam/chem/emis/CMIP6_emissions_1750_2015/emissions-cmip6_C2H4_bb_surface_1750-2015_0.9x1.25_c20170322.nc</C2H4_bb_srf_file>
+<C2H4_ot_srf_file     ver="cam6">atm/cam/chem/emis/CMIP6_emissions_1750_2015/emissions-cmip6_C2H4_other_surface_1750-2015_0.9x1.25_c20170322.nc</C2H4_ot_srf_file>
+<C2H5OH_an_srf_file   ver="cam6">atm/cam/chem/emis/CMIP6_emissions_1750_2015/emissions-cmip6_C2H5OH_anthro_surface_1750-2015_0.9x1.25_c20170608.nc</C2H5OH_an_srf_file>
+<C2H5OH_bb_srf_file   ver="cam6">atm/cam/chem/emis/CMIP6_emissions_1750_2015/emissions-cmip6_C2H5OH_bb_surface_1750-2015_0.9x1.25_c20170322.nc</C2H5OH_bb_srf_file>
+<C2H6_an_srf_file     ver="cam6">atm/cam/chem/emis/CMIP6_emissions_1750_2015/emissions-cmip6_C2H6_anthro_surface_1750-2015_0.9x1.25_c20170608.nc</C2H6_an_srf_file>
+<C2H6_bb_srf_file     ver="cam6">atm/cam/chem/emis/CMIP6_emissions_1750_2015/emissions-cmip6_C2H6_bb_surface_1750-2015_0.9x1.25_c20170322.nc</C2H6_bb_srf_file>
+<C2H6_ot_srf_file     ver="cam6">atm/cam/chem/emis/CMIP6_emissions_1750_2015/emissions-cmip6_C2H6_other_surface_1750-2015_0.9x1.25_c20170322.nc</C2H6_ot_srf_file>
+<C3H6_an_srf_file     ver="cam6">atm/cam/chem/emis/CMIP6_emissions_1750_2015/emissions-cmip6_C3H6_anthro_surface_1750-2015_0.9x1.25_c20170608.nc</C3H6_an_srf_file>
+<C3H6_bb_srf_file     ver="cam6">atm/cam/chem/emis/CMIP6_emissions_1750_2015/emissions-cmip6_C3H6_bb_surface_1750-2015_0.9x1.25_c20170322.nc</C3H6_bb_srf_file>
+<C3H6_ot_srf_file     ver="cam6">atm/cam/chem/emis/CMIP6_emissions_1750_2015/emissions-cmip6_C3H6_other_surface_1750-2015_0.9x1.25_c20170322.nc</C3H6_ot_srf_file>
+<C3H8_an_srf_file     ver="cam6">atm/cam/chem/emis/CMIP6_emissions_1750_2015/emissions-cmip6_C3H8_anthro_surface_1750-2015_0.9x1.25_c20170608.nc</C3H8_an_srf_file>
+<C3H8_bb_srf_file     ver="cam6">atm/cam/chem/emis/CMIP6_emissions_1750_2015/emissions-cmip6_C3H8_bb_surface_1750-2015_0.9x1.25_c20170322.nc</C3H8_bb_srf_file>
+<C3H8_ot_srf_file     ver="cam6">atm/cam/chem/emis/CMIP6_emissions_1750_2015/emissions-cmip6_C3H8_other_surface_1750-2015_0.9x1.25_c20170322.nc</C3H8_ot_srf_file>
+<CH2O_an_srf_file     ver="cam6">atm/cam/chem/emis/CMIP6_emissions_1750_2015/emissions-cmip6_CH2O_anthro_surface_1750-2015_0.9x1.25_c20170608.nc</CH2O_an_srf_file>
+<CH2O_bb_srf_file     ver="cam6">atm/cam/chem/emis/CMIP6_emissions_1750_2015/emissions-cmip6_CH2O_bb_surface_1750-2015_0.9x1.25_c20170322.nc</CH2O_bb_srf_file>
+<CH3CHO_an_srf_file   ver="cam6">atm/cam/chem/emis/CMIP6_emissions_1750_2015/emissions-cmip6_CH3CHO_anthro_surface_1750-2015_0.9x1.25_c20170608.nc</CH3CHO_an_srf_file>
+<CH3CHO_bb_srf_file   ver="cam6">atm/cam/chem/emis/CMIP6_emissions_1750_2015/emissions-cmip6_CH3CHO_bb_surface_1750-2015_0.9x1.25_c20170322.nc</CH3CHO_bb_srf_file>
+<CH3CN_an_srf_file    ver="cam6">atm/cam/chem/emis/CMIP6_emissions_1750_2015/emissions-cmip6_CH3CN_anthro_surface_1750-2015_0.9x1.25_c20170608.nc</CH3CN_an_srf_file>
+<CH3CN_bb_srf_file    ver="cam6">atm/cam/chem/emis/CMIP6_emissions_1750_2015/emissions-cmip6_CH3CN_bb_surface_1750-2015_0.9x1.25_c20170322.nc</CH3CN_bb_srf_file>
+<CH3COCH3_an_srf_file ver="cam6">atm/cam/chem/emis/CMIP6_emissions_1750_2015/emissions-cmip6_CH3COCH3_anthro_surface_1750-2015_0.9x1.25_c20170608.nc</CH3COCH3_an_srf_file>
+<CH3COCH3_bb_srf_file ver="cam6">atm/cam/chem/emis/CMIP6_emissions_1750_2015/emissions-cmip6_CH3COCH3_bb_surface_1750-2015_0.9x1.25_c20170322.nc</CH3COCH3_bb_srf_file>
+<CH3COCHO_bb_srf_file ver="cam6">atm/cam/chem/emis/CMIP6_emissions_1750_2015/emissions-cmip6_CH3COCHO_bb_surface_1750-2015_0.9x1.25_c20170322.nc</CH3COCHO_bb_srf_file>
+<CH3COOH_an_srf_file  ver="cam6">atm/cam/chem/emis/CMIP6_emissions_1750_2015/emissions-cmip6_CH3COOH_anthro_surface_1750-2015_0.9x1.25_c20170608.nc</CH3COOH_an_srf_file>
+<CH3COOH_bb_srf_file  ver="cam6">atm/cam/chem/emis/CMIP6_emissions_1750_2015/emissions-cmip6_CH3COOH_bb_surface_1750-2015_0.9x1.25_c20170322.nc</CH3COOH_bb_srf_file>
+<CH3OH_an_srf_file    ver="cam6">atm/cam/chem/emis/CMIP6_emissions_1750_2015/emissions-cmip6_CH3OH_anthro_surface_1750-2015_0.9x1.25_c20170608.nc</CH3OH_an_srf_file>
+<CH3OH_bb_srf_file    ver="cam6">atm/cam/chem/emis/CMIP6_emissions_1750_2015/emissions-cmip6_CH3OH_bb_surface_1750-2015_0.9x1.25_c20170322.nc</CH3OH_bb_srf_file>
+<CO_an_srf_file       ver="cam6">atm/cam/chem/emis/CMIP6_emissions_1750_2015/emissions-cmip6_CO_anthro_surface_1750-2015_0.9x1.25_c20180504.nc</CO_an_srf_file>
+<CO_bb_srf_file       ver="cam6">atm/cam/chem/emis/CMIP6_emissions_1750_2015/emissions-cmip6_CO_bb_surface_1750-2015_0.9x1.25_c20170322.nc</CO_bb_srf_file>
+<CO_ot_srf_file       ver="cam6">atm/cam/chem/emis/CMIP6_emissions_1750_2015/emissions-cmip6_CO_other_surface_1750-2015_0.9x1.25_c20170322.nc</CO_ot_srf_file>
+<GLYALD_bb_srf_file   ver="cam6">atm/cam/chem/emis/CMIP6_emissions_1750_2015/emissions-cmip6_GLYALD_bb_surface_1750-2015_0.9x1.25_c20170322.nc</GLYALD_bb_srf_file>
+<HCN_an_srf_file      ver="cam6">atm/cam/chem/emis/CMIP6_emissions_1750_2015/emissions-cmip6_HCN_anthro_surface_1750-2015_0.9x1.25_c20170608.nc</HCN_an_srf_file>
+<HCN_bb_srf_file      ver="cam6">atm/cam/chem/emis/CMIP6_emissions_1750_2015/emissions-cmip6_HCN_bb_surface_1750-2015_0.9x1.25_c20170322.nc</HCN_bb_srf_file>
+<HCOOH_an_srf_file    ver="cam6">atm/cam/chem/emis/CMIP6_emissions_1750_2015/emissions-cmip6_HCOOH_anthro_surface_1750-2015_0.9x1.25_c20170608.nc</HCOOH_an_srf_file>
+<HCOOH_bb_srf_file    ver="cam6">atm/cam/chem/emis/CMIP6_emissions_1750_2015/emissions-cmip6_HCOOH_bb_surface_1750-2015_0.9x1.25_c20170322.nc</HCOOH_bb_srf_file>
+<ISOP_bb_srf_file     ver="cam6">atm/cam/chem/emis/CMIP6_emissions_1750_2015/emissions-cmip6_ISOP_bb_surface_1750-2015_0.9x1.25_c20170322.nc</ISOP_bb_srf_file>
+<IVOC_an_srf_file     ver="cam6">atm/cam/chem/emis/CMIP6_emissions_1750_2015/emissions-cmip6_IVOC_anthro_surface_1750-2015_0.9x1.25_c20170608.nc</IVOC_an_srf_file>
+<IVOC_bb_srf_file     ver="cam6">atm/cam/chem/emis/CMIP6_emissions_1750_2015/emissions-cmip6_IVOC_bb_surface_1750-2015_0.9x1.25_c20170322.nc</IVOC_bb_srf_file>
+<MEK_an_srf_file      ver="cam6">atm/cam/chem/emis/CMIP6_emissions_1750_2015/emissions-cmip6_MEK_anthro_surface_1750-2015_0.9x1.25_c20170608.nc</MEK_an_srf_file>
+<MEK_bb_srf_file      ver="cam6">atm/cam/chem/emis/CMIP6_emissions_1750_2015/emissions-cmip6_MEK_bb_surface_1750-2015_0.9x1.25_c20170322.nc</MEK_bb_srf_file>
+<MTERP_bb_srf_file    ver="cam6">atm/cam/chem/emis/CMIP6_emissions_1750_2015/emissions-cmip6_MTERP_bb_surface_1750-2015_0.9x1.25_c20170322.nc</MTERP_bb_srf_file>
+<NH3_an_srf_file      ver="cam6">atm/cam/chem/emis/CMIP6_emissions_1750_2015/emissions-cmip6_NH3_anthro_surface_1750-2015_0.9x1.25_c20170608.nc</NH3_an_srf_file>
+<NH3_bb_srf_file      ver="cam6">atm/cam/chem/emis/CMIP6_emissions_1750_2015/emissions-cmip6_NH3_bb_surface_1750-2015_0.9x1.25_c20170322.nc</NH3_bb_srf_file>
+<NH3_ot_srf_file      ver="cam6">atm/cam/chem/emis/CMIP6_emissions_1750_2015/emissions-cmip6_NH3_other_surface_1750-2015_0.9x1.25_c20170322.nc</NH3_ot_srf_file>
+<NO_an_srf_file       ver="cam6">atm/cam/chem/emis/CMIP6_emissions_1750_2015/emissions-cmip6_NO_anthro_surface_1750-2015_0.9x1.25_c20170608.nc</NO_an_srf_file>
+<NO_bb_srf_file       ver="cam6">atm/cam/chem/emis/CMIP6_emissions_1750_2015/emissions-cmip6_NO_bb_surface_1750-2015_0.9x1.25_c20180611.nc</NO_bb_srf_file>
+<NO_ot_srf_file       ver="cam6">atm/cam/chem/emis/CMIP6_emissions_1750_2015/emissions-cmip6_NO_other_surface_1750-2015_0.9x1.25_c20170322.nc</NO_ot_srf_file>
+<SVOC_an_srf_file     ver="cam6">atm/cam/chem/emis/CMIP6_emissions_1750_2015/emissions-cmip6_SVOC_anthro_surface_1750-2015_0.9x1.25_c20170608.nc</SVOC_an_srf_file>
+<SVOC_bb_srf_file     ver="cam6">atm/cam/chem/emis/CMIP6_emissions_1750_2015/emissions-cmip6_SVOC_bb_surface_1750-2015_0.9x1.25_c20170322.nc</SVOC_bb_srf_file>
+<TOLUENE_an_srf_file  ver="cam6">atm/cam/chem/emis/CMIP6_emissions_1750_2015/emissions-cmip6_TOLUENE_anthro_surface_1750-2015_0.9x1.25_c20170608.nc</TOLUENE_an_srf_file>
+<TOLUENE_bb_srf_file  ver="cam6">atm/cam/chem/emis/CMIP6_emissions_1750_2015/emissions-cmip6_TOLUENE_bb_surface_1750-2015_0.9x1.25_c20170322.nc</TOLUENE_bb_srf_file>
+<XYLENES_an_srf_file  ver="cam6">atm/cam/chem/emis/CMIP6_emissions_1750_2015/emissions-cmip6_XYLENES_anthro_surface_1750-2015_0.9x1.25_c20170608.nc</XYLENES_an_srf_file>
+<XYLENES_bb_srf_file  ver="cam6">atm/cam/chem/emis/CMIP6_emissions_1750_2015/emissions-cmip6_XYLENES_bb_surface_1750-2015_0.9x1.25_c20170322.nc</XYLENES_bb_srf_file>
+
+<E90_srf_file         ver="cam6">atm/cam/chem/emis/CMIP6_emissions_1750_2015/emissions_E90global_surface_1750-2100_0.9x1.25_c20170322.nc</E90_srf_file>
+
+<h2o_ch4ox_ext_file    ver="cam6">atm/cam/chem/emis/elev/H2OemissionCH4oxidationx2_3D_L70_1849-2015_CMIP6ensAvg_c180927.nc</h2o_ch4ox_ext_file>
+<so2_cv_ext_file       ver="cam6">atm/cam/chem/emis/CMIP6_emissions_1750_2015/emissions-cmip6_SO2_contvolcano_vertical_850-5000_0.9x1.25_c20170724.nc</so2_cv_ext_file>
+<so4_a1_cv_ext_file    ver="cam6">atm/cam/chem/emis/CMIP6_emissions_1750_2015/emissions-cmip6_so4_a1_contvolcano_vertical_850-5000_0.9x1.25_c20170724.nc</so4_a1_cv_ext_file>
+<num_a1_cv_ext_file    ver="cam6">atm/cam/chem/emis/CMIP6_emissions_1750_2015/emissions-cmip6_num_a1_so4_contvolcano_vertical_850-5000_0.9x1.25_c20170724.nc</num_a1_cv_ext_file>
+<so4_a2_cv_ext_file    ver="cam6">atm/cam/chem/emis/CMIP6_emissions_1750_2015/emissions-cmip6_so4_a2_contvolcano_vertical_850-5000_0.9x1.25_c20170724.nc</so4_a2_cv_ext_file>
+<num_a2_cv_ext_file    ver="cam6">atm/cam/chem/emis/CMIP6_emissions_1750_2015/emissions-cmip6_num_a2_so4_contvolcano_vertical_850-5000_0.9x1.25_c20170724.nc</num_a2_cv_ext_file>
+<so4_a1_an_ext_file    ver="cam6">atm/cam/chem/emis/CMIP6_emissions_1750_2015/emissions-cmip6_so4_a1_anthro-ene_vertical_1750-2015_0.9x1.25_c20170616.nc</so4_a1_an_ext_file>
+<num_a1_an_ext_file    ver="cam6">atm/cam/chem/emis/CMIP6_emissions_1750_2015/emissions-cmip6_num_so4_a1_anthro-ene_vertical_1750-2015_0.9x1.25_c20170616.nc</num_a1_an_ext_file>
+
+<bc_a4_ar_ext_file     ver="cam6">atm/cam/chem/emis/CMIP6_emissions_1750_2015/emissions-cmip6_bc_a4_aircraft_vertical_1750-2015_0.9x1.25_c20170608.nc</bc_a4_ar_ext_file>
+<no2_ar_ext_file       ver="cam6">atm/cam/chem/emis/CMIP6_emissions_1750_2015/emissions-cmip6_NO2_aircraft_vertical_1750-2015_0.9x1.25_c20170608.nc</no2_ar_ext_file>
+<num_a4_ar_ext_file    ver="cam6">atm/cam/chem/emis/CMIP6_emissions_1750_2015/emissions-cmip6_num_bc_a4_aircraft_vertical_1750-2015_0.9x1.25_c20170608.nc</num_a4_ar_ext_file>
+<so2_ar_ext_file       ver="cam6">atm/cam/chem/emis/CMIP6_emissions_1750_2015/emissions-cmip6_SO2_aircraft_vertical_1750-2015_0.9x1.25_c20170608.nc</so2_ar_ext_file>
+<so2_volc_1deg_ext_file ver="cam6">atm/cam/chem/stratvolc/VolcanEESMv3.11_SO2_850-2016_Mscale_Zreduc_1deg_c191121.nc</so2_volc_1deg_ext_file>
+<so2_volc_2deg_ext_file ver="cam6">atm/cam/chem/stratvolc/VolcanEESMv3.11_SO2_850-2016_Mscale_Zreduc_2deg_c191125.nc</so2_volc_2deg_ext_file>
+<so2_volc_pi_ext_file   ver="cam6">atm/cam/chem/stratvolc/VolcanEESMv3.10_piControl_SO2_1850-2014average_1deg_ZeroTrop_c180416.nc</so2_volc_pi_ext_file>
+
+<!-- 2-DEG VRT -->
+
+<h2o_ch4ox_ext_file hgrid="1.9x2.5" ver="cam6">atm/cam/chem/emis/CMIP6_emissions_1750_2015_2deg/H2OemissionCH4oxidationx2_3D_L70_1849-2015_CMIP6ensAvg_1.9x2.5_c190308.nc</h2o_ch4ox_ext_file>
+<num_a1_an_ext_file hgrid="1.9x2.5" ver="cam6">atm/cam/chem/emis/CMIP6_emissions_1750_2015_2deg/emissions-cmip6_num_so4_a1_anthro-ene_vertical_1750-2015_1.9x2.5_c20170616.nc</num_a1_an_ext_file>
+<num_a1_cv_ext_file hgrid="1.9x2.5" ver="cam6">atm/cam/chem/emis/CMIP6_emissions_1750_2015_2deg/emissions-cmip6_num_a1_so4_contvolcano_vertical_850-5000_1.9x2.5_c20190417.nc</num_a1_cv_ext_file>
+<num_a2_cv_ext_file hgrid="1.9x2.5" ver="cam6">atm/cam/chem/emis/CMIP6_emissions_1750_2015_2deg/emissions-cmip6_num_a2_so4_contvolcano_vertical_850-5000_1.9x2.5_c20190417.nc</num_a2_cv_ext_file>
+<so2_cv_ext_file    hgrid="1.9x2.5" ver="cam6">atm/cam/chem/emis/CMIP6_emissions_1750_2015_2deg/emissions-cmip6_SO2_contvolcano_vertical_850-5000_1.9x2.5_c20190417.nc</so2_cv_ext_file>
+<so4_a1_an_ext_file hgrid="1.9x2.5" ver="cam6">atm/cam/chem/emis/CMIP6_emissions_1750_2015_2deg/emissions-cmip6_so4_a1_anthro-ene_vertical_1750-2015_1.9x2.5_c20170616.nc</so4_a1_an_ext_file>
+<so4_a1_cv_ext_file hgrid="1.9x2.5" ver="cam6">atm/cam/chem/emis/CMIP6_emissions_1750_2015_2deg/emissions-cmip6_so4_a1_contvolcano_vertical_850-5000_1.9x2.5_c20190417.nc</so4_a1_cv_ext_file>
+<so4_a2_cv_ext_file hgrid="1.9x2.5" ver="cam6">atm/cam/chem/emis/CMIP6_emissions_1750_2015_2deg/emissions-cmip6_so4_a2_contvolcano_vertical_850-5000_1.9x2.5_c20190417.nc</so4_a2_cv_ext_file>
+<so2_ar_ext_file    hgrid="1.9x2.5" ver="cam6">atm/cam/chem/emis/CMIP6_emissions_1750_2015_2deg/emissions-cmip6_SO2_aircraft_vertical_1750-2015_1.9x2.5_c20170608.nc</so2_ar_ext_file>
+<bc_a4_ar_ext_file  hgrid="1.9x2.5" ver="cam6">atm/cam/chem/emis/CMIP6_emissions_1750_2015_2deg/emissions-cmip6_bc_a4_aircraft_vertical_1750-2015_1.9x2.5_c20170608.nc</bc_a4_ar_ext_file>
+<no2_ar_ext_file    hgrid="1.9x2.5" ver="cam6">atm/cam/chem/emis/CMIP6_emissions_1750_2015_2deg/emissions-cmip6_NO2_aircraft_vertical_1750-2015_1.9x2.5_c20170608.nc</no2_ar_ext_file>
+<num_a4_ar_ext_file hgrid="1.9x2.5" ver="cam6">atm/cam/chem/emis/CMIP6_emissions_1750_2015_2deg/emissions-cmip6_num_bc_a4_aircraft_vertical_1750-2015_1.9x2.5_c20170608.nc</num_a4_ar_ext_file>
+<so2_volc_pi_ext_file hgrid="1.9x2.5" ver="cam6">atm/cam/chem/stratvolc/VolcanEESMv3.10_piControl_SO2_1850-2014average_2deg_ZeroTrop_c190701.nc</so2_volc_pi_ext_file>
+
+<!-- 2-DEG SRF -->
+
+<bc_a4_an_srf_file  hgrid="1.9x2.5" ver="cam6">atm/cam/chem/emis/CMIP6_emissions_1750_2015_2deg/emissions-cmip6_bc_a4_anthro_surface_1750-2015_1.9x2.5_c20170608.nc</bc_a4_an_srf_file>
+<bc_a4_bb_srf_file  hgrid="1.9x2.5" ver="cam6">atm/cam/chem/emis/CMIP6_emissions_1750_2015_2deg/emissions-cmip6_bc_a4_bb_surface_1750-2015_1.9x2.5_c20170322.nc</bc_a4_bb_srf_file>
+<dms_ot_srf_file    hgrid="1.9x2.5" ver="cam6">atm/cam/chem/emis/CMIP6_emissions_1750_2015_2deg/emissions-cmip6_DMS_other_surface_1750-2015_1.9x2.5_c20170322.nc</dms_ot_srf_file>
+<dms_bb_srf_file    hgrid="1.9x2.5" ver="cam6">atm/cam/chem/emis/CMIP6_emissions_1750_2015_2deg/emissions-cmip6_DMS_bb_surface_1750-2015_1.9x2.5_c20170322.nc</dms_bb_srf_file>
+<num_a1_bb_srf_file hgrid="1.9x2.5" ver="cam6">atm/cam/chem/emis/CMIP6_emissions_1750_2015_2deg/emissions-cmip6_num_so4_a1_bb_surface_1750-2015_1.9x2.5_c20170322.nc</num_a1_bb_srf_file>
+<num_a1_sh_srf_file hgrid="1.9x2.5" ver="cam6">atm/cam/chem/emis/CMIP6_emissions_1750_2015_2deg/emissions-cmip6_num_so4_a1_anthro-ag-ship_surface_1750-2015_1.9x2.5_c20170616.nc</num_a1_sh_srf_file>
+<num_a2_an_srf_file hgrid="1.9x2.5" ver="cam6">atm/cam/chem/emis/CMIP6_emissions_1750_2015_2deg/emissions-cmip6_num_so4_a2_anthro-res_surface_1750-2015_1.9x2.5_c20170616.nc</num_a2_an_srf_file>
+<num_a4_oc_srf_file hgrid="1.9x2.5" ver="cam6">atm/cam/chem/emis/CMIP6_emissions_1750_2015_2deg/emissions-cmip6_num_pom_a4_anthro_surface_1750-2015_1.9x2.5_c20170608.nc</num_a4_oc_srf_file>
+<num_a4_bc_srf_file hgrid="1.9x2.5" ver="cam6">atm/cam/chem/emis/CMIP6_emissions_1750_2015_2deg/emissions-cmip6_num_bc_a4_anthro_surface_1750-2015_1.9x2.5_c20170608.nc</num_a4_bc_srf_file>
+<num_a4_bb_srf_file hgrid="1.9x2.5" ver="cam6">atm/cam/chem/emis/CMIP6_emissions_1750_2015_2deg/emissions-cmip6_num_bc_a4_bb_surface_1750-2015_1.9x2.5_c20170322.nc</num_a4_bb_srf_file>
+<num_pom_bb_srf_file hgrid="1.9x2.5" ver="cam6">atm/cam/chem/emis/CMIP6_emissions_1750_2015_2deg/emissions-cmip6_num_pom_a4_bb_surface_1750-2015_1.9x2.5_c20170322.nc</num_pom_bb_srf_file>
+
+<so2_ag_sh_file     hgrid="1.9x2.5" ver="cam6">atm/cam/chem/emis/CMIP6_emissions_1750_2015_2deg/emissions-cmip6_SO2_anthro-ag-ship-res_surface_1750-2015_1.9x2.5_c20170616.nc</so2_ag_sh_file>
+<so2_an_srf_file    hgrid="1.9x2.5" ver="cam6">atm/cam/chem/emis/CMIP6_emissions_1750_2015_2deg/emissions-cmip6_SO2_anthro-ene_surface_1750-2015_1.9x2.5_c20170616.nc</so2_an_srf_file>
+<so2_bb_srf_file    hgrid="1.9x2.5" ver="cam6">atm/cam/chem/emis/CMIP6_emissions_1750_2015_2deg/emissions-cmip6_SO2_bb_surface_1750-2015_1.9x2.5_c20170322.nc</so2_bb_srf_file>
+<so4_a1_an_srf_file hgrid="1.9x2.5" ver="cam6">atm/cam/chem/emis/CMIP6_emissions_1750_2015_2deg/emissions-cmip6_so4_a1_anthro-ag-ship_surface_1750-2015_1.9x2.5_c20170616.nc</so4_a1_an_srf_file>
+<so4_a1_bb_srf_file hgrid="1.9x2.5" ver="cam6">atm/cam/chem/emis/CMIP6_emissions_1750_2015_2deg/emissions-cmip6_so4_a1_bb_surface_1750-2015_1.9x2.5_c20170322.nc</so4_a1_bb_srf_file>
+<so4_a2_an_srf_file hgrid="1.9x2.5" ver="cam6">atm/cam/chem/emis/CMIP6_emissions_1750_2015_2deg/emissions-cmip6_so4_a2_anthro-res_surface_1750-2015_1.9x2.5_c20170616.nc</so4_a2_an_srf_file>
+<soag_an_srf_file   hgrid="1.9x2.5" ver="cam6">atm/cam/chem/emis/CMIP6_emissions_1750_2015_2deg/emissions-cmip6_SOAGx1.5_anthro_surface_1750-2015_1.9x2.5_c20170608.nc</soag_an_srf_file>
+<soag_bg_srf_file   hgrid="1.9x2.5" ver="cam6">atm/cam/chem/emis/CMIP6_emissions_1750_2015_2deg/emissions-cmip6_SOAGx1.5_biogenic_surface_1750-2015_1.9x2.5_c20170322.nc</soag_bg_srf_file>
+<soag_bb_srf_file   hgrid="1.9x2.5" ver="cam6">atm/cam/chem/emis/CMIP6_emissions_1750_2015_2deg/emissions-cmip6_SOAGx1.5_bb_surface_1750-2015_1.9x2.5_c20170322.nc</soag_bb_srf_file>
+<pom_a4_bb_srf_file hgrid="1.9x2.5" ver="cam6">atm/cam/chem/emis/CMIP6_emissions_1750_2015_2deg/emissions-cmip6_pom_a4_bb_surface_1750-2015_1.9x2.5_c20170322.nc</pom_a4_bb_srf_file>
+<pom_a4_an_srf_file hgrid="1.9x2.5" ver="cam6">atm/cam/chem/emis/CMIP6_emissions_1750_2015_2deg/emissions-cmip6_pom_a4_anthro_surface_1750-2015_1.9x2.5_c20170608.nc</pom_a4_an_srf_file>
+<CH2O_an_srf_file   hgrid="1.9x2.5" ver="cam6">atm/cam/chem/emis/CMIP6_emissions_1750_2015_2deg/emissions-cmip6_CH2O_anthro_surface_1750-2015_1.9x2.5_c20170608.nc</CH2O_an_srf_file>
+<CH2O_bb_srf_file   hgrid="1.9x2.5" ver="cam6">atm/cam/chem/emis/CMIP6_emissions_1750_2015_2deg/emissions-cmip6_CH2O_bb_surface_1750-2015_1.9x2.5_c20170322.nc</CH2O_bb_srf_file>
+<CO_an_srf_file     hgrid="1.9x2.5" ver="cam6">atm/cam/chem/emis/CMIP6_emissions_1750_2015_2deg/emissions-cmip6_CO_anthro_surface_1750-2015_1.9x2.5_c20180504.nc</CO_an_srf_file>
+<CO_bb_srf_file     hgrid="1.9x2.5" ver="cam6">atm/cam/chem/emis/CMIP6_emissions_1750_2015_2deg/emissions-cmip6_CO_bb_surface_1750-2015_1.9x2.5_c20170322.nc</CO_bb_srf_file>
+<CO_ot_srf_file     hgrid="1.9x2.5" ver="cam6">atm/cam/chem/emis/CMIP6_emissions_1750_2015_2deg/emissions-cmip6_CO_other_surface_1750-2015_1.9x2.5_c20170322.nc</CO_ot_srf_file>
+<NO_an_srf_file     hgrid="1.9x2.5" ver="cam6">atm/cam/chem/emis/CMIP6_emissions_1750_2015_2deg/emissions-cmip6_NO_anthro_surface_1750-2015_1.9x2.5_c20170608.nc</NO_an_srf_file>
+<NO_bb_srf_file     hgrid="1.9x2.5" ver="cam6">atm/cam/chem/emis/CMIP6_emissions_1750_2015_2deg/emissions-cmip6_NO_bb_surface_1750-2015_1.9x2.5_c20170322.nc</NO_bb_srf_file>
+<NO_ot_srf_file     hgrid="1.9x2.5" ver="cam6">atm/cam/chem/emis/CMIP6_emissions_1750_2015_2deg/emissions-cmip6_NO_other_surface_1750-2015_1.9x2.5_c20170322.nc</NO_ot_srf_file>
+
+<!-- ne30 pg0 -->
+
+<dms_ot_srf_file     hgrid="ne30np4" npg="0" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_DMS_other_surface_1750_2015_ne30np4_c20200605.nc</dms_ot_srf_file>
+<dms_bb_srf_file     hgrid="ne30np4" npg="0" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_DMS_bb_surface_175001-201512_ne30np4_c20200606.nc</dms_bb_srf_file>
+<so2_ag_sh_file      hgrid="ne30np4" npg="0" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_SO2_anthro-ag-ship-res_surface_mol_175001-201412_ne30np4_c20200606.nc</so2_ag_sh_file>
+<so2_an_srf_file     hgrid="ne30np4" npg="0" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_SO2_anthro-ene_surface_mol_175001-201412_ne30np4_c20200606.nc</so2_an_srf_file>
+<so2_bb_srf_file     hgrid="ne30np4" npg="0" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_SO2_bb_surface_175001-201512_ne30np4_c20200606.nc</so2_bb_srf_file>
+<so4_a1_an_srf_file  hgrid="ne30np4" npg="0" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_so4_a1_anthro-ag-ship_surface_mol_175001-201412_ne30np4_c20200606.nc</so4_a1_an_srf_file>
+<so4_a1_bb_srf_file  hgrid="ne30np4" npg="0" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_so4_a1_bb_surface_175001-201512_ne30np4_c20200606.nc</so4_a1_bb_srf_file>
+<so4_a2_an_srf_file  hgrid="ne30np4" npg="0" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_so4_a2_anthro-res_surface_mol_175001-201412_ne30np4_c20200606.nc</so4_a2_an_srf_file>
+<num_a1_sh_srf_file  hgrid="ne30np4" npg="0" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_num_so4_a1_anthro-ag-ship_surface_mol_175001-201412_ne30np4_c20200606.nc</num_a1_sh_srf_file>
+<num_a2_an_srf_file  hgrid="ne30np4" npg="0" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_num_so4_a2_anthro-res_surface_mol_175001-201412_ne30np4_c20200606.nc</num_a2_an_srf_file>
+<bc_a4_an_srf_file   hgrid="ne30np4" npg="0" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_bc_a4_anthro_surface_175001-201412_ne30np4_c20200606.nc</bc_a4_an_srf_file>
+<num_a4_bc_srf_file  hgrid="ne30np4" npg="0" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_num_bc_a4_anthro_surface_175001-201412_ne30np4_c20200606.nc</num_a4_bc_srf_file>
+<pom_a4_an_srf_file  hgrid="ne30np4" npg="0" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_pom_a4_anthro_surface_175001-201412_ne30np4_c20200606.nc</pom_a4_an_srf_file>
+<num_a4_oc_srf_file  hgrid="ne30np4" npg="0" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_num_pom_a4_anthro_surface_175001-201412_ne30np4_c20200606.nc</num_a4_oc_srf_file>
+<num_a1_bb_srf_file  hgrid="ne30np4" npg="0" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_num_so4_a1_bb_surface_175001-201512_ne30np4_c20200606.nc</num_a1_bb_srf_file>
+<bc_a4_bb_srf_file   hgrid="ne30np4" npg="0" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_bc_a4_bb_surface_175001-201512_ne30np4_c20200606.nc</bc_a4_bb_srf_file>
+<num_a4_bb_srf_file  hgrid="ne30np4" npg="0" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_num_bc_a4_bb_surface_175001-201512_ne30np4_c20200606.nc</num_a4_bb_srf_file>
+<pom_a4_bb_srf_file  hgrid="ne30np4" npg="0" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_pom_a4_bb_surface_175001-201512_ne30np4_c20200606.nc</pom_a4_bb_srf_file>
+<num_pom_bb_srf_file hgrid="ne30np4" npg="0" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_num_pom_a4_bb_surface_175001-201512_ne30np4_c20200606.nc</num_pom_bb_srf_file>
+<soag_an_srf_file    hgrid="ne30np4" npg="0" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_SOAGx1.5_anthro_surface_175001-201412_ne30np4_c20200607.nc</soag_an_srf_file>
+<soag_bg_srf_file    hgrid="ne30np4" npg="0" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_SOAGx1.5_biogenic_surface_1750_2015_ne30np4_c20200129.nc</soag_bg_srf_file>
+<soag_bb_srf_file    hgrid="ne30np4" npg="0" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_SOAGx1.5_bb_surface_175001-201512_ne30np4_c20200607.nc</soag_bb_srf_file>
+
+<BENZENE_an_srf_file  hgrid="ne30np4" npg="0" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_BENZENE_anthro_surface_175001-201412_ne30np4_c20200606.nc</BENZENE_an_srf_file>
+<BENZENE_bb_srf_file  hgrid="ne30np4" npg="0" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_BENZENE_bb_surface_175001-201512_ne30np4_c20200606.nc</BENZENE_bb_srf_file>
+<BIGALK_an_srf_file   hgrid="ne30np4" npg="0" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_BIGALK_anthro_surface_175001-201412_ne30np4_c20200606.nc</BIGALK_an_srf_file>
+<BIGALK_bb_srf_file   hgrid="ne30np4" npg="0" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_BIGALK_bb_surface_175001-201512_ne30np4_c20200606.nc</BIGALK_bb_srf_file>
+<BIGENE_an_srf_file   hgrid="ne30np4" npg="0" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_BIGENE_anthro_surface_175001-201412_ne30np4_c20200606.nc</BIGENE_an_srf_file>
+<BIGENE_bb_srf_file   hgrid="ne30np4" npg="0" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_BIGENE_bb_surface_175001-201512_ne30np4_c20200606.nc</BIGENE_bb_srf_file>
+<C2H2_an_srf_file     hgrid="ne30np4" npg="0" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_C2H2_anthro_surface_175001-201412_ne30np4_c20200606.nc</C2H2_an_srf_file>
+<C2H2_bb_srf_file     hgrid="ne30np4" npg="0" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_C2H2_bb_surface_175001-201512_ne30np4_c20200606.nc</C2H2_bb_srf_file>
+<C2H4_an_srf_file     hgrid="ne30np4" npg="0" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_C2H4_anthro_surface_175001-201412_ne30np4_c20200606.nc</C2H4_an_srf_file>
+<C2H4_bb_srf_file     hgrid="ne30np4" npg="0" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_C2H4_bb_surface_175001-201512_ne30np4_c20200606.nc</C2H4_bb_srf_file>
+<C2H4_ot_srf_file     hgrid="ne30np4" npg="0" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_C2H4_other_surface_1750_2015_ne30np4_c20200605.nc</C2H4_ot_srf_file>
+<C2H5OH_an_srf_file   hgrid="ne30np4" npg="0" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_C2H5OH_anthro_surface_175001-201412_ne30np4_c20200606.nc</C2H5OH_an_srf_file>
+<C2H5OH_bb_srf_file   hgrid="ne30np4" npg="0" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_C2H5OH_bb_surface_175001-201512_ne30np4_c20200606.nc</C2H5OH_bb_srf_file>
+<C2H6_an_srf_file     hgrid="ne30np4" npg="0" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_C2H6_anthro_surface_175001-201412_ne30np4_c20200606.nc</C2H6_an_srf_file>
+<C2H6_bb_srf_file     hgrid="ne30np4" npg="0" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_C2H6_bb_surface_175001-201512_ne30np4_c20200606.nc</C2H6_bb_srf_file>
+<C2H6_ot_srf_file     hgrid="ne30np4" npg="0" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_C2H6_other_surface_1750_2015_ne30np4_c20200605.nc</C2H6_ot_srf_file>
+<C3H6_an_srf_file     hgrid="ne30np4" npg="0" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_C3H6_anthro_surface_175001-201412_ne30np4_c20200606.nc</C3H6_an_srf_file>
+<C3H6_bb_srf_file     hgrid="ne30np4" npg="0" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_C3H6_bb_surface_175001-201512_ne30np4_c20200606.nc</C3H6_bb_srf_file>
+<C3H6_ot_srf_file     hgrid="ne30np4" npg="0" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_C3H6_other_surface_1750_2015_ne30np4_c20200605.nc</C3H6_ot_srf_file>
+<C3H8_an_srf_file     hgrid="ne30np4" npg="0" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_C3H8_anthro_surface_175001-201412_ne30np4_c20200606.nc</C3H8_an_srf_file>
+<C3H8_bb_srf_file     hgrid="ne30np4" npg="0" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_C3H8_bb_surface_175001-201512_ne30np4_c20200606.nc</C3H8_bb_srf_file>
+<C3H8_ot_srf_file     hgrid="ne30np4" npg="0" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_C3H8_other_surface_1750_2015_ne30np4_c20200605.nc</C3H8_ot_srf_file>
+<CH2O_an_srf_file     hgrid="ne30np4" npg="0" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_CH2O_anthro_surface_175001-201412_ne30np4_c20200606.nc</CH2O_an_srf_file>
+<CH2O_bb_srf_file     hgrid="ne30np4" npg="0" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_CH2O_bb_surface_175001-201512_ne30np4_c20200606.nc</CH2O_bb_srf_file>
+<CH3CHO_an_srf_file   hgrid="ne30np4" npg="0" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_CH3CHO_anthro_surface_175001-201412_ne30np4_c20200606.nc</CH3CHO_an_srf_file>
+<CH3CHO_bb_srf_file   hgrid="ne30np4" npg="0" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_CH3CHO_bb_surface_175001-201512_ne30np4_c20200606.nc</CH3CHO_bb_srf_file>
+<CH3CN_an_srf_file    hgrid="ne30np4" npg="0" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_CH3CN_anthro_surface_175001-201412_ne30np4_c20200606.nc</CH3CN_an_srf_file>
+<CH3CN_bb_srf_file    hgrid="ne30np4" npg="0" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_CH3CN_bb_surface_175001-201512_ne30np4_c20200606.nc</CH3CN_bb_srf_file>
+<CH3COCH3_an_srf_file hgrid="ne30np4" npg="0" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_CH3COCH3_anthro_surface_175001-201412_ne30np4_c20200606.nc</CH3COCH3_an_srf_file>
+<CH3COCH3_bb_srf_file hgrid="ne30np4" npg="0" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_CH3COCH3_bb_surface_175001-201512_ne30np4_c20200606.nc</CH3COCH3_bb_srf_file>
+<CH3COCHO_bb_srf_file hgrid="ne30np4" npg="0" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_CH3COCHO_bb_surface_175001-201512_ne30np4_c20200606.nc</CH3COCHO_bb_srf_file>
+<CH3COOH_an_srf_file  hgrid="ne30np4" npg="0" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_CH3COOH_anthro_surface_175001-201412_ne30np4_c20200606.nc</CH3COOH_an_srf_file>
+<CH3COOH_bb_srf_file  hgrid="ne30np4" npg="0" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_CH3COOH_bb_surface_175001-201512_ne30np4_c20200606.nc</CH3COOH_bb_srf_file>
+<CH3OH_an_srf_file    hgrid="ne30np4" npg="0" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_CH3OH_anthro_surface_175001-201412_ne30np4_c20200606.nc</CH3OH_an_srf_file>
+<CH3OH_bb_srf_file    hgrid="ne30np4" npg="0" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_CH3OH_bb_surface_175001-201512_ne30np4_c20200606.nc</CH3OH_bb_srf_file>
+<CO_an_srf_file       hgrid="ne30np4" npg="0" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_CO_anthro_surface_175001-201412_ne30np4_c20200606.nc</CO_an_srf_file>
+<CO_bb_srf_file       hgrid="ne30np4" npg="0" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_CO_bb_surface_175001-201512_ne30np4_c20200606.nc</CO_bb_srf_file>
+<CO_ot_srf_file       hgrid="ne30np4" npg="0" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_CO_other_surface_1750_2015_ne30np4_c20200605.nc</CO_ot_srf_file>
+<GLYALD_bb_srf_file   hgrid="ne30np4" npg="0" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_GLYALD_bb_surface_175001-201512_ne30np4_c20200606.nc</GLYALD_bb_srf_file>
+<HCN_an_srf_file      hgrid="ne30np4" npg="0" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_HCN_anthro_surface_175001-201412_ne30np4_c20200606.nc</HCN_an_srf_file>
+<HCN_bb_srf_file      hgrid="ne30np4" npg="0" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_HCN_bb_surface_175001-201512_ne30np4_c20200606.nc</HCN_bb_srf_file>
+<HCOOH_an_srf_file    hgrid="ne30np4" npg="0" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_HCOOH_anthro_surface_175001-201412_ne30np4_c20200606.nc</HCOOH_an_srf_file>
+<HCOOH_bb_srf_file    hgrid="ne30np4" npg="0" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_HCOOH_bb_surface_175001-201512_ne30np4_c20200606.nc</HCOOH_bb_srf_file>
+<ISOP_bb_srf_file     hgrid="ne30np4" npg="0" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_ISOP_bb_surface_175001-201512_ne30np4_c20200606.nc</ISOP_bb_srf_file>
+<IVOC_an_srf_file     hgrid="ne30np4" npg="0" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_IVOC_anthro_surface_175001-201412_ne30np4_c20200607.nc</IVOC_an_srf_file>
+<IVOC_bb_srf_file     hgrid="ne30np4" npg="0" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_IVOC_bb_surface_175001-201512_ne30np4_c20200607.nc</IVOC_bb_srf_file>
+<MEK_an_srf_file      hgrid="ne30np4" npg="0" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_MEK_anthro_surface_175001-201412_ne30np4_c20200606.nc</MEK_an_srf_file>
+<MEK_bb_srf_file      hgrid="ne30np4" npg="0" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_MEK_bb_surface_175001-201512_ne30np4_c20200606.nc</MEK_bb_srf_file>
+<MTERP_bb_srf_file    hgrid="ne30np4" npg="0" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_MTERP_bb_surface_175001-201512_ne30np4_c20200606.nc</MTERP_bb_srf_file>
+<NH3_an_srf_file      hgrid="ne30np4" npg="0" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_NH3_anthro_surface_175001-201412_ne30np4_c20200606.nc</NH3_an_srf_file>
+<NH3_bb_srf_file      hgrid="ne30np4" npg="0" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_NH3_bb_surface_175001-201512_ne30np4_c20200606.nc</NH3_bb_srf_file>
+<NH3_ot_srf_file      hgrid="ne30np4" npg="0" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_NH3_other_surface_1750_2015_ne30np4_c20200605.nc</NH3_ot_srf_file>
+<NO_an_srf_file       hgrid="ne30np4" npg="0" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_NOx_anthro_surface_175001-201412_ne30np4_c20200606.nc</NO_an_srf_file>
+<NO_bb_srf_file       hgrid="ne30np4" npg="0" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_NOx_bb_surface_175001-201512_ne30np4_c20200606.nc</NO_bb_srf_file>
+<NO_ot_srf_file       hgrid="ne30np4" npg="0" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_NO_other_surface_1750_2015_ne30np4_c20200605.nc</NO_ot_srf_file>
+<SVOC_an_srf_file     hgrid="ne30np4" npg="0" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_SVOC_anthro_surface_175001-201412_ne30np4_c20200607.nc</SVOC_an_srf_file>
+<SVOC_bb_srf_file     hgrid="ne30np4" npg="0" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_SVOC_bb_surface_175001-201512_ne30np4_c20200607.nc</SVOC_bb_srf_file>
+<TOLUENE_an_srf_file  hgrid="ne30np4" npg="0" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_TOLUENE_anthro_surface_175001-201412_ne30np4_c20200606.nc</TOLUENE_an_srf_file>
+<TOLUENE_bb_srf_file  hgrid="ne30np4" npg="0" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_TOLUENE_bb_surface_175001-201512_ne30np4_c20200606.nc</TOLUENE_bb_srf_file>
+<XYLENES_an_srf_file  hgrid="ne30np4" npg="0" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_XYLENES_anthro_surface_175001-201412_ne30np4_c20200606.nc</XYLENES_an_srf_file>
+<XYLENES_bb_srf_file  hgrid="ne30np4" npg="0" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_XYLENES_bb_surface_175001-201512_ne30np4_c20200606.nc</XYLENES_bb_srf_file>
+
+<E90_srf_file         hgrid="ne30np4" npg="0" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions_E90global_surface_1750_2015_ne30np4_c20200606.nc</E90_srf_file>
+
+<so2_cv_ext_file      hgrid="ne30np4" npg="0" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_SO2_contvolcano_vertical_850-5000_ne30np4_c20200606.nc</so2_cv_ext_file>
+<so4_a1_cv_ext_file   hgrid="ne30np4" npg="0" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_so4_a1_contvolcano_vertical_850-5000_ne30np4_c20200606.nc</so4_a1_cv_ext_file>
+<num_a1_cv_ext_file   hgrid="ne30np4" npg="0" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_num_a1_so4_contvolcano_vertical_850-5000_ne30np4_c20200606.nc</num_a1_cv_ext_file>
+<so4_a2_cv_ext_file   hgrid="ne30np4" npg="0" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_so4_a2_contvolcano_vertical_850-5000_ne30np4_c20200606.nc</so4_a2_cv_ext_file>
+<num_a2_cv_ext_file   hgrid="ne30np4" npg="0" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_num_a2_so4_contvolcano_vertical_850-5000_ne30np4_c20200606.nc</num_a2_cv_ext_file>
+<so4_a1_an_ext_file   hgrid="ne30np4" npg="0" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_so4_a1_anthro-ene_vertical_mol_175001-201412_ne30np4_c20200606.nc</so4_a1_an_ext_file>
+<num_a1_an_ext_file   hgrid="ne30np4" npg="0" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_num_so4_a1_anthro-ene_vertical_mol_175001-201412_ne30np4_c20200606.nc</num_a1_an_ext_file>
+
+<!-- ne30 pg3 -->
+
+<dms_ot_srf_file     hgrid="ne30np4" npg="3" ver="cam6">atm/cam/chem/emis/historical_ne30pg3/emissions-cmip6_DMS_other_surface_1750_2015_ne30pg3_c20200630.nc</dms_ot_srf_file>
+<dms_bb_srf_file     hgrid="ne30np4" npg="3" ver="cam6">atm/cam/chem/emis/historical_ne30pg3/emissions-cmip6_DMS_bb_surface_175001-201512_ne30pg3_c20191118.nc</dms_bb_srf_file>
+<so2_ag_sh_file      hgrid="ne30np4" npg="3" ver="cam6">atm/cam/chem/emis/historical_ne30pg3/emissions-cmip6_SO2_anthro-ag-ship-res_surface_mol_175001-201412_ne30pg3_c20200103.nc</so2_ag_sh_file>
+<so2_an_srf_file     hgrid="ne30np4" npg="3" ver="cam6">atm/cam/chem/emis/historical_ne30pg3/emissions-cmip6_SO2_anthro-ene_surface_mol_175001-201412_ne30pg3_c20200103.nc</so2_an_srf_file>
+<so2_bb_srf_file     hgrid="ne30np4" npg="3" ver="cam6">atm/cam/chem/emis/historical_ne30pg3/emissions-cmip6_SO2_bb_surface_175001-201512_ne30pg3_c20191118.nc</so2_bb_srf_file>
+<so4_a1_an_srf_file  hgrid="ne30np4" npg="3" ver="cam6">atm/cam/chem/emis/historical_ne30pg3/emissions-cmip6_so4_a1_anthro-ag-ship_surface_mol_175001-201412_ne30pg3_c20200103.nc</so4_a1_an_srf_file>
+<so4_a1_bb_srf_file  hgrid="ne30np4" npg="3" ver="cam6">atm/cam/chem/emis/historical_ne30pg3/emissions-cmip6_so4_a1_bb_surface_175001-201512_ne30pg3_c20191118.nc</so4_a1_bb_srf_file>
+<so4_a2_an_srf_file  hgrid="ne30np4" npg="3" ver="cam6">atm/cam/chem/emis/historical_ne30pg3/emissions-cmip6_so4_a2_anthro-res_surface_mol_175001-201412_ne30pg3_c20200103.nc</so4_a2_an_srf_file>
+<num_a1_sh_srf_file  hgrid="ne30np4" npg="3" ver="cam6">atm/cam/chem/emis/historical_ne30pg3/emissions-cmip6_num_so4_a1_anthro-ag-ship_surface_mol_175001-201412_ne30pg3_c20200103.nc</num_a1_sh_srf_file>
+<num_a2_an_srf_file  hgrid="ne30np4" npg="3" ver="cam6">atm/cam/chem/emis/historical_ne30pg3/emissions-cmip6_num_so4_a2_anthro-res_surface_mol_175001-201412_ne30pg3_c20200103.nc</num_a2_an_srf_file>
+<bc_a4_an_srf_file   hgrid="ne30np4" npg="3" ver="cam6">atm/cam/chem/emis/historical_ne30pg3/emissions-cmip6_bc_a4_anthro_surface_175001-201412_ne30pg3_c20191118.nc</bc_a4_an_srf_file>
+<num_a4_bc_srf_file  hgrid="ne30np4" npg="3" ver="cam6">atm/cam/chem/emis/historical_ne30pg3/emissions-cmip6_num_bc_a4_anthro_surface_175001-201412_ne30pg3_c20191118.nc</num_a4_bc_srf_file>
+<pom_a4_an_srf_file  hgrid="ne30np4" npg="3" ver="cam6">atm/cam/chem/emis/historical_ne30pg3/emissions-cmip6_pom_a4_anthro_surface_175001-201412_ne30pg3_c20191118.nc</pom_a4_an_srf_file>
+<num_a4_oc_srf_file  hgrid="ne30np4" npg="3" ver="cam6">atm/cam/chem/emis/historical_ne30pg3/emissions-cmip6_num_pom_a4_anthro_surface_175001-201412_ne30pg3_c20191118.nc</num_a4_oc_srf_file>
+<num_a1_bb_srf_file  hgrid="ne30np4" npg="3" ver="cam6">atm/cam/chem/emis/historical_ne30pg3/emissions-cmip6_num_so4_a1_bb_surface_175001-201512_ne30pg3_c20191118.nc</num_a1_bb_srf_file>
+<bc_a4_bb_srf_file   hgrid="ne30np4" npg="3" ver="cam6">atm/cam/chem/emis/historical_ne30pg3/emissions-cmip6_bc_a4_bb_surface_175001-201512_ne30pg3_c20191118.nc</bc_a4_bb_srf_file>
+<num_a4_bb_srf_file  hgrid="ne30np4" npg="3" ver="cam6">atm/cam/chem/emis/historical_ne30pg3/emissions-cmip6_num_bc_a4_bb_surface_175001-201512_ne30pg3_c20191118.nc</num_a4_bb_srf_file>
+<pom_a4_bb_srf_file  hgrid="ne30np4" npg="3" ver="cam6">atm/cam/chem/emis/historical_ne30pg3/emissions-cmip6_pom_a4_bb_surface_175001-201512_ne30pg3_c20191118.nc</pom_a4_bb_srf_file>
+<num_pom_bb_srf_file hgrid="ne30np4" npg="3" ver="cam6">atm/cam/chem/emis/historical_ne30pg3/emissions-cmip6_num_pom_a4_bb_surface_175001-201512_ne30pg3_c20191118.nc</num_pom_bb_srf_file>
+<soag_an_srf_file    hgrid="ne30np4" npg="3" ver="cam6">atm/cam/chem/emis/historical_ne30pg3/emissions-cmip6_SOAGx1.5_anthro_surface_175001-201412_ne30pg3_c20200103.nc</soag_an_srf_file>
+<soag_bg_srf_file    hgrid="ne30np4" npg="3" ver="cam6">atm/cam/chem/emis/historical_ne30pg3/emissions-cmip6_SOAGx1.5_biogenic_surface_1750_2015_ne30pg3_c20200629.nc</soag_bg_srf_file>
+<soag_bb_srf_file    hgrid="ne30np4" npg="3" ver="cam6">atm/cam/chem/emis/historical_ne30pg3/emissions-cmip6_SOAGx1.5_bb_surface_175001-201512_ne30pg3_c20191119.nc</soag_bb_srf_file>
+
+<BENZENE_an_srf_file  hgrid="ne30np4" npg="3" ver="cam6">atm/cam/chem/emis/historical_ne30pg3/emissions-cmip6_BENZENE_anthro_surface_175001-201412_ne30pg3_c20191118.nc</BENZENE_an_srf_file>
+<BENZENE_bb_srf_file  hgrid="ne30np4" npg="3" ver="cam6">atm/cam/chem/emis/historical_ne30pg3/emissions-cmip6_BENZENE_bb_surface_175001-201512_ne30pg3_c20191118.nc</BENZENE_bb_srf_file>
+<BIGALK_an_srf_file   hgrid="ne30np4" npg="3" ver="cam6">atm/cam/chem/emis/historical_ne30pg3/emissions-cmip6_BIGALK_anthro_surface_175001-201412_ne30pg3_c20191118.nc</BIGALK_an_srf_file>
+<BIGALK_bb_srf_file   hgrid="ne30np4" npg="3" ver="cam6">atm/cam/chem/emis/historical_ne30pg3/emissions-cmip6_BIGALK_bb_surface_175001-201512_ne30pg3_c20191118.nc</BIGALK_bb_srf_file>
+<BIGENE_an_srf_file   hgrid="ne30np4" npg="3" ver="cam6">atm/cam/chem/emis/historical_ne30pg3/emissions-cmip6_BIGENE_anthro_surface_175001-201412_ne30pg3_c20191118.nc</BIGENE_an_srf_file>
+<BIGENE_bb_srf_file   hgrid="ne30np4" npg="3" ver="cam6">atm/cam/chem/emis/historical_ne30pg3/emissions-cmip6_BIGENE_bb_surface_175001-201512_ne30pg3_c20191118.nc</BIGENE_bb_srf_file>
+<C2H2_an_srf_file     hgrid="ne30np4" npg="3" ver="cam6">atm/cam/chem/emis/historical_ne30pg3/emissions-cmip6_C2H2_anthro_surface_175001-201412_ne30pg3_c20191118.nc</C2H2_an_srf_file>
+<C2H2_bb_srf_file     hgrid="ne30np4" npg="3" ver="cam6">atm/cam/chem/emis/historical_ne30pg3/emissions-cmip6_C2H2_bb_surface_175001-201512_ne30pg3_c20191118.nc</C2H2_bb_srf_file>
+<C2H4_an_srf_file     hgrid="ne30np4" npg="3" ver="cam6">atm/cam/chem/emis/historical_ne30pg3/emissions-cmip6_C2H4_anthro_surface_175001-201412_ne30pg3_c20191118.nc</C2H4_an_srf_file>
+<C2H4_bb_srf_file     hgrid="ne30np4" npg="3" ver="cam6">atm/cam/chem/emis/historical_ne30pg3/emissions-cmip6_C2H4_bb_surface_175001-201512_ne30pg3_c20191118.nc</C2H4_bb_srf_file>
+<C2H4_ot_srf_file     hgrid="ne30np4" npg="3" ver="cam6">atm/cam/chem/emis/historical_ne30pg3/emissions-cmip6_C2H4_other_surface_1750_2015_ne30pg3_c20200630.nc</C2H4_ot_srf_file>
+<C2H5OH_an_srf_file   hgrid="ne30np4" npg="3" ver="cam6">atm/cam/chem/emis/historical_ne30pg3/emissions-cmip6_C2H5OH_anthro_surface_175001-201412_ne30pg3_c20191118.nc</C2H5OH_an_srf_file>
+<C2H5OH_bb_srf_file   hgrid="ne30np4" npg="3" ver="cam6">atm/cam/chem/emis/historical_ne30pg3/emissions-cmip6_C2H5OH_bb_surface_175001-201512_ne30pg3_c20191118.nc</C2H5OH_bb_srf_file>
+<C2H6_an_srf_file     hgrid="ne30np4" npg="3" ver="cam6">atm/cam/chem/emis/historical_ne30pg3/emissions-cmip6_C2H6_anthro_surface_175001-201412_ne30pg3_c20191118.nc</C2H6_an_srf_file>
+<C2H6_bb_srf_file     hgrid="ne30np4" npg="3" ver="cam6">atm/cam/chem/emis/historical_ne30pg3/emissions-cmip6_C2H6_bb_surface_175001-201512_ne30pg3_c20191118.nc</C2H6_bb_srf_file>
+<C2H6_ot_srf_file     hgrid="ne30np4" npg="3" ver="cam6">atm/cam/chem/emis/historical_ne30pg3/emissions-cmip6_C2H6_other_surface_1750_2015_ne30pg3_c20200630.nc</C2H6_ot_srf_file>
+<C3H6_an_srf_file     hgrid="ne30np4" npg="3" ver="cam6">atm/cam/chem/emis/historical_ne30pg3/emissions-cmip6_C3H6_anthro_surface_175001-201412_ne30pg3_c20191118.nc</C3H6_an_srf_file>
+<C3H6_bb_srf_file     hgrid="ne30np4" npg="3" ver="cam6">atm/cam/chem/emis/historical_ne30pg3/emissions-cmip6_C3H6_bb_surface_175001-201512_ne30pg3_c20191118.nc</C3H6_bb_srf_file>
+<C3H6_ot_srf_file     hgrid="ne30np4" npg="3" ver="cam6">atm/cam/chem/emis/historical_ne30pg3/emissions-cmip6_C3H6_other_surface_1750_2015_ne30pg3_c20200630.nc</C3H6_ot_srf_file>
+<C3H8_an_srf_file     hgrid="ne30np4" npg="3" ver="cam6">atm/cam/chem/emis/historical_ne30pg3/emissions-cmip6_C3H8_anthro_surface_175001-201412_ne30pg3_c20191118.nc</C3H8_an_srf_file>
+<C3H8_bb_srf_file     hgrid="ne30np4" npg="3" ver="cam6">atm/cam/chem/emis/historical_ne30pg3/emissions-cmip6_C3H8_bb_surface_175001-201512_ne30pg3_c20191118.nc</C3H8_bb_srf_file>
+<C3H8_ot_srf_file     hgrid="ne30np4" npg="3" ver="cam6">atm/cam/chem/emis/historical_ne30pg3/emissions-cmip6_C3H8_other_surface_1750_2015_ne30pg3_c20200630.nc</C3H8_ot_srf_file>
+<CH2O_an_srf_file     hgrid="ne30np4" npg="3" ver="cam6">atm/cam/chem/emis/historical_ne30pg3/emissions-cmip6_CH2O_anthro_surface_175001-201412_ne30pg3_c20191118.nc</CH2O_an_srf_file>
+<CH2O_bb_srf_file     hgrid="ne30np4" npg="3" ver="cam6">atm/cam/chem/emis/historical_ne30pg3/emissions-cmip6_CH2O_bb_surface_175001-201512_ne30pg3_c20191118.nc</CH2O_bb_srf_file>
+<CH3CHO_an_srf_file   hgrid="ne30np4" npg="3" ver="cam6">atm/cam/chem/emis/historical_ne30pg3/emissions-cmip6_CH3CHO_anthro_surface_175001-201412_ne30pg3_c20191118.nc</CH3CHO_an_srf_file>
+<CH3CHO_bb_srf_file   hgrid="ne30np4" npg="3" ver="cam6">atm/cam/chem/emis/historical_ne30pg3/emissions-cmip6_CH3CHO_bb_surface_175001-201512_ne30pg3_c20191118.nc</CH3CHO_bb_srf_file>
+<CH3CN_an_srf_file    hgrid="ne30np4" npg="3" ver="cam6">atm/cam/chem/emis/historical_ne30pg3/emissions-cmip6_CH3CN_anthro_surface_175001-201412_ne30pg3_c20191119.nc</CH3CN_an_srf_file>
+<CH3CN_bb_srf_file    hgrid="ne30np4" npg="3" ver="cam6">atm/cam/chem/emis/historical_ne30pg3/emissions-cmip6_CH3CN_bb_surface_175001-201512_ne30pg3_c20191119.nc</CH3CN_bb_srf_file>
+<CH3COCH3_an_srf_file hgrid="ne30np4" npg="3" ver="cam6">atm/cam/chem/emis/historical_ne30pg3/emissions-cmip6_CH3COCH3_anthro_surface_175001-201412_ne30pg3_c20191118.nc</CH3COCH3_an_srf_file>
+<CH3COCH3_bb_srf_file hgrid="ne30np4" npg="3" ver="cam6">atm/cam/chem/emis/historical_ne30pg3/emissions-cmip6_CH3COCH3_bb_surface_175001-201512_ne30pg3_c20191118.nc</CH3COCH3_bb_srf_file>
+<CH3COCHO_bb_srf_file hgrid="ne30np4" npg="3" ver="cam6">atm/cam/chem/emis/historical_ne30pg3/emissions-cmip6_CH3COCHO_bb_surface_175001-201512_ne30pg3_c20191118.nc</CH3COCHO_bb_srf_file>
+<CH3COOH_an_srf_file  hgrid="ne30np4" npg="3" ver="cam6">atm/cam/chem/emis/historical_ne30pg3/emissions-cmip6_CH3COOH_anthro_surface_175001-201412_ne30pg3_c20191118.nc</CH3COOH_an_srf_file>
+<CH3COOH_bb_srf_file  hgrid="ne30np4" npg="3" ver="cam6">atm/cam/chem/emis/historical_ne30pg3/emissions-cmip6_CH3COOH_bb_surface_175001-201512_ne30pg3_c20191118.nc</CH3COOH_bb_srf_file>
+<CH3OH_an_srf_file    hgrid="ne30np4" npg="3" ver="cam6">atm/cam/chem/emis/historical_ne30pg3/emissions-cmip6_CH3OH_anthro_surface_175001-201412_ne30pg3_c20191118.nc</CH3OH_an_srf_file>
+<CH3OH_bb_srf_file    hgrid="ne30np4" npg="3" ver="cam6">atm/cam/chem/emis/historical_ne30pg3/emissions-cmip6_CH3OH_bb_surface_175001-201512_ne30pg3_c20191118.nc</CH3OH_bb_srf_file>
+<CO_an_srf_file       hgrid="ne30np4" npg="3" ver="cam6">atm/cam/chem/emis/historical_ne30pg3/emissions-cmip6_CO_anthro_surface_175001-201412_ne30pg3_c20191118.nc</CO_an_srf_file>
+<CO_bb_srf_file       hgrid="ne30np4" npg="3" ver="cam6">atm/cam/chem/emis/historical_ne30pg3/emissions-cmip6_CO_bb_surface_175001-201512_ne30pg3_c20191118.nc</CO_bb_srf_file>
+<CO_ot_srf_file       hgrid="ne30np4" npg="3" ver="cam6">atm/cam/chem/emis/historical_ne30pg3/emissions-cmip6_CO_other_surface_1750_2015_ne30pg3_c20200630.nc</CO_ot_srf_file>
+<GLYALD_bb_srf_file   hgrid="ne30np4" npg="3" ver="cam6">atm/cam/chem/emis/historical_ne30pg3/emissions-cmip6_GLYALD_bb_surface_175001-201512_ne30pg3_c20191118.nc</GLYALD_bb_srf_file>
+<HCN_an_srf_file      hgrid="ne30np4" npg="3" ver="cam6">atm/cam/chem/emis/historical_ne30pg3/emissions-cmip6_HCN_anthro_surface_175001-201412_ne30pg3_c20191119.nc</HCN_an_srf_file>
+<HCN_bb_srf_file      hgrid="ne30np4" npg="3" ver="cam6">atm/cam/chem/emis/historical_ne30pg3/emissions-cmip6_HCN_bb_surface_175001-201512_ne30pg3_c20191119.nc</HCN_bb_srf_file>
+<HCOOH_an_srf_file    hgrid="ne30np4" npg="3" ver="cam6">atm/cam/chem/emis/historical_ne30pg3/emissions-cmip6_HCOOH_anthro_surface_175001-201412_ne30pg3_c20191118.nc</HCOOH_an_srf_file>
+<HCOOH_bb_srf_file    hgrid="ne30np4" npg="3" ver="cam6">atm/cam/chem/emis/historical_ne30pg3/emissions-cmip6_HCOOH_bb_surface_175001-201512_ne30pg3_c20191118.nc</HCOOH_bb_srf_file>
+<ISOP_bb_srf_file     hgrid="ne30np4" npg="3" ver="cam6">atm/cam/chem/emis/historical_ne30pg3/emissions-cmip6_ISOP_bb_surface_175001-201512_ne30pg3_c20191118.nc</ISOP_bb_srf_file>
+<IVOC_an_srf_file     hgrid="ne30np4" npg="3" ver="cam6">atm/cam/chem/emis/historical_ne30pg3/emissions-cmip6_IVOC_anthro_surface_175001-201412_ne30pg3_c20200103.nc</IVOC_an_srf_file>
+<IVOC_bb_srf_file     hgrid="ne30np4" npg="3" ver="cam6">atm/cam/chem/emis/historical_ne30pg3/emissions-cmip6_IVOC_bb_surface_175001-201512_ne30pg3_c20191119.nc</IVOC_bb_srf_file>
+<MEK_an_srf_file      hgrid="ne30np4" npg="3" ver="cam6">atm/cam/chem/emis/historical_ne30pg3/emissions-cmip6_MEK_anthro_surface_175001-201412_ne30pg3_c20191118.nc</MEK_an_srf_file>
+<MEK_bb_srf_file      hgrid="ne30np4" npg="3" ver="cam6">atm/cam/chem/emis/historical_ne30pg3/emissions-cmip6_MEK_bb_surface_175001-201512_ne30pg3_c20191118.nc</MEK_bb_srf_file>
+<MTERP_bb_srf_file    hgrid="ne30np4" npg="3" ver="cam6">atm/cam/chem/emis/historical_ne30pg3/emissions-cmip6_MTERP_bb_surface_175001-201512_ne30pg3_c20191118.nc</MTERP_bb_srf_file>
+<NH3_an_srf_file      hgrid="ne30np4" npg="3" ver="cam6">atm/cam/chem/emis/historical_ne30pg3/emissions-cmip6_NH3_anthro_surface_175001-201412_ne30pg3_c20191118.nc</NH3_an_srf_file>
+<NH3_bb_srf_file      hgrid="ne30np4" npg="3" ver="cam6">atm/cam/chem/emis/historical_ne30pg3/emissions-cmip6_NH3_bb_surface_175001-201512_ne30pg3_c20191118.nc</NH3_bb_srf_file>
+<NH3_ot_srf_file      hgrid="ne30np4" npg="3" ver="cam6">atm/cam/chem/emis/historical_ne30pg3/emissions-cmip6_NH3_other_surface_1750_2015_ne30pg3_c20200531.nc</NH3_ot_srf_file>
+<NO_an_srf_file       hgrid="ne30np4" npg="3" ver="cam6">atm/cam/chem/emis/historical_ne30pg3/emissions-cmip6_NOx_anthro_surface_175001-201412_ne30pg3_c20191118.nc</NO_an_srf_file>
+<NO_bb_srf_file       hgrid="ne30np4" npg="3" ver="cam6">atm/cam/chem/emis/historical_ne30pg3/emissions-cmip6_NOx_bb_surface_175001-201512_ne30pg3_c20191118.nc</NO_bb_srf_file>
+<NO_ot_srf_file       hgrid="ne30np4" npg="3" ver="cam6">atm/cam/chem/emis/historical_ne30pg3/emissions-cmip6_NO_other_surface_1750_2015_ne30pg3_c20200523.nc</NO_ot_srf_file>
+<SVOC_an_srf_file     hgrid="ne30np4" npg="3" ver="cam6">atm/cam/chem/emis/historical_ne30pg3/emissions-cmip6_SVOC_anthro_surface_175001-201412_ne30pg3_c20200103.nc</SVOC_an_srf_file>
+<SVOC_bb_srf_file     hgrid="ne30np4" npg="3" ver="cam6">atm/cam/chem/emis/historical_ne30pg3/emissions-cmip6_SVOC_bb_surface_175001-201512_ne30pg3_c20191119.nc</SVOC_bb_srf_file>
+<TOLUENE_an_srf_file  hgrid="ne30np4" npg="3" ver="cam6">atm/cam/chem/emis/historical_ne30pg3/emissions-cmip6_TOLUENE_anthro_surface_175001-201412_ne30pg3_c20191118.nc</TOLUENE_an_srf_file>
+<TOLUENE_bb_srf_file  hgrid="ne30np4" npg="3" ver="cam6">atm/cam/chem/emis/historical_ne30pg3/emissions-cmip6_TOLUENE_bb_surface_175001-201512_ne30pg3_c20191118.nc</TOLUENE_bb_srf_file>
+<XYLENES_an_srf_file  hgrid="ne30np4" npg="3" ver="cam6">atm/cam/chem/emis/historical_ne30pg3/emissions-cmip6_XYLENES_anthro_surface_175001-201412_ne30pg3_c20191118.nc</XYLENES_an_srf_file>
+<XYLENES_bb_srf_file  hgrid="ne30np4" npg="3" ver="cam6">atm/cam/chem/emis/historical_ne30pg3/emissions-cmip6_XYLENES_bb_surface_175001-201512_ne30pg3_c20191118.nc</XYLENES_bb_srf_file>
+
+<E90_srf_file         hgrid="ne30np4" npg="3" ver="cam6">atm/cam/chem/emis/historical_ne30pg3/emissions_E90global_surface_1750_2015_ne30pg3_c20200630.nc</E90_srf_file>
+
+<so2_cv_ext_file      hgrid="ne30np4" npg="3" ver="cam6">atm/cam/chem/emis/historical_ne30pg3/emissions-cmip6_SO2_contvolcano_vertical_850-5000_ne30pg3_c20200125.nc</so2_cv_ext_file>
+<so4_a1_cv_ext_file   hgrid="ne30np4" npg="3" ver="cam6">atm/cam/chem/emis/historical_ne30pg3/emissions-cmip6_so4_a1_contvolcano_vertical_850-5000_ne30pg3_c20200125.nc</so4_a1_cv_ext_file>
+<num_a1_cv_ext_file   hgrid="ne30np4" npg="3" ver="cam6">atm/cam/chem/emis/historical_ne30pg3/emissions-cmip6_num_a1_so4_contvolcano_vertical_850-5000_ne30pg3_c20200125.nc</num_a1_cv_ext_file>
+<so4_a2_cv_ext_file   hgrid="ne30np4" npg="3" ver="cam6">atm/cam/chem/emis/historical_ne30pg3/emissions-cmip6_so4_a2_contvolcano_vertical_850-5000_ne30pg3_c20200125.nc</so4_a2_cv_ext_file>
+<num_a2_cv_ext_file   hgrid="ne30np4" npg="3" ver="cam6">atm/cam/chem/emis/historical_ne30pg3/emissions-cmip6_num_a2_so4_contvolcano_vertical_850-5000_ne30pg3_c20200125.nc</num_a2_cv_ext_file>
+<so4_a1_an_ext_file   hgrid="ne30np4" npg="3" ver="cam6">atm/cam/chem/emis/historical_ne30pg3/emissions-cmip6_so4_a1_anthro-ene_vertical_mol_175001-201412_ne30pg3_c20200103.nc</so4_a1_an_ext_file>
+<num_a1_an_ext_file   hgrid="ne30np4" npg="3" ver="cam6">atm/cam/chem/emis/historical_ne30pg3/emissions-cmip6_num_so4_a1_anthro-ene_vertical_mol_175001-201412_ne30pg3_c20200103.nc</num_a1_an_ext_file>
+
+<bc_a4_ar_ext_file    hgrid="ne30np4" npg="3" ver="cam6">atm/cam/chem/emis/historical_ne30pg3/emissions-cmip6_bc_a4_aircraft_vertical_1750-2015_ne30pg3_c20231112.nc</bc_a4_ar_ext_file>
+<num_a4_ar_ext_file   hgrid="ne30np4" npg="3" ver="cam6">atm/cam/chem/emis/historical_ne30pg3/emissions-cmip6_num_bc_a4_aircraft_vertical_1750-2015_ne30pg3_c20231112.nc</num_a4_ar_ext_file>
+<no2_ar_ext_file      hgrid="ne30np4" npg="3" ver="cam6">atm/cam/chem/emis/historical_ne30pg3/emissions-cmip6_NO2_aircraft_vertical_1750-2015_ne30pg3_c20231112.nc</no2_ar_ext_file>
+<so2_ar_ext_file      hgrid="ne30np4" npg="3" ver="cam6">atm/cam/chem/emis/historical_ne30pg3/emissions-cmip6_SO2_aircraft_vertical_1750-2015_ne30pg3_c20231112.nc</so2_ar_ext_file>
+
+<!-- ne30 pg2 -->
+
+<dms_ot_srf_file     hgrid="ne30np4" npg="2" ver="cam6">atm/cam/chem/emis/historical_ne30pg2/emissions-cmip6_DMS_other_surface_1750_2015_ne30pg2_c20200630.nc</dms_ot_srf_file>
+<dms_bb_srf_file     hgrid="ne30np4" npg="2" ver="cam6">atm/cam/chem/emis/historical_ne30pg2/emissions-cmip6_DMS_bb_surface_175001-201512_ne30pg2_c20200630.nc</dms_bb_srf_file>
+<so2_ag_sh_file      hgrid="ne30np4" npg="2" ver="cam6">atm/cam/chem/emis/historical_ne30pg2/emissions-cmip6_SO2_anthro-ag-ship-res_surface_mol_175001-201412_ne30pg2_c20200630.nc</so2_ag_sh_file>
+<so2_an_srf_file     hgrid="ne30np4" npg="2" ver="cam6">atm/cam/chem/emis/historical_ne30pg2/emissions-cmip6_SO2_anthro-ene_surface_mol_175001-201412_ne30pg2_c20200630.nc</so2_an_srf_file>
+<so2_bb_srf_file     hgrid="ne30np4" npg="2" ver="cam6">atm/cam/chem/emis/historical_ne30pg2/emissions-cmip6_SO2_bb_surface_175001-201512_ne30pg2_c20200630.nc</so2_bb_srf_file>
+<so4_a1_an_srf_file  hgrid="ne30np4" npg="2" ver="cam6">atm/cam/chem/emis/historical_ne30pg2/emissions-cmip6_so4_a1_anthro-ag-ship_surface_mol_175001-201412_ne30pg2_c20200630.nc</so4_a1_an_srf_file>
+<so4_a1_bb_srf_file  hgrid="ne30np4" npg="2" ver="cam6">atm/cam/chem/emis/historical_ne30pg2/emissions-cmip6_so4_a1_bb_surface_175001-201512_ne30pg2_c20200630.nc</so4_a1_bb_srf_file>
+<so4_a2_an_srf_file  hgrid="ne30np4" npg="2" ver="cam6">atm/cam/chem/emis/historical_ne30pg2/emissions-cmip6_so4_a2_anthro-res_surface_mol_175001-201412_ne30pg2_c20200630.nc</so4_a2_an_srf_file>
+<num_a1_sh_srf_file  hgrid="ne30np4" npg="2" ver="cam6">atm/cam/chem/emis/historical_ne30pg2/emissions-cmip6_num_so4_a1_anthro-ag-ship_surface_mol_175001-201412_ne30pg2_c20200630.nc</num_a1_sh_srf_file>
+<num_a2_an_srf_file  hgrid="ne30np4" npg="2" ver="cam6">atm/cam/chem/emis/historical_ne30pg2/emissions-cmip6_num_so4_a2_anthro-res_surface_mol_175001-201412_ne30pg2_c20200630.nc</num_a2_an_srf_file>
+<bc_a4_an_srf_file   hgrid="ne30np4" npg="2" ver="cam6">atm/cam/chem/emis/historical_ne30pg2/emissions-cmip6_bc_a4_anthro_surface_175001-201412_ne30pg2_c20200630.nc</bc_a4_an_srf_file>
+<num_a4_bc_srf_file  hgrid="ne30np4" npg="2" ver="cam6">atm/cam/chem/emis/historical_ne30pg2/emissions-cmip6_num_bc_a4_anthro_surface_175001-201412_ne30pg2_c20200630.nc</num_a4_bc_srf_file>
+<pom_a4_an_srf_file  hgrid="ne30np4" npg="2" ver="cam6">atm/cam/chem/emis/historical_ne30pg2/emissions-cmip6_pom_a4_anthro_surface_175001-201412_ne30pg2_c20200630.nc</pom_a4_an_srf_file>
+<num_a4_oc_srf_file  hgrid="ne30np4" npg="2" ver="cam6">atm/cam/chem/emis/historical_ne30pg2/emissions-cmip6_num_pom_a4_anthro_surface_175001-201412_ne30pg2_c20200630.nc</num_a4_oc_srf_file>
+<num_a1_bb_srf_file  hgrid="ne30np4" npg="2" ver="cam6">atm/cam/chem/emis/historical_ne30pg2/emissions-cmip6_num_so4_a1_bb_surface_175001-201512_ne30pg2_c20200630.nc</num_a1_bb_srf_file>
+<bc_a4_bb_srf_file   hgrid="ne30np4" npg="2" ver="cam6">atm/cam/chem/emis/historical_ne30pg2/emissions-cmip6_bc_a4_bb_surface_175001-201512_ne30pg2_c20200630.nc</bc_a4_bb_srf_file>
+<num_a4_bb_srf_file  hgrid="ne30np4" npg="2" ver="cam6">atm/cam/chem/emis/historical_ne30pg2/emissions-cmip6_num_bc_a4_bb_surface_175001-201512_ne30pg2_c20200630.nc</num_a4_bb_srf_file>
+<pom_a4_bb_srf_file  hgrid="ne30np4" npg="2" ver="cam6">atm/cam/chem/emis/historical_ne30pg2/emissions-cmip6_pom_a4_bb_surface_175001-201512_ne30pg2_c20200630.nc</pom_a4_bb_srf_file>
+<num_pom_bb_srf_file hgrid="ne30np4" npg="2" ver="cam6">atm/cam/chem/emis/historical_ne30pg2/emissions-cmip6_num_pom_a4_bb_surface_175001-201512_ne30pg2_c20200630.nc</num_pom_bb_srf_file>
+<soag_an_srf_file    hgrid="ne30np4" npg="2" ver="cam6">atm/cam/chem/emis/historical_ne30pg2/emissions-cmip6_SOAGx1.5_anthro_surface_175001-201412_ne30pg2_c20200701.nc</soag_an_srf_file>
+<soag_bg_srf_file    hgrid="ne30np4" npg="2" ver="cam6">atm/cam/chem/emis/historical_ne30pg2/emissions-cmip6_SOAGx1.5_biogenic_surface_1750_2015_ne30pg2_c20200629.nc</soag_bg_srf_file>
+<soag_bb_srf_file    hgrid="ne30np4" npg="2" ver="cam6">atm/cam/chem/emis/historical_ne30pg2/emissions-cmip6_SOAGx1.5_bb_surface_175001-201512_ne30pg2_c20200630.nc</soag_bb_srf_file>
+
+<BENZENE_an_srf_file  hgrid="ne30np4" npg="2" ver="cam6">atm/cam/chem/emis/historical_ne30pg2/emissions-cmip6_BENZENE_anthro_surface_175001-201412_ne30pg2_c20200701.nc</BENZENE_an_srf_file>
+<BENZENE_bb_srf_file  hgrid="ne30np4" npg="2" ver="cam6">atm/cam/chem/emis/historical_ne30pg2/emissions-cmip6_BENZENE_bb_surface_175001-201512_ne30pg2_c20200630.nc</BENZENE_bb_srf_file>
+<BIGALK_an_srf_file   hgrid="ne30np4" npg="2" ver="cam6">atm/cam/chem/emis/historical_ne30pg2/emissions-cmip6_BIGALK_anthro_surface_175001-201412_ne30pg2_c20200701.nc</BIGALK_an_srf_file>
+<BIGALK_bb_srf_file   hgrid="ne30np4" npg="2" ver="cam6">atm/cam/chem/emis/historical_ne30pg2/emissions-cmip6_BIGALK_bb_surface_175001-201512_ne30pg2_c20200630.nc</BIGALK_bb_srf_file>
+<BIGENE_an_srf_file   hgrid="ne30np4" npg="2" ver="cam6">atm/cam/chem/emis/historical_ne30pg2/emissions-cmip6_BIGENE_anthro_surface_175001-201412_ne30pg2_c20200701.nc</BIGENE_an_srf_file>
+<BIGENE_bb_srf_file   hgrid="ne30np4" npg="2" ver="cam6">atm/cam/chem/emis/historical_ne30pg2/emissions-cmip6_BIGENE_bb_surface_175001-201512_ne30pg2_c20200630.nc</BIGENE_bb_srf_file>
+<C2H2_an_srf_file     hgrid="ne30np4" npg="2" ver="cam6">atm/cam/chem/emis/historical_ne30pg2/emissions-cmip6_C2H2_anthro_surface_175001-201412_ne30pg2_c20200701.nc</C2H2_an_srf_file>
+<C2H2_bb_srf_file     hgrid="ne30np4" npg="2" ver="cam6">atm/cam/chem/emis/historical_ne30pg2/emissions-cmip6_C2H2_bb_surface_175001-201512_ne30pg2_c20200630.nc</C2H2_bb_srf_file>
+<C2H4_an_srf_file     hgrid="ne30np4" npg="2" ver="cam6">atm/cam/chem/emis/historical_ne30pg2/emissions-cmip6_C2H4_anthro_surface_175001-201412_ne30pg2_c20200701.nc</C2H4_an_srf_file>
+<C2H4_bb_srf_file     hgrid="ne30np4" npg="2" ver="cam6">atm/cam/chem/emis/historical_ne30pg2/emissions-cmip6_C2H4_bb_surface_175001-201512_ne30pg2_c20200630.nc</C2H4_bb_srf_file>
+<C2H4_ot_srf_file     hgrid="ne30np4" npg="2" ver="cam6">atm/cam/chem/emis/historical_ne30pg2/emissions-cmip6_C2H4_other_surface_1750_2015_ne30pg2_c20200630.nc</C2H4_ot_srf_file>
+<C2H5OH_an_srf_file   hgrid="ne30np4" npg="2" ver="cam6">atm/cam/chem/emis/historical_ne30pg2/emissions-cmip6_C2H5OH_anthro_surface_175001-201412_ne30pg2_c20200701.nc</C2H5OH_an_srf_file>
+<C2H5OH_bb_srf_file   hgrid="ne30np4" npg="2" ver="cam6">atm/cam/chem/emis/historical_ne30pg2/emissions-cmip6_C2H5OH_bb_surface_175001-201512_ne30pg2_c20200630.nc</C2H5OH_bb_srf_file>
+<C2H6_an_srf_file     hgrid="ne30np4" npg="2" ver="cam6">atm/cam/chem/emis/historical_ne30pg2/emissions-cmip6_C2H6_anthro_surface_175001-201412_ne30pg2_c20200701.nc</C2H6_an_srf_file>
+<C2H6_bb_srf_file     hgrid="ne30np4" npg="2" ver="cam6">atm/cam/chem/emis/historical_ne30pg2/emissions-cmip6_C2H6_bb_surface_175001-201512_ne30pg2_c20200630.nc</C2H6_bb_srf_file>
+<C2H6_ot_srf_file     hgrid="ne30np4" npg="2" ver="cam6">atm/cam/chem/emis/historical_ne30pg2/emissions-cmip6_C2H6_other_surface_1750_2015_ne30pg2_c20200630.nc</C2H6_ot_srf_file>
+<C3H6_an_srf_file     hgrid="ne30np4" npg="2" ver="cam6">atm/cam/chem/emis/historical_ne30pg2/emissions-cmip6_C3H6_anthro_surface_175001-201412_ne30pg2_c20200701.nc</C3H6_an_srf_file>
+<C3H6_bb_srf_file     hgrid="ne30np4" npg="2" ver="cam6">atm/cam/chem/emis/historical_ne30pg2/emissions-cmip6_C3H6_bb_surface_175001-201512_ne30pg2_c20200630.nc</C3H6_bb_srf_file>
+<C3H6_ot_srf_file     hgrid="ne30np4" npg="2" ver="cam6">atm/cam/chem/emis/historical_ne30pg2/emissions-cmip6_C3H6_other_surface_1750_2015_ne30pg2_c20200630.nc</C3H6_ot_srf_file>
+<C3H8_an_srf_file     hgrid="ne30np4" npg="2" ver="cam6">atm/cam/chem/emis/historical_ne30pg2/emissions-cmip6_C3H8_anthro_surface_175001-201412_ne30pg2_c20200701.nc</C3H8_an_srf_file>
+<C3H8_bb_srf_file     hgrid="ne30np4" npg="2" ver="cam6">atm/cam/chem/emis/historical_ne30pg2/emissions-cmip6_C3H8_bb_surface_175001-201512_ne30pg2_c20200630.nc</C3H8_bb_srf_file>
+<C3H8_ot_srf_file     hgrid="ne30np4" npg="2" ver="cam6">atm/cam/chem/emis/historical_ne30pg2/emissions-cmip6_C3H8_other_surface_1750_2015_ne30pg2_c20200630.nc</C3H8_ot_srf_file>
+<CH2O_an_srf_file     hgrid="ne30np4" npg="2" ver="cam6">atm/cam/chem/emis/historical_ne30pg2/emissions-cmip6_CH2O_anthro_surface_175001-201412_ne30pg2_c20200701.nc</CH2O_an_srf_file>
+<CH2O_bb_srf_file     hgrid="ne30np4" npg="2" ver="cam6">atm/cam/chem/emis/historical_ne30pg2/emissions-cmip6_CH2O_bb_surface_175001-201512_ne30pg2_c20200630.nc</CH2O_bb_srf_file>
+<CH3CHO_an_srf_file   hgrid="ne30np4" npg="2" ver="cam6">atm/cam/chem/emis/historical_ne30pg2/emissions-cmip6_CH3CHO_anthro_surface_175001-201412_ne30pg2_c20200701.nc</CH3CHO_an_srf_file>
+<CH3CHO_bb_srf_file   hgrid="ne30np4" npg="2" ver="cam6">atm/cam/chem/emis/historical_ne30pg2/emissions-cmip6_CH3CHO_bb_surface_175001-201512_ne30pg2_c20200630.nc</CH3CHO_bb_srf_file>
+<CH3CN_an_srf_file    hgrid="ne30np4" npg="2" ver="cam6">atm/cam/chem/emis/historical_ne30pg2/emissions-cmip6_CH3CN_anthro_surface_175001-201412_ne30pg2_c20200701.nc</CH3CN_an_srf_file>
+<CH3CN_bb_srf_file    hgrid="ne30np4" npg="2" ver="cam6">atm/cam/chem/emis/historical_ne30pg2/emissions-cmip6_CH3CN_bb_surface_175001-201512_ne30pg2_c20200630.nc</CH3CN_bb_srf_file>
+<CH3COCH3_an_srf_file hgrid="ne30np4" npg="2" ver="cam6">atm/cam/chem/emis/historical_ne30pg2/emissions-cmip6_CH3COCH3_anthro_surface_175001-201412_ne30pg2_c20200701.nc</CH3COCH3_an_srf_file>
+<CH3COCH3_bb_srf_file hgrid="ne30np4" npg="2" ver="cam6">atm/cam/chem/emis/historical_ne30pg2/emissions-cmip6_CH3COCH3_bb_surface_175001-201512_ne30pg2_c20200630.nc</CH3COCH3_bb_srf_file>
+<CH3COCHO_bb_srf_file hgrid="ne30np4" npg="2" ver="cam6">atm/cam/chem/emis/historical_ne30pg2/emissions-cmip6_CH3COCHO_bb_surface_175001-201512_ne30pg2_c20200630.nc</CH3COCHO_bb_srf_file>
+<CH3COOH_an_srf_file  hgrid="ne30np4" npg="2" ver="cam6">atm/cam/chem/emis/historical_ne30pg2/emissions-cmip6_CH3COOH_anthro_surface_175001-201412_ne30pg2_c20200701.nc</CH3COOH_an_srf_file>
+<CH3COOH_bb_srf_file  hgrid="ne30np4" npg="2" ver="cam6">atm/cam/chem/emis/historical_ne30pg2/emissions-cmip6_CH3COOH_bb_surface_175001-201512_ne30pg2_c20200630.nc</CH3COOH_bb_srf_file>
+<CH3OH_an_srf_file    hgrid="ne30np4" npg="2" ver="cam6">atm/cam/chem/emis/historical_ne30pg2/emissions-cmip6_CH3OH_anthro_surface_175001-201412_ne30pg2_c20200701.nc</CH3OH_an_srf_file>
+<CH3OH_bb_srf_file    hgrid="ne30np4" npg="2" ver="cam6">atm/cam/chem/emis/historical_ne30pg2/emissions-cmip6_CH3OH_bb_surface_175001-201512_ne30pg2_c20200630.nc</CH3OH_bb_srf_file>
+<CO_an_srf_file       hgrid="ne30np4" npg="2" ver="cam6">atm/cam/chem/emis/historical_ne30pg2/emissions-cmip6_CO_anthro_surface_175001-201412_ne30pg2_c20200630.nc</CO_an_srf_file>
+<CO_bb_srf_file       hgrid="ne30np4" npg="2" ver="cam6">atm/cam/chem/emis/historical_ne30pg2/emissions-cmip6_CO_bb_surface_175001-201512_ne30pg2_c20200630.nc</CO_bb_srf_file>
+<CO_ot_srf_file       hgrid="ne30np4" npg="2" ver="cam6">atm/cam/chem/emis/historical_ne30pg2/emissions-cmip6_CO_other_surface_1750_2015_ne30pg2_c20200630.nc</CO_ot_srf_file>
+<GLYALD_bb_srf_file   hgrid="ne30np4" npg="2" ver="cam6">atm/cam/chem/emis/historical_ne30pg2/emissions-cmip6_GLYALD_bb_surface_175001-201512_ne30pg2_c20200630.nc</GLYALD_bb_srf_file>
+<HCN_an_srf_file      hgrid="ne30np4" npg="2" ver="cam6">atm/cam/chem/emis/historical_ne30pg2/emissions-cmip6_HCN_anthro_surface_175001-201412_ne30pg2_c20200701.nc</HCN_an_srf_file>
+<HCN_bb_srf_file      hgrid="ne30np4" npg="2" ver="cam6">atm/cam/chem/emis/historical_ne30pg2/emissions-cmip6_HCN_bb_surface_175001-201512_ne30pg2_c20200630.nc</HCN_bb_srf_file>
+<HCOOH_an_srf_file    hgrid="ne30np4" npg="2" ver="cam6">atm/cam/chem/emis/historical_ne30pg2/emissions-cmip6_HCOOH_anthro_surface_175001-201412_ne30pg2_c20200701.nc</HCOOH_an_srf_file>
+<HCOOH_bb_srf_file    hgrid="ne30np4" npg="2" ver="cam6">atm/cam/chem/emis/historical_ne30pg2/emissions-cmip6_HCOOH_bb_surface_175001-201512_ne30pg2_c20200630.nc</HCOOH_bb_srf_file>
+<ISOP_bb_srf_file     hgrid="ne30np4" npg="2" ver="cam6">atm/cam/chem/emis/historical_ne30pg2/emissions-cmip6_ISOP_bb_surface_175001-201512_ne30pg2_c20200630.nc</ISOP_bb_srf_file>
+<IVOC_an_srf_file     hgrid="ne30np4" npg="2" ver="cam6">atm/cam/chem/emis/historical_ne30pg2/emissions-cmip6_IVOC_anthro_surface_175001-201412_ne30pg2_c20200701.nc</IVOC_an_srf_file>
+<IVOC_bb_srf_file     hgrid="ne30np4" npg="2" ver="cam6">atm/cam/chem/emis/historical_ne30pg2/emissions-cmip6_IVOC_bb_surface_175001-201512_ne30pg2_c20200630.nc</IVOC_bb_srf_file>
+<MEK_an_srf_file      hgrid="ne30np4" npg="2" ver="cam6">atm/cam/chem/emis/historical_ne30pg2/emissions-cmip6_MEK_anthro_surface_175001-201412_ne30pg2_c20200701.nc</MEK_an_srf_file>
+<MEK_bb_srf_file      hgrid="ne30np4" npg="2" ver="cam6">atm/cam/chem/emis/historical_ne30pg2/emissions-cmip6_MEK_bb_surface_175001-201512_ne30pg2_c20200630.nc</MEK_bb_srf_file>
+<MTERP_bb_srf_file    hgrid="ne30np4" npg="2" ver="cam6">atm/cam/chem/emis/historical_ne30pg2/emissions-cmip6_MTERP_bb_surface_175001-201512_ne30pg2_c20200630.nc</MTERP_bb_srf_file>
+<NH3_an_srf_file      hgrid="ne30np4" npg="2" ver="cam6">atm/cam/chem/emis/historical_ne30pg2/emissions-cmip6_NH3_anthro_surface_175001-201412_ne30pg2_c20200630.nc</NH3_an_srf_file>
+<NH3_bb_srf_file      hgrid="ne30np4" npg="2" ver="cam6">atm/cam/chem/emis/historical_ne30pg2/emissions-cmip6_NH3_bb_surface_175001-201512_ne30pg2_c20200630.nc</NH3_bb_srf_file>
+<NH3_ot_srf_file      hgrid="ne30np4" npg="2" ver="cam6">atm/cam/chem/emis/historical_ne30pg2/emissions-cmip6_NH3_other_surface_1750_2015_ne30pg2_c20200630.nc</NH3_ot_srf_file>
+<NO_an_srf_file       hgrid="ne30np4" npg="2" ver="cam6">atm/cam/chem/emis/historical_ne30pg2/emissions-cmip6_NOx_anthro_surface_175001-201412_ne30pg2_c20200630.nc</NO_an_srf_file>
+<NO_bb_srf_file       hgrid="ne30np4" npg="2" ver="cam6">atm/cam/chem/emis/historical_ne30pg2/emissions-cmip6_NOx_bb_surface_175001-201512_ne30pg2_c20200701.nc</NO_bb_srf_file>
+<NO_ot_srf_file       hgrid="ne30np4" npg="2" ver="cam6">atm/cam/chem/emis/historical_ne30pg2/emissions-cmip6_NO_other_surface_1750_2015_ne30pg2_c20200630.nc</NO_ot_srf_file>
+<SVOC_an_srf_file     hgrid="ne30np4" npg="2" ver="cam6">atm/cam/chem/emis/historical_ne30pg2/emissions-cmip6_SVOC_anthro_surface_175001-201412_ne30pg2_c20200701.nc</SVOC_an_srf_file>
+<SVOC_bb_srf_file     hgrid="ne30np4" npg="2" ver="cam6">atm/cam/chem/emis/historical_ne30pg2/emissions-cmip6_SVOC_bb_surface_175001-201512_ne30pg2_c20200630.nc</SVOC_bb_srf_file>
+<TOLUENE_an_srf_file  hgrid="ne30np4" npg="2" ver="cam6">atm/cam/chem/emis/historical_ne30pg2/emissions-cmip6_TOLUENE_anthro_surface_175001-201412_ne30pg2_c20200701.nc</TOLUENE_an_srf_file>
+<TOLUENE_bb_srf_file  hgrid="ne30np4" npg="2" ver="cam6">atm/cam/chem/emis/historical_ne30pg2/emissions-cmip6_TOLUENE_bb_surface_175001-201512_ne30pg2_c20200630.nc</TOLUENE_bb_srf_file>
+<XYLENES_an_srf_file  hgrid="ne30np4" npg="2" ver="cam6">atm/cam/chem/emis/historical_ne30pg2/emissions-cmip6_XYLENES_anthro_surface_175001-201412_ne30pg2_c20200701.nc</XYLENES_an_srf_file>
+<XYLENES_bb_srf_file  hgrid="ne30np4" npg="2" ver="cam6">atm/cam/chem/emis/historical_ne30pg2/emissions-cmip6_XYLENES_bb_surface_175001-201512_ne30pg2_c20200630.nc</XYLENES_bb_srf_file>
+
+<E90_srf_file         hgrid="ne30np4" npg="2" ver="cam6">atm/cam/chem/emis/historical_ne30pg2/emissions_E90global_surface_1750_2015_ne30pg2_c20200630.nc</E90_srf_file>
+
+<so2_cv_ext_file      hgrid="ne30np4" npg="2" ver="cam6">atm/cam/chem/emis/historical_ne30pg2/emissions-cmip6_SO2_contvolcano_vertical_850-5000_ne30pg2_c20200701.nc</so2_cv_ext_file>
+<so4_a1_cv_ext_file   hgrid="ne30np4" npg="2" ver="cam6">atm/cam/chem/emis/historical_ne30pg2/emissions-cmip6_so4_a1_contvolcano_vertical_850-5000_ne30pg2_c20200701.nc</so4_a1_cv_ext_file>
+<num_a1_cv_ext_file   hgrid="ne30np4" npg="2" ver="cam6">atm/cam/chem/emis/historical_ne30pg2/emissions-cmip6_num_a1_so4_contvolcano_vertical_850-5000_ne30pg2_c20200701.nc</num_a1_cv_ext_file>
+<so4_a2_cv_ext_file   hgrid="ne30np4" npg="2" ver="cam6">atm/cam/chem/emis/historical_ne30pg2/emissions-cmip6_so4_a2_contvolcano_vertical_850-5000_ne30pg2_c20200701.nc</so4_a2_cv_ext_file>
+<num_a2_cv_ext_file   hgrid="ne30np4" npg="2" ver="cam6">atm/cam/chem/emis/historical_ne30pg2/emissions-cmip6_num_a2_so4_contvolcano_vertical_850-5000_ne30pg2_c20200701.nc</num_a2_cv_ext_file>
+<so4_a1_an_ext_file   hgrid="ne30np4" npg="2" ver="cam6">atm/cam/chem/emis/historical_ne30pg2/emissions-cmip6_so4_a1_anthro-ene_vertical_mol_175001-201412_ne30pg2_c20200630.nc</so4_a1_an_ext_file>
+<num_a1_an_ext_file   hgrid="ne30np4" npg="2" ver="cam6">atm/cam/chem/emis/historical_ne30pg2/emissions-cmip6_num_so4_a1_anthro-ene_vertical_mol_175001-201412_ne30pg2_c20200630.nc</num_a1_an_ext_file>
+
+<!-- CONUS -->
+
+<so4_a1_an_ext_file hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam4_vbs" ver="cam6">atm/cam/chem/emis/CAMS_Anthro_ne0CONUSne30x8/CAMS-GLOB-ANT_Glb_ne0CONUSne30x8_so4_a1_anthro-ene_vertical_v3.1_c20191104.nc</so4_a1_an_ext_file>
+<num_a1_an_ext_file hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam4_vbs" ver="cam6">atm/cam/chem/emis/CAMS_Anthro_ne0CONUSne30x8/CAMS-GLOB-ANT_Glb_ne0CONUSne30x8_num_so4_a1_anthro-ene_vertical_v3.1_c20191104.nc</num_a1_an_ext_file>
+<so4_a1_cv_ext_file hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam4_vbs" ver="cam6">atm/cam/chem/emis/historical_ne0CONUSne30x8/emissions-cmip6_so4_a1_contvolcano_vertical_850-5000_ne0CONUSne30x8_c20191202.nc</so4_a1_cv_ext_file>
+<num_a1_cv_ext_file hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam4_vbs" ver="cam6">atm/cam/chem/emis/historical_ne0CONUSne30x8/emissions-cmip6_num_a1_so4_contvolcano_vertical_850-5000_ne0CONUSne30x8_c20191202.nc</num_a1_cv_ext_file>
+<so4_a2_cv_ext_file hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam4_vbs" ver="cam6">atm/cam/chem/emis/historical_ne0CONUSne30x8/emissions-cmip6_so4_a2_contvolcano_vertical_850-5000_ne0CONUSne30x8_c20191202.nc</so4_a2_cv_ext_file>
+<num_a2_cv_ext_file hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam4_vbs" ver="cam6">atm/cam/chem/emis/historical_ne0CONUSne30x8/emissions-cmip6_num_a2_so4_contvolcano_vertical_850-5000_ne0CONUSne30x8_c20191202.nc</num_a2_cv_ext_file>
+<so2_cv_ext_file    hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam4_vbs" ver="cam6">atm/cam/chem/emis/historical_ne0CONUSne30x8/emissions-cmip6_SO2_contvolcano_vertical_850-5000_ne0CONUSne30x8_c20191202.nc</so2_cv_ext_file>
+
+<so4_a1_an_ext_file hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_t1s1" ver="cam6">atm/cam/chem/emis/CAMS_Anthro_ne0CONUSne30x8/CAMS-GLOB-ANT_Glb_ne0CONUSne30x8_so4_a1_anthro-ene_vertical_v3.1_c20191104.nc</so4_a1_an_ext_file>
+<num_a1_an_ext_file hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_t1s1" ver="cam6">atm/cam/chem/emis/CAMS_Anthro_ne0CONUSne30x8/CAMS-GLOB-ANT_Glb_ne0CONUSne30x8_num_so4_a1_anthro-ene_vertical_v3.1_c20191104.nc</num_a1_an_ext_file>
+<so4_a1_cv_ext_file hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_t1s1" ver="cam6">atm/cam/chem/emis/historical_ne0CONUSne30x8/emissions-cmip6_so4_a1_contvolcano_vertical_850-5000_ne0CONUSne30x8_c20191202.nc</so4_a1_cv_ext_file>
+<num_a1_cv_ext_file hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_t1s1" ver="cam6">atm/cam/chem/emis/historical_ne0CONUSne30x8/emissions-cmip6_num_a1_so4_contvolcano_vertical_850-5000_ne0CONUSne30x8_c20191202.nc</num_a1_cv_ext_file>
+<so4_a2_cv_ext_file hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_t1s1" ver="cam6">atm/cam/chem/emis/historical_ne0CONUSne30x8/emissions-cmip6_so4_a2_contvolcano_vertical_850-5000_ne0CONUSne30x8_c20191202.nc</so4_a2_cv_ext_file>
+<num_a2_cv_ext_file hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_t1s1" ver="cam6">atm/cam/chem/emis/historical_ne0CONUSne30x8/emissions-cmip6_num_a2_so4_contvolcano_vertical_850-5000_ne0CONUSne30x8_c20191202.nc</num_a2_cv_ext_file>
+<so2_cv_ext_file    hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_t1s1" ver="cam6">atm/cam/chem/emis/historical_ne0CONUSne30x8/emissions-cmip6_SO2_contvolcano_vertical_850-5000_ne0CONUSne30x8_c20191202.nc</so2_cv_ext_file>
+
+<bc_a4_an_srf_file    hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam4_vbs" ver="cam6">atm/cam/chem/emis/CAMS_Anthro_ne0CONUSne30x8/CAMS-GLOB-ANT_Glb_ne0CONUSne30x8_anthro_surface_bc_a4_v3.1_c20191103.nc</bc_a4_an_srf_file>
+<num_a4_bc_srf_file   hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam4_vbs" ver="cam6">atm/cam/chem/emis/CAMS_Anthro_ne0CONUSne30x8/CAMS-GLOB-ANT_Glb_ne0CONUSne30x8_anthro_surface_num_bc_a4_v3.1_c20191103.nc</num_a4_bc_srf_file>
+<bc_a4_bb_srf_file    hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam4_vbs" ver="cam6">atm/cam/chem/emis/finn1.5/CONUSne30x8/emissions-finnv1.5_bc_a4_bb_surface_20100101-20171231_ne0conus_c200619.nc</bc_a4_bb_srf_file>
+<num_a4_bb_srf_file   hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam4_vbs" ver="cam6">atm/cam/chem/emis/finn1.5/CONUSne30x8/emissions-finnv1.5_num_bc_a4_bb_surface_20100101-20171231_ne0conus_c200619.nc</num_a4_bb_srf_file>
+<pom_a4_an_srf_file   hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam4_vbs" ver="cam6">atm/cam/chem/emis/CAMS_Anthro_ne0CONUSne30x8/CAMS-GLOB-ANT_Glb_ne0CONUSne30x8_anthro_surface_pom_a4_v3.1_c20191103.nc</pom_a4_an_srf_file>
+<num_a4_oc_srf_file   hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam4_vbs" ver="cam6">atm/cam/chem/emis/CAMS_Anthro_ne0CONUSne30x8/CAMS-GLOB-ANT_Glb_ne0CONUSne30x8_anthro_surface_num_pom_a4_v3.1_c20191103.nc</num_a4_oc_srf_file>
+<pom_a4_bb_srf_file   hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam4_vbs" ver="cam6">atm/cam/chem/emis/finn1.5/CONUSne30x8/emissions-finnv1.5_pom_a4_bb_surface_20100101-20171231_ne0conus_c200619.nc</pom_a4_bb_srf_file>
+<num_pom_bb_srf_file  hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam4_vbs" ver="cam6">atm/cam/chem/emis/finn1.5/CONUSne30x8/emissions-finnv1.5_num_pom_a4_bb_surface_20100101-20171231_ne0conus_c200619.nc</num_pom_bb_srf_file>
+<so4_a1_an_srf_file   hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam4_vbs" ver="cam6">atm/cam/chem/emis/CAMS_Anthro_ne0CONUSne30x8/CAMS-GLOB-ANT_Glb_ne0CONUSne30x8_so4_a1_anthro-ag-ship_surface_v3.1_c20191103.nc</so4_a1_an_srf_file>
+<num_a1_sh_srf_file   hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam4_vbs" ver="cam6">atm/cam/chem/emis/CAMS_Anthro_ne0CONUSne30x8/CAMS-GLOB-ANT_Glb_ne0CONUSne30x8_num_so4_a1_anthro-ag-ship_surface_v3.1_c20191103.nc</num_a1_sh_srf_file>
+<so4_a2_an_srf_file   hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam4_vbs" ver="cam6">atm/cam/chem/emis/CAMS_Anthro_ne0CONUSne30x8/CAMS-GLOB-ANT_Glb_ne0CONUSne30x8_so4_a2_anthro-res_surface_v3.1_c20191103.nc</so4_a2_an_srf_file>
+<num_a2_an_srf_file   hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam4_vbs" ver="cam6">atm/cam/chem/emis/CAMS_Anthro_ne0CONUSne30x8/CAMS-GLOB-ANT_Glb_ne0CONUSne30x8_num_so4_a2_anthro-res_surface_v3.1_c20191103.nc</num_a2_an_srf_file>
+
+<bc_a4_an_srf_file    hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_t1s1" ver="cam6">atm/cam/chem/emis/CAMS_Anthro_ne0CONUSne30x8/CAMS-GLOB-ANT_Glb_ne0CONUSne30x8_anthro_surface_bc_a4_v3.1_c20191103.nc</bc_a4_an_srf_file>
+<num_a4_bc_srf_file   hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_t1s1" ver="cam6">atm/cam/chem/emis/CAMS_Anthro_ne0CONUSne30x8/CAMS-GLOB-ANT_Glb_ne0CONUSne30x8_anthro_surface_num_bc_a4_v3.1_c20191103.nc</num_a4_bc_srf_file>
+<bc_a4_bb_srf_file    hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_t1s1" ver="cam6">atm/cam/chem/emis/finn1.5/CONUSne30x8/emissions-finnv1.5_bc_a4_bb_surface_20100101-20171231_ne0conus_c200619.nc</bc_a4_bb_srf_file>
+<num_a4_bb_srf_file   hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_t1s1" ver="cam6">atm/cam/chem/emis/finn1.5/CONUSne30x8/emissions-finnv1.5_num_bc_a4_bb_surface_20100101-20171231_ne0conus_c200619.nc</num_a4_bb_srf_file>
+<pom_a4_an_srf_file   hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_t1s1" ver="cam6">atm/cam/chem/emis/CAMS_Anthro_ne0CONUSne30x8/CAMS-GLOB-ANT_Glb_ne0CONUSne30x8_anthro_surface_pom_a4_v3.1_c20191103.nc</pom_a4_an_srf_file>
+<num_a4_oc_srf_file   hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_t1s1" ver="cam6">atm/cam/chem/emis/CAMS_Anthro_ne0CONUSne30x8/CAMS-GLOB-ANT_Glb_ne0CONUSne30x8_anthro_surface_num_pom_a4_v3.1_c20191103.nc</num_a4_oc_srf_file>
+<pom_a4_bb_srf_file   hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_t1s1" ver="cam6">atm/cam/chem/emis/finn1.5/CONUSne30x8/emissions-finnv1.5_pom_a4_bb_surface_20100101-20171231_ne0conus_c200619.nc</pom_a4_bb_srf_file>
+<num_pom_bb_srf_file  hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_t1s1" ver="cam6">atm/cam/chem/emis/finn1.5/CONUSne30x8/emissions-finnv1.5_num_pom_a4_bb_surface_20100101-20171231_ne0conus_c200619.nc</num_pom_bb_srf_file>
+<so4_a1_an_srf_file   hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_t1s1" ver="cam6">atm/cam/chem/emis/CAMS_Anthro_ne0CONUSne30x8/CAMS-GLOB-ANT_Glb_ne0CONUSne30x8_so4_a1_anthro-ag-ship_surface_v3.1_c20191103.nc</so4_a1_an_srf_file>
+<num_a1_sh_srf_file   hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_t1s1" ver="cam6">atm/cam/chem/emis/CAMS_Anthro_ne0CONUSne30x8/CAMS-GLOB-ANT_Glb_ne0CONUSne30x8_num_so4_a1_anthro-ag-ship_surface_v3.1_c20191103.nc</num_a1_sh_srf_file>
+<so4_a2_an_srf_file   hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_t1s1" ver="cam6">atm/cam/chem/emis/CAMS_Anthro_ne0CONUSne30x8/CAMS-GLOB-ANT_Glb_ne0CONUSne30x8_so4_a2_anthro-res_surface_v3.1_c20191103.nc</so4_a2_an_srf_file>
+<num_a2_an_srf_file   hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_t1s1" ver="cam6">atm/cam/chem/emis/CAMS_Anthro_ne0CONUSne30x8/CAMS-GLOB-ANT_Glb_ne0CONUSne30x8_num_so4_a2_anthro-res_surface_v3.1_c20191103.nc</num_a2_an_srf_file>
+
+<BENZENE_an_srf_file  hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam4_vbs" ver="cam6">atm/cam/chem/emis/CAMS_Anthro_ne0CONUSne30x8/CAMS-GLOB-ANT_Glb_ne0CONUSne30x8_anthro_surface_BENZENE_v3.1_c20191103.nc</BENZENE_an_srf_file>
+<BENZENE_bb_srf_file  hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam4_vbs" ver="cam6">atm/cam/chem/emis/finn1.5/CONUSne30x8/emissions-finnv1.5_BENZENE_bb_surface_20100101-20171231_ne0conus_c200619.nc</BENZENE_bb_srf_file>
+<BIGALD_bb_srf_file   hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam4_vbs" ver="cam6">atm/cam/chem/emis/finn1.5/CONUSne30x8/emissions-finnv1.5_BIGALD_bb_surface_20100101-20171231_ne0conus_c200619.nc</BIGALD_bb_srf_file>
+<BIGALK_an_srf_file   hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam4_vbs" ver="cam6">atm/cam/chem/emis/CAMS_Anthro_ne0CONUSne30x8/CAMS-GLOB-ANT_Glb_ne0CONUSne30x8_anthro_surface_BIGALK_v3.1_c20191103.nc</BIGALK_an_srf_file>
+<BIGALK_bb_srf_file   hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam4_vbs" ver="cam6">atm/cam/chem/emis/finn1.5/CONUSne30x8/emissions-finnv1.5_BIGALK_bb_surface_20100101-20171231_ne0conus_c200619.nc</BIGALK_bb_srf_file>
+<BIGENE_an_srf_file   hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam4_vbs" ver="cam6">atm/cam/chem/emis/CAMS_Anthro_ne0CONUSne30x8/CAMS-GLOB-ANT_Glb_ne0CONUSne30x8_anthro_surface_BIGENE_v3.1_c20191103.nc</BIGENE_an_srf_file>
+<BIGENE_bb_srf_file   hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam4_vbs" ver="cam6">atm/cam/chem/emis/finn1.5/CONUSne30x8/emissions-finnv1.5_BIGENE_bb_surface_20100101-20171231_ne0conus_c200619.nc</BIGENE_bb_srf_file>
+<C2H2_an_srf_file     hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam4_vbs" ver="cam6">atm/cam/chem/emis/CAMS_Anthro_ne0CONUSne30x8/CAMS-GLOB-ANT_Glb_ne0CONUSne30x8_anthro_surface_C2H2_v3.1_c20191103.nc</C2H2_an_srf_file>
+<C2H2_bb_srf_file     hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam4_vbs" ver="cam6">atm/cam/chem/emis/finn1.5/CONUSne30x8/emissions-finnv1.5_C2H2_bb_surface_20100101-20171231_ne0conus_c200619.nc</C2H2_bb_srf_file>
+<C2H4_an_srf_file     hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam4_vbs" ver="cam6">atm/cam/chem/emis/CAMS_Anthro_ne0CONUSne30x8/CAMS-GLOB-ANT_Glb_ne0CONUSne30x8_anthro_surface_C2H4_v3.1_c20191103.nc</C2H4_an_srf_file>
+<C2H4_bb_srf_file     hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam4_vbs" ver="cam6">atm/cam/chem/emis/finn1.5/CONUSne30x8/emissions-finnv1.5_C2H4_bb_surface_20100101-20171231_ne0conus_c200619.nc</C2H4_bb_srf_file>
+<C2H4_ot_srf_file     hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam4_vbs" ver="cam6">atm/cam/chem/emis/historical_ne0CONUSne30x8/emissions-cmip6_C2H4_other_surface_1750_2015_historical_ne0CONUSne30x8_c20191028.nc</C2H4_ot_srf_file>
+<C2H5OH_an_srf_file   hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam4_vbs" ver="cam6">atm/cam/chem/emis/CAMS_Anthro_ne0CONUSne30x8/CAMS-GLOB-ANT_Glb_ne0CONUSne30x8_anthro_surface_C2H5OH_v3.1_c20191103.nc</C2H5OH_an_srf_file>
+<C2H5OH_bb_srf_file   hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam4_vbs" ver="cam6">atm/cam/chem/emis/finn1.5/CONUSne30x8/emissions-finnv1.5_C2H5OH_bb_surface_20100101-20171231_ne0conus_c200619.nc</C2H5OH_bb_srf_file>
+<C2H6_an_srf_file     hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam4_vbs" ver="cam6">atm/cam/chem/emis/CAMS_Anthro_ne0CONUSne30x8/CAMS-GLOB-ANT_Glb_ne0CONUSne30x8_anthro_surface_C2H6_v3.1_c20191103.nc</C2H6_an_srf_file>
+<C2H6_bb_srf_file     hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam4_vbs" ver="cam6">atm/cam/chem/emis/finn1.5/CONUSne30x8/emissions-finnv1.5_C2H6_bb_surface_20100101-20171231_ne0conus_c200619.nc</C2H6_bb_srf_file>
+<C2H6_ot_srf_file     hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam4_vbs" ver="cam6">atm/cam/chem/emis/historical_ne0CONUSne30x8/emissions-cmip6_C2H6_other_surface_1750_2015_historical_ne0CONUSne30x8_c20191028.nc</C2H6_ot_srf_file>
+<C3H6_an_srf_file     hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam4_vbs" ver="cam6">atm/cam/chem/emis/CAMS_Anthro_ne0CONUSne30x8/CAMS-GLOB-ANT_Glb_ne0CONUSne30x8_anthro_surface_C3H6_v3.1_c20191103.nc</C3H6_an_srf_file>
+<C3H6_bb_srf_file     hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam4_vbs" ver="cam6">atm/cam/chem/emis/finn1.5/CONUSne30x8/emissions-finnv1.5_C3H6_bb_surface_20100101-20171231_ne0conus_c200619.nc</C3H6_bb_srf_file>
+<C3H6_ot_srf_file     hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam4_vbs" ver="cam6">atm/cam/chem/emis/historical_ne0CONUSne30x8/emissions-cmip6_C3H6_other_surface_1750_2015_historical_ne0CONUSne30x8_c20191028.nc</C3H6_ot_srf_file>
+<C3H8_an_srf_file     hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam4_vbs" ver="cam6">atm/cam/chem/emis/CAMS_Anthro_ne0CONUSne30x8/CAMS-GLOB-ANT_Glb_ne0CONUSne30x8_anthro_surface_C3H8_v3.1_c20191103.nc</C3H8_an_srf_file>
+<C3H8_bb_srf_file     hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam4_vbs" ver="cam6">atm/cam/chem/emis/finn1.5/CONUSne30x8/emissions-finnv1.5_C3H8_bb_surface_20100101-20171231_ne0conus_c200619.nc</C3H8_bb_srf_file>
+<C3H8_ot_srf_file     hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam4_vbs" ver="cam6">atm/cam/chem/emis/historical_ne0CONUSne30x8/emissions-cmip6_C3H8_other_surface_1750_2015_historical_ne0CONUSne30x8_c20191028.nc</C3H8_ot_srf_file>
+<CH2O_an_srf_file     hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam4_vbs" ver="cam6">atm/cam/chem/emis/CAMS_Anthro_ne0CONUSne30x8/CAMS-GLOB-ANT_Glb_ne0CONUSne30x8_anthro_surface_CH2O_v3.1_c20191103.nc</CH2O_an_srf_file>
+<CH2O_bb_srf_file     hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam4_vbs" ver="cam6">atm/cam/chem/emis/finn1.5/CONUSne30x8/emissions-finnv1.5_CH2O_bb_surface_20100101-20171231_ne0conus_c200619.nc</CH2O_bb_srf_file>
+<CH3CHO_an_srf_file   hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam4_vbs" ver="cam6">atm/cam/chem/emis/CAMS_Anthro_ne0CONUSne30x8/CAMS-GLOB-ANT_Glb_ne0CONUSne30x8_anthro_surface_CH3CHO_v3.1_c20191103.nc</CH3CHO_an_srf_file>
+<CH3CHO_bb_srf_file   hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam4_vbs" ver="cam6">atm/cam/chem/emis/finn1.5/CONUSne30x8/emissions-finnv1.5_CH3CHO_bb_surface_20100101-20171231_ne0conus_c200619.nc</CH3CHO_bb_srf_file>
+<CH3CN_an_srf_file    hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam4_vbs" ver="cam6">atm/cam/chem/emis/CAMS_Anthro_ne0CONUSne30x8/CAMS-GLOB-ANT_Glb_ne0CONUSne30x8_anthro_surface_CH3CN_v3.1_c20191103.nc</CH3CN_an_srf_file>
+<CH3CN_bb_srf_file    hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam4_vbs" ver="cam6">atm/cam/chem/emis/finn1.5/CONUSne30x8/emissions-finnv1.5_CH3CN_bb_surface_20100101-20171231_ne0conus_c200619.nc</CH3CN_bb_srf_file>
+<CH3COCH3_an_srf_file hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam4_vbs" ver="cam6">atm/cam/chem/emis/CAMS_Anthro_ne0CONUSne30x8/CAMS-GLOB-ANT_Glb_ne0CONUSne30x8_anthro_surface_CH3COCH3_v3.1_c20191103.nc</CH3COCH3_an_srf_file>
+<CH3COCH3_bb_srf_file hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam4_vbs" ver="cam6">atm/cam/chem/emis/finn1.5/CONUSne30x8/emissions-finnv1.5_CH3COCH3_bb_surface_20100101-20171231_ne0conus_c200619.nc</CH3COCH3_bb_srf_file>
+<CH3COCHO_bb_srf_file hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam4_vbs" ver="cam6">atm/cam/chem/emis/finn1.5/CONUSne30x8/emissions-finnv1.5_CH3COCHO_bb_surface_20100101-20171231_ne0conus_c200619.nc</CH3COCHO_bb_srf_file>
+<CH3COOH_an_srf_file  hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam4_vbs" ver="cam6">atm/cam/chem/emis/CAMS_Anthro_ne0CONUSne30x8/CAMS-GLOB-ANT_Glb_ne0CONUSne30x8_anthro_surface_CH3COOH_v3.1_c20191103.nc</CH3COOH_an_srf_file>
+<CH3COOH_bb_srf_file  hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam4_vbs" ver="cam6">atm/cam/chem/emis/finn1.5/CONUSne30x8/emissions-finnv1.5_CH3COOH_bb_surface_20100101-20171231_ne0conus_c200619.nc</CH3COOH_bb_srf_file>
+<CH3OH_an_srf_file    hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam4_vbs" ver="cam6">atm/cam/chem/emis/CAMS_Anthro_ne0CONUSne30x8/CAMS-GLOB-ANT_Glb_ne0CONUSne30x8_anthro_surface_CH3OH_v3.1_c20191103.nc</CH3OH_an_srf_file>
+<CH3OH_bb_srf_file    hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam4_vbs" ver="cam6">atm/cam/chem/emis/finn1.5/CONUSne30x8/emissions-finnv1.5_CH3OH_bb_surface_20100101-20171231_ne0conus_c200619.nc</CH3OH_bb_srf_file>
+<CO_an_srf_file       hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam4_vbs" ver="cam6">atm/cam/chem/emis/CAMS_Anthro_ne0CONUSne30x8/CAMS-GLOB-ANT_Glb_ne0CONUSne30x8_anthro_surface_CO_v3.1_c20191103.nc</CO_an_srf_file>
+<CO_bb_srf_file       hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam4_vbs" ver="cam6">atm/cam/chem/emis/finn1.5/CONUSne30x8/emissions-finnv1.5_CO_bb_surface_20100101-20171231_ne0conus_c200619.nc</CO_bb_srf_file>
+<CO_ot_srf_file       hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam4_vbs" ver="cam6">atm/cam/chem/emis/historical_ne0CONUSne30x8/emissions-cmip6_CO_other_surface_1750_2015_historical_ne0CONUSne30x8_c20191028.nc</CO_ot_srf_file>
+<CRESOL_bb_srf_file   hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam4_vbs" ver="cam6">atm/cam/chem/emis/finn1.5/CONUSne30x8/emissions-finnv1.5_CRESOL_bb_surface_20100101-20171231_ne0conus_c200619.nc</CRESOL_bb_srf_file>
+<dms_ot_srf_file      hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam4_vbs" ver="cam6">atm/cam/chem/emis/historical_ne0CONUSne30x8/emissions-cmip6_DMS_other_surface_1750_2015_historical_ne0CONUSne30x8_c20191028.nc</dms_ot_srf_file>
+<GLYALD_bb_srf_file   hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam4_vbs" ver="cam6">atm/cam/chem/emis/finn1.5/CONUSne30x8/emissions-finnv1.5_GLYALD_bb_surface_20100101-20171231_ne0conus_c200619.nc</GLYALD_bb_srf_file>
+<HCN_an_srf_file      hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam4_vbs" ver="cam6">atm/cam/chem/emis/CAMS_Anthro_ne0CONUSne30x8/CAMS-GLOB-ANT_Glb_ne0CONUSne30x8_anthro_surface_HCN_v3.1_c20191103.nc</HCN_an_srf_file>
+<HCN_bb_srf_file      hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam4_vbs" ver="cam6">atm/cam/chem/emis/finn1.5/CONUSne30x8/emissions-finnv1.5_HCN_bb_surface_20100101-20171231_ne0conus_c200619.nc</HCN_bb_srf_file>
+<HCOOH_an_srf_file    hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam4_vbs" ver="cam6">atm/cam/chem/emis/CAMS_Anthro_ne0CONUSne30x8/CAMS-GLOB-ANT_Glb_ne0CONUSne30x8_anthro_surface_HCOOH_v3.1_c20191103.nc</HCOOH_an_srf_file>
+<HCOOH_bb_srf_file    hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam4_vbs" ver="cam6">atm/cam/chem/emis/finn1.5/CONUSne30x8/emissions-finnv1.5_HCOOH_bb_surface_20100101-20171231_ne0conus_c200619.nc</HCOOH_bb_srf_file>
+<HYAC_bb_srf_file     hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam4_vbs" ver="cam6">atm/cam/chem/emis/finn1.5/CONUSne30x8/emissions-finnv1.5_HYAC_bb_surface_20100101-20171231_ne0conus_c200619.nc</HYAC_bb_srf_file>
+<ISOP_an_srf_file     hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam4_vbs" ver="cam6">atm/cam/chem/emis/CAMS_Anthro_ne0CONUSne30x8/CAMS-GLOB-ANT_Glb_ne0CONUSne30x8_anthro_surface_ISOP_v3.1_c20191103.nc</ISOP_an_srf_file>
+<ISOP_bb_srf_file     hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam4_vbs" ver="cam6">atm/cam/chem/emis/finn1.5/CONUSne30x8/emissions-finnv1.5_ISOP_bb_surface_20100101-20171231_ne0conus_c200619.nc</ISOP_bb_srf_file>
+<IVOC_an_srf_file     hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam4_vbs" ver="cam6">atm/cam/chem/emis/CAMS_Anthro_ne0CONUSne30x8/CAMS-GLOB-ANT_Glb_ne0CONUSne30x8_anthro_surface_IVOC_v3.1_c20191103.nc</IVOC_an_srf_file>
+<IVOC_bb_srf_file     hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam4_vbs" ver="cam6">atm/cam/chem/emis/finn1.5/CONUSne30x8/emissions-finnv1.5_IVOC_bb_surface_20100101-20171231_ne0conus_c200619.nc</IVOC_bb_srf_file>
+<MACR_bb_srf_file     hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam4_vbs" ver="cam6">atm/cam/chem/emis/finn1.5/CONUSne30x8/emissions-finnv1.5_MACR_bb_surface_20100101-20171231_ne0conus_c200619.nc</MACR_bb_srf_file>
+<MEK_an_srf_file      hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam4_vbs" ver="cam6">atm/cam/chem/emis/CAMS_Anthro_ne0CONUSne30x8/CAMS-GLOB-ANT_Glb_ne0CONUSne30x8_anthro_surface_MEK_v3.1_c20191103.nc</MEK_an_srf_file>
+<MEK_bb_srf_file      hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam4_vbs" ver="cam6">atm/cam/chem/emis/finn1.5/CONUSne30x8/emissions-finnv1.5_MEK_bb_surface_20100101-20171231_ne0conus_c200619.nc</MEK_bb_srf_file>
+<MTERP_an_srf_file    hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam4_vbs" ver="cam6">atm/cam/chem/emis/CAMS_Anthro_ne0CONUSne30x8/CAMS-GLOB-ANT_Glb_ne0CONUSne30x8_anthro_surface_MTERP_v3.1_c20191103.nc</MTERP_an_srf_file>
+<MTERP_bb_srf_file    hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam4_vbs" ver="cam6">atm/cam/chem/emis/finn1.5/CONUSne30x8/emissions-finnv1.5_TERPENES_bb_surface_20100101-20171231_ne0conus_c200619.nc</MTERP_bb_srf_file>
+<MVK_bb_srf_file      hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam4_vbs" ver="cam6">atm/cam/chem/emis/finn1.5/CONUSne30x8/emissions-finnv1.5_MVK_bb_surface_20100101-20171231_ne0conus_c200619.nc</MVK_bb_srf_file>
+<NH3_an_srf_file      hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam4_vbs" ver="cam6">atm/cam/chem/emis/CAMS_Anthro_ne0CONUSne30x8/CAMS-GLOB-ANT_Glb_ne0CONUSne30x8_anthro_surface_NH3_v3.1_c20191103.nc</NH3_an_srf_file>
+<NH3_bb_srf_file      hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam4_vbs" ver="cam6">atm/cam/chem/emis/finn1.5/CONUSne30x8/emissions-finnv1.5_NH3_bb_surface_20100101-20171231_ne0conus_c200619.nc</NH3_bb_srf_file>
+<NH3_ot_srf_file      hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam4_vbs" ver="cam6">atm/cam/chem/emis/historical_ne0CONUSne30x8/emissions-cmip6_NH3_other_surface_1750_2015_historical_ne0CONUSne30x8_c20191028.nc</NH3_ot_srf_file>
+<NO_an_srf_file       hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam4_vbs" ver="cam6">atm/cam/chem/emis/CAMS_Anthro_ne0CONUSne30x8/CAMS-GLOB-ANT_Glb_ne0CONUSne30x8_anthro_surface_NOx_v3.1_c20191103.nc</NO_an_srf_file>
+<NO_bb_srf_file       hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam4_vbs" ver="cam6">atm/cam/chem/emis/finn1.5/CONUSne30x8/emissions-finnv1.5_NO_bb_surface_20100101-20171231_ne0conus_c200619.nc</NO_bb_srf_file>
+<NO_ot_srf_file       hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam4_vbs" ver="cam6">atm/cam/chem/emis/historical_ne0CONUSne30x8/emissions-cmip6_NO_other_surface_1750_2015_historical_ne0CONUSne30x8_c20191028.nc</NO_ot_srf_file>
+<NO2_bb_srf_file      hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam4_vbs" ver="cam6">atm/cam/chem/emis/finn1.5/CONUSne30x8/emissions-finnv1.5_NO2_bb_surface_20100101-20171231_ne0conus_c200619.nc</NO2_bb_srf_file>
+<so2_ag_sh_file       hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam4_vbs" ver="cam6">atm/cam/chem/emis/CAMS_Anthro_ne0CONUSne30x8/CAMS-GLOB-ANT_Glb_ne0CONUSne30x8_SO2_anthro-ag-ship-res_surface_v3.1_c20191103.nc</so2_ag_sh_file>
+<so2_an_srf_file      hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam4_vbs" ver="cam6">atm/cam/chem/emis/CAMS_Anthro_ne0CONUSne30x8/CAMS-GLOB-ANT_Glb_ne0CONUSne30x8_SO2_anthro-ene_surface_v3.1_c20191103.nc</so2_an_srf_file>
+<so2_bb_srf_file      hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam4_vbs" ver="cam6">atm/cam/chem/emis/finn1.5/CONUSne30x8/emissions-finnv1.5_SO2_bb_surface_20100101-20171231_ne0conus_c200619.nc</so2_bb_srf_file>
+<SOAG_an_srf_file     hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam4_vbs" ver="cam6">atm/cam/chem/emis/CAMS_Anthro_ne0CONUSne30x8/CAMS-GLOB-ANT_Glb_ne0CONUSne30x8_anthro_surface_SOAGx1.5_v3.1_c20191103.nc</SOAG_an_srf_file>
+<SVOC_an_srf_file     hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam4_vbs" ver="cam6">atm/cam/chem/emis/CAMS_Anthro_ne0CONUSne30x8/CAMS-GLOB-ANT_Glb_ne0CONUSne30x8_anthro_surface_SVOC_v3.1_c20191103.nc</SVOC_an_srf_file>
+<SVOC_bb_srf_file     hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam4_vbs" ver="cam6">atm/cam/chem/emis/finn1.5/CONUSne30x8/emissions-finnv1.5_SVOC_bb_surface_20100101-20171231_ne0conus_c200619.nc</SVOC_bb_srf_file>
+<TOLUENE_an_srf_file  hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam4_vbs" ver="cam6">atm/cam/chem/emis/CAMS_Anthro_ne0CONUSne30x8/CAMS-GLOB-ANT_Glb_ne0CONUSne30x8_anthro_surface_TOLUENE_v3.1_c20191103.nc</TOLUENE_an_srf_file>
+<TOLUENE_bb_srf_file  hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam4_vbs" ver="cam6">atm/cam/chem/emis/finn1.5/CONUSne30x8/emissions-finnv1.5_TOLUENE_bb_surface_20100101-20171231_ne0conus_c200619.nc</TOLUENE_bb_srf_file>
+<XYLENES_an_srf_file  hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam4_vbs" ver="cam6">atm/cam/chem/emis/CAMS_Anthro_ne0CONUSne30x8/CAMS-GLOB-ANT_Glb_ne0CONUSne30x8_anthro_surface_XYLENES_v3.1_c20191103.nc</XYLENES_an_srf_file>
+<XYLENES_bb_srf_file  hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam4_vbs" ver="cam6">atm/cam/chem/emis/finn1.5/CONUSne30x8/emissions-finnv1.5_XYLENES_bb_surface_20100101-20171231_ne0conus_c200619.nc</XYLENES_bb_srf_file>
+
+<BIGALD_bb_srf_file   hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_t1s1" ver="cam6">atm/cam/chem/emis/finn1.5/CONUSne30x8/emissions-finnv1.5_BIGALD_bb_surface_20100101-20171231_ne0conus_c200619.nc</BIGALD_bb_srf_file>
+<BIGALK_an_srf_file   hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_t1s1" ver="cam6">atm/cam/chem/emis/CAMS_Anthro_ne0CONUSne30x8/CAMS-GLOB-ANT_Glb_ne0CONUSne30x8_anthro_surface_BIGALK_v3.1_c20191103.nc</BIGALK_an_srf_file>
+<BIGALK_bb_srf_file   hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_t1s1" ver="cam6">atm/cam/chem/emis/finn1.5/CONUSne30x8/emissions-finnv1.5_BIGALK_bb_surface_20100101-20171231_ne0conus_c200619.nc</BIGALK_bb_srf_file>
+<BIGENE_an_srf_file   hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_t1s1" ver="cam6">atm/cam/chem/emis/CAMS_Anthro_ne0CONUSne30x8/CAMS-GLOB-ANT_Glb_ne0CONUSne30x8_anthro_surface_BIGENE_v3.1_c20191103.nc</BIGENE_an_srf_file>
+<BIGENE_bb_srf_file   hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_t1s1" ver="cam6">atm/cam/chem/emis/finn1.5/CONUSne30x8/emissions-finnv1.5_BIGENE_bb_surface_20100101-20171231_ne0conus_c200619.nc</BIGENE_bb_srf_file>
+<C2H2_an_srf_file     hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_t1s1" ver="cam6">atm/cam/chem/emis/CAMS_Anthro_ne0CONUSne30x8/CAMS-GLOB-ANT_Glb_ne0CONUSne30x8_anthro_surface_C2H2_v3.1_c20191103.nc</C2H2_an_srf_file>
+<C2H2_bb_srf_file     hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_t1s1" ver="cam6">atm/cam/chem/emis/finn1.5/CONUSne30x8/emissions-finnv1.5_C2H2_bb_surface_20100101-20171231_ne0conus_c200619.nc</C2H2_bb_srf_file>
+<C2H4_an_srf_file     hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_t1s1" ver="cam6">atm/cam/chem/emis/CAMS_Anthro_ne0CONUSne30x8/CAMS-GLOB-ANT_Glb_ne0CONUSne30x8_anthro_surface_C2H4_v3.1_c20191103.nc</C2H4_an_srf_file>
+<C2H4_bb_srf_file     hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_t1s1" ver="cam6">atm/cam/chem/emis/finn1.5/CONUSne30x8/emissions-finnv1.5_C2H4_bb_surface_20100101-20171231_ne0conus_c200619.nc</C2H4_bb_srf_file>
+<C2H4_ot_srf_file     hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_t1s1" ver="cam6">atm/cam/chem/emis/historical_ne0CONUSne30x8/emissions-cmip6_C2H4_other_surface_1750_2015_historical_ne0CONUSne30x8_c20191028.nc</C2H4_ot_srf_file>
+<C2H5OH_an_srf_file   hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_t1s1" ver="cam6">atm/cam/chem/emis/CAMS_Anthro_ne0CONUSne30x8/CAMS-GLOB-ANT_Glb_ne0CONUSne30x8_anthro_surface_C2H5OH_v3.1_c20191103.nc</C2H5OH_an_srf_file>
+<C2H5OH_bb_srf_file   hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_t1s1" ver="cam6">atm/cam/chem/emis/finn1.5/CONUSne30x8/emissions-finnv1.5_C2H5OH_bb_surface_20100101-20171231_ne0conus_c200619.nc</C2H5OH_bb_srf_file>
+<C2H6_an_srf_file     hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_t1s1" ver="cam6">atm/cam/chem/emis/CAMS_Anthro_ne0CONUSne30x8/CAMS-GLOB-ANT_Glb_ne0CONUSne30x8_anthro_surface_C2H6_v3.1_c20191103.nc</C2H6_an_srf_file>
+<C2H6_bb_srf_file     hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_t1s1" ver="cam6">atm/cam/chem/emis/finn1.5/CONUSne30x8/emissions-finnv1.5_C2H6_bb_surface_20100101-20171231_ne0conus_c200619.nc</C2H6_bb_srf_file>
+<C2H6_ot_srf_file     hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_t1s1" ver="cam6">atm/cam/chem/emis/historical_ne0CONUSne30x8/emissions-cmip6_C2H6_other_surface_1750_2015_historical_ne0CONUSne30x8_c20191028.nc</C2H6_ot_srf_file>
+<C3H6_an_srf_file     hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_t1s1" ver="cam6">atm/cam/chem/emis/CAMS_Anthro_ne0CONUSne30x8/CAMS-GLOB-ANT_Glb_ne0CONUSne30x8_anthro_surface_C3H6_v3.1_c20191103.nc</C3H6_an_srf_file>
+<C3H6_bb_srf_file     hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_t1s1" ver="cam6">atm/cam/chem/emis/finn1.5/CONUSne30x8/emissions-finnv1.5_C3H6_bb_surface_20100101-20171231_ne0conus_c200619.nc</C3H6_bb_srf_file>
+<C3H6_ot_srf_file     hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_t1s1" ver="cam6">atm/cam/chem/emis/historical_ne0CONUSne30x8/emissions-cmip6_C3H6_other_surface_1750_2015_historical_ne0CONUSne30x8_c20191028.nc</C3H6_ot_srf_file>
+<C3H8_an_srf_file     hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_t1s1" ver="cam6">atm/cam/chem/emis/CAMS_Anthro_ne0CONUSne30x8/CAMS-GLOB-ANT_Glb_ne0CONUSne30x8_anthro_surface_C3H8_v3.1_c20191103.nc</C3H8_an_srf_file>
+<C3H8_bb_srf_file     hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_t1s1" ver="cam6">atm/cam/chem/emis/finn1.5/CONUSne30x8/emissions-finnv1.5_C3H8_bb_surface_20100101-20171231_ne0conus_c200619.nc</C3H8_bb_srf_file>
+<C3H8_ot_srf_file     hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_t1s1" ver="cam6">atm/cam/chem/emis/historical_ne0CONUSne30x8/emissions-cmip6_C3H8_other_surface_1750_2015_historical_ne0CONUSne30x8_c20191028.nc</C3H8_ot_srf_file>
+<CH2O_an_srf_file     hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_t1s1" ver="cam6">atm/cam/chem/emis/CAMS_Anthro_ne0CONUSne30x8/CAMS-GLOB-ANT_Glb_ne0CONUSne30x8_anthro_surface_CH2O_v3.1_c20191103.nc</CH2O_an_srf_file>
+<CH2O_bb_srf_file     hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_t1s1" ver="cam6">atm/cam/chem/emis/finn1.5/CONUSne30x8/emissions-finnv1.5_CH2O_bb_surface_20100101-20171231_ne0conus_c200619.nc</CH2O_bb_srf_file>
+<CH3CHO_an_srf_file   hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_t1s1" ver="cam6">atm/cam/chem/emis/CAMS_Anthro_ne0CONUSne30x8/CAMS-GLOB-ANT_Glb_ne0CONUSne30x8_anthro_surface_CH3CHO_v3.1_c20191103.nc</CH3CHO_an_srf_file>
+<CH3CHO_bb_srf_file   hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_t1s1" ver="cam6">atm/cam/chem/emis/finn1.5/CONUSne30x8/emissions-finnv1.5_CH3CHO_bb_surface_20100101-20171231_ne0conus_c200619.nc</CH3CHO_bb_srf_file>
+<CH3CN_an_srf_file    hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_t1s1" ver="cam6">atm/cam/chem/emis/CAMS_Anthro_ne0CONUSne30x8/CAMS-GLOB-ANT_Glb_ne0CONUSne30x8_anthro_surface_CH3CN_v3.1_c20191103.nc</CH3CN_an_srf_file>
+<CH3CN_bb_srf_file    hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_t1s1" ver="cam6">atm/cam/chem/emis/finn1.5/CONUSne30x8/emissions-finnv1.5_CH3CN_bb_surface_20100101-20171231_ne0conus_c200619.nc</CH3CN_bb_srf_file>
+<CH3COCH3_an_srf_file hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_t1s1" ver="cam6">atm/cam/chem/emis/CAMS_Anthro_ne0CONUSne30x8/CAMS-GLOB-ANT_Glb_ne0CONUSne30x8_anthro_surface_CH3COCH3_v3.1_c20191103.nc</CH3COCH3_an_srf_file>
+<CH3COCH3_bb_srf_file hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_t1s1" ver="cam6">atm/cam/chem/emis/finn1.5/CONUSne30x8/emissions-finnv1.5_CH3COCH3_bb_surface_20100101-20171231_ne0conus_c200619.nc</CH3COCH3_bb_srf_file>
+<CH3COCHO_bb_srf_file hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_t1s1" ver="cam6">atm/cam/chem/emis/finn1.5/CONUSne30x8/emissions-finnv1.5_CH3COCHO_bb_surface_20100101-20171231_ne0conus_c200619.nc</CH3COCHO_bb_srf_file>
+<CH3COOH_an_srf_file  hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_t1s1" ver="cam6">atm/cam/chem/emis/CAMS_Anthro_ne0CONUSne30x8/CAMS-GLOB-ANT_Glb_ne0CONUSne30x8_anthro_surface_CH3COOH_v3.1_c20191103.nc</CH3COOH_an_srf_file>
+<CH3COOH_bb_srf_file  hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_t1s1" ver="cam6">atm/cam/chem/emis/finn1.5/CONUSne30x8/emissions-finnv1.5_CH3COOH_bb_surface_20100101-20171231_ne0conus_c200619.nc</CH3COOH_bb_srf_file>
+<CH3OH_an_srf_file    hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_t1s1" ver="cam6">atm/cam/chem/emis/CAMS_Anthro_ne0CONUSne30x8/CAMS-GLOB-ANT_Glb_ne0CONUSne30x8_anthro_surface_CH3OH_v3.1_c20191103.nc</CH3OH_an_srf_file>
+<CH3OH_bb_srf_file    hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_t1s1" ver="cam6">atm/cam/chem/emis/finn1.5/CONUSne30x8/emissions-finnv1.5_CH3OH_bb_surface_20100101-20171231_ne0conus_c200619.nc</CH3OH_bb_srf_file>
+<CO_an_srf_file       hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_t1s1" ver="cam6">atm/cam/chem/emis/CAMS_Anthro_ne0CONUSne30x8/CAMS-GLOB-ANT_Glb_ne0CONUSne30x8_anthro_surface_CO_v3.1_c20191103.nc</CO_an_srf_file>
+<CO_bb_srf_file       hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_t1s1" ver="cam6">atm/cam/chem/emis/finn1.5/CONUSne30x8/emissions-finnv1.5_CO_bb_surface_20100101-20171231_ne0conus_c200619.nc</CO_bb_srf_file>
+<CO_ot_srf_file       hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_t1s1" ver="cam6">atm/cam/chem/emis/historical_ne0CONUSne30x8/emissions-cmip6_CO_other_surface_1750_2015_historical_ne0CONUSne30x8_c20191028.nc</CO_ot_srf_file>
+<CRESOL_bb_srf_file   hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_t1s1" ver="cam6">atm/cam/chem/emis/finn1.5/CONUSne30x8/emissions-finnv1.5_CRESOL_bb_surface_20100101-20171231_ne0conus_c200619.nc</CRESOL_bb_srf_file>
+<dms_ot_srf_file      hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_t1s1" ver="cam6">atm/cam/chem/emis/historical_ne0CONUSne30x8/emissions-cmip6_DMS_other_surface_1750_2015_historical_ne0CONUSne30x8_c20191028.nc</dms_ot_srf_file>
+<GLYALD_bb_srf_file   hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_t1s1" ver="cam6">atm/cam/chem/emis/finn1.5/CONUSne30x8/emissions-finnv1.5_GLYALD_bb_surface_20100101-20171231_ne0conus_c200619.nc</GLYALD_bb_srf_file>
+<HCN_an_srf_file      hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_t1s1" ver="cam6">atm/cam/chem/emis/CAMS_Anthro_ne0CONUSne30x8/CAMS-GLOB-ANT_Glb_ne0CONUSne30x8_anthro_surface_HCN_v3.1_c20191103.nc</HCN_an_srf_file>
+<HCN_bb_srf_file      hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_t1s1" ver="cam6">atm/cam/chem/emis/finn1.5/CONUSne30x8/emissions-finnv1.5_HCN_bb_surface_20100101-20171231_ne0conus_c200619.nc</HCN_bb_srf_file>
+<HCOOH_an_srf_file    hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_t1s1" ver="cam6">atm/cam/chem/emis/CAMS_Anthro_ne0CONUSne30x8/CAMS-GLOB-ANT_Glb_ne0CONUSne30x8_anthro_surface_HCOOH_v3.1_c20191103.nc</HCOOH_an_srf_file>
+<HCOOH_bb_srf_file    hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_t1s1" ver="cam6">atm/cam/chem/emis/finn1.5/CONUSne30x8/emissions-finnv1.5_HCOOH_bb_surface_20100101-20171231_ne0conus_c200619.nc</HCOOH_bb_srf_file>
+<HYAC_bb_srf_file     hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_t1s1" ver="cam6">atm/cam/chem/emis/finn1.5/CONUSne30x8/emissions-finnv1.5_HYAC_bb_surface_20100101-20171231_ne0conus_c200619.nc</HYAC_bb_srf_file>
+<ISOP_an_srf_file     hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_t1s1" ver="cam6">atm/cam/chem/emis/CAMS_Anthro_ne0CONUSne30x8/CAMS-GLOB-ANT_Glb_ne0CONUSne30x8_anthro_surface_ISOP_v3.1_c20191103.nc</ISOP_an_srf_file>
+<ISOP_bb_srf_file     hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_t1s1" ver="cam6">atm/cam/chem/emis/finn1.5/CONUSne30x8/emissions-finnv1.5_ISOP_bb_surface_20100101-20171231_ne0conus_c200619.nc</ISOP_bb_srf_file>
+<IVOC_an_srf_file     hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_t1s1" ver="cam6">atm/cam/chem/emis/CAMS_Anthro_ne0CONUSne30x8/CAMS-GLOB-ANT_Glb_ne0CONUSne30x8_anthro_surface_IVOC_v3.1_c20191103.nc</IVOC_an_srf_file>
+<IVOC_bb_srf_file     hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_t1s1" ver="cam6">atm/cam/chem/emis/finn1.5/CONUSne30x8/emissions-finnv1.5_IVOC_bb_surface_20100101-20171231_ne0conus_c200619.nc</IVOC_bb_srf_file>
+<MACR_bb_srf_file     hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_t1s1" ver="cam6">atm/cam/chem/emis/finn1.5/CONUSne30x8/emissions-finnv1.5_MACR_bb_surface_20100101-20171231_ne0conus_c200619.nc</MACR_bb_srf_file>
+<MEK_an_srf_file      hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_t1s1" ver="cam6">atm/cam/chem/emis/CAMS_Anthro_ne0CONUSne30x8/CAMS-GLOB-ANT_Glb_ne0CONUSne30x8_anthro_surface_MEK_v3.1_c20191103.nc</MEK_an_srf_file>
+<MEK_bb_srf_file      hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_t1s1" ver="cam6">atm/cam/chem/emis/finn1.5/CONUSne30x8/emissions-finnv1.5_MEK_bb_surface_20100101-20171231_ne0conus_c200619.nc</MEK_bb_srf_file>
+<MTERP_an_srf_file    hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_t1s1" ver="cam6">atm/cam/chem/emis/CAMS_Anthro_ne0CONUSne30x8/CAMS-GLOB-ANT_Glb_ne0CONUSne30x8_anthro_surface_MTERP_v3.1_c20191103.nc</MTERP_an_srf_file>
+<MTERP_bb_srf_file    hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_t1s1" ver="cam6">atm/cam/chem/emis/finn1.5/CONUSne30x8/emissions-finnv1.5_TERPENES_bb_surface_20100101-20171231_ne0conus_c200619.nc</MTERP_bb_srf_file>
+<MVK_bb_srf_file      hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_t1s1" ver="cam6">atm/cam/chem/emis/finn1.5/CONUSne30x8/emissions-finnv1.5_MVK_bb_surface_20100101-20171231_ne0conus_c200619.nc</MVK_bb_srf_file>
+<NH3_an_srf_file      hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_t1s1" ver="cam6">atm/cam/chem/emis/CAMS_Anthro_ne0CONUSne30x8/CAMS-GLOB-ANT_Glb_ne0CONUSne30x8_anthro_surface_NH3_v3.1_c20191103.nc</NH3_an_srf_file>
+<NH3_bb_srf_file      hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_t1s1" ver="cam6">atm/cam/chem/emis/finn1.5/CONUSne30x8/emissions-finnv1.5_NH3_bb_surface_20100101-20171231_ne0conus_c200619.nc</NH3_bb_srf_file>
+<NH3_ot_srf_file      hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_t1s1" ver="cam6">atm/cam/chem/emis/historical_ne0CONUSne30x8/emissions-cmip6_NH3_other_surface_1750_2015_historical_ne0CONUSne30x8_c20191028.nc</NH3_ot_srf_file>
+<NO_an_srf_file       hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_t1s1" ver="cam6">atm/cam/chem/emis/CAMS_Anthro_ne0CONUSne30x8/CAMS-GLOB-ANT_Glb_ne0CONUSne30x8_anthro_surface_NOx_v3.1_c20191103.nc</NO_an_srf_file>
+<NO_bb_srf_file       hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_t1s1" ver="cam6">atm/cam/chem/emis/finn1.5/CONUSne30x8/emissions-finnv1.5_NO_bb_surface_20100101-20171231_ne0conus_c200619.nc</NO_bb_srf_file>
+<NO_ot_srf_file       hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_t1s1" ver="cam6">atm/cam/chem/emis/historical_ne0CONUSne30x8/emissions-cmip6_NO_other_surface_1750_2015_historical_ne0CONUSne30x8_c20191028.nc</NO_ot_srf_file>
+<NO2_bb_srf_file      hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_t1s1" ver="cam6">atm/cam/chem/emis/finn1.5/CONUSne30x8/emissions-finnv1.5_NO2_bb_surface_20100101-20171231_ne0conus_c200619.nc</NO2_bb_srf_file>
+<so2_ag_sh_file       hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_t1s1" ver="cam6">atm/cam/chem/emis/CAMS_Anthro_ne0CONUSne30x8/CAMS-GLOB-ANT_Glb_ne0CONUSne30x8_SO2_anthro-ag-ship-res_surface_v3.1_c20191103.nc</so2_ag_sh_file>
+<so2_an_srf_file      hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_t1s1" ver="cam6">atm/cam/chem/emis/CAMS_Anthro_ne0CONUSne30x8/CAMS-GLOB-ANT_Glb_ne0CONUSne30x8_SO2_anthro-ene_surface_v3.1_c20191103.nc</so2_an_srf_file>
+<so2_bb_srf_file      hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_t1s1" ver="cam6">atm/cam/chem/emis/finn1.5/CONUSne30x8/emissions-finnv1.5_SO2_bb_surface_20100101-20171231_ne0conus_c200619.nc</so2_bb_srf_file>
+<SOAG_an_srf_file     hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_t1s1" ver="cam6">atm/cam/chem/emis/CAMS_Anthro_ne0CONUSne30x8/CAMS-GLOB-ANT_Glb_ne0CONUSne30x8_anthro_surface_SOAGx1.5_v3.1_c20191103.nc</SOAG_an_srf_file>
+<SVOC_an_srf_file     hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_t1s1" ver="cam6">atm/cam/chem/emis/CAMS_Anthro_ne0CONUSne30x8/CAMS-GLOB-ANT_Glb_ne0CONUSne30x8_anthro_surface_SVOC_v3.1_c20191103.nc</SVOC_an_srf_file>
+<SVOC_bb_srf_file     hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_t1s1" ver="cam6">atm/cam/chem/emis/finn1.5/CONUSne30x8/emissions-finnv1.5_SVOC_bb_surface_20100101-20171231_ne0conus_c200619.nc</SVOC_bb_srf_file>
+<TOLUENE_an_srf_file  hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_t1s1" ver="cam6">atm/cam/chem/emis/CAMS_Anthro_ne0CONUSne30x8/CAMS-GLOB-ANT_Glb_ne0CONUSne30x8_anthro_surface_TOLUENE_v3.1_c20191103.nc</TOLUENE_an_srf_file>
+<TOLUENE_bb_srf_file  hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_t1s1" ver="cam6">atm/cam/chem/emis/finn1.5/CONUSne30x8/emissions-finnv1.5_TOLUENE_bb_surface_20100101-20171231_ne0conus_c200619.nc</TOLUENE_bb_srf_file>
+<XYLENES_an_srf_file  hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_t1s1" ver="cam6">atm/cam/chem/emis/CAMS_Anthro_ne0CONUSne30x8/CAMS-GLOB-ANT_Glb_ne0CONUSne30x8_anthro_surface_XYLENES_v3.1_c20191103.nc</XYLENES_an_srf_file>
+<XYLENES_bb_srf_file  hgrid="ne0np4CONUS.ne30x8" chem="trop_strat_mam5_t1s1" ver="cam6">atm/cam/chem/emis/finn1.5/CONUSne30x8/emissions-finnv1.5_XYLENES_bb_surface_20100101-20171231_ne0conus_c200619.nc</XYLENES_bb_srf_file>
+
+<!-- SCAM CMIP emissions - lightweight set of emissions files for single column -->
+
+<dms_ot_srf_file     ver="cam6" scam="1">atm/cam/chem/emis/CMIP6_emissions_2000climo/emissions-cmip6_DMS_other_surface_2000climo_0.9x1.25_c20170322.nc</dms_ot_srf_file>
+<dms_bb_srf_file     ver="cam6" scam="1">atm/cam/chem/emis/CMIP6_emissions_2000climo/emissions-cmip6_DMS_bb_surface_2000climo_0.9x1.25_c20170322.nc</dms_bb_srf_file>
+<so2_ag_sh_file      ver="cam6" scam="1">atm/cam/chem/emis/CMIP6_emissions_2000climo/emissions-cmip6_SO2_anthro-ag-ship-res_surface_2000climo_0.9x1.25_c20170616.nc</so2_ag_sh_file>
+<so2_an_srf_file     ver="cam6" scam="1">atm/cam/chem/emis/CMIP6_emissions_2000climo/emissions-cmip6_SO2_anthro-ene_surface_2000climo_0.9x1.25_c20170616.nc</so2_an_srf_file>
+<so2_bb_srf_file     ver="cam6" scam="1">atm/cam/chem/emis/CMIP6_emissions_2000climo/emissions-cmip6_SO2_bb_surface_2000climo_0.9x1.25_c20170322.nc</so2_bb_srf_file>
+<so4_a1_an_srf_file  ver="cam6" scam="1">atm/cam/chem/emis/CMIP6_emissions_2000climo/emissions-cmip6_so4_a1_anthro-ag-ship_surface_2000climo_0.9x1.25_c20170616.nc</so4_a1_an_srf_file>
+<so4_a1_bb_srf_file  ver="cam6" scam="1">atm/cam/chem/emis/CMIP6_emissions_2000climo/emissions-cmip6_so4_a1_bb_surface_2000climo_0.9x1.25_c20170322.nc</so4_a1_bb_srf_file>
+<so4_a2_an_srf_file  ver="cam6" scam="1">atm/cam/chem/emis/CMIP6_emissions_2000climo/emissions-cmip6_so4_a2_anthro-res_surface_2000climo_0.9x1.25_c20170616.nc</so4_a2_an_srf_file>
+<num_a1_sh_srf_file  ver="cam6" scam="1">atm/cam/chem/emis/CMIP6_emissions_2000climo/emissions-cmip6_num_so4_a1_anthro-ag-ship_surface_2000climo_0.9x1.25_c20170616.nc</num_a1_sh_srf_file>
+<num_a2_an_srf_file  ver="cam6" scam="1">atm/cam/chem/emis/CMIP6_emissions_2000climo/emissions-cmip6_num_so4_a2_anthro-res_surface_2000climo_0.9x1.25_c20170616.nc</num_a2_an_srf_file>
+<bc_a4_an_srf_file   ver="cam6" scam="1">atm/cam/chem/emis/CMIP6_emissions_2000climo/emissions-cmip6_bc_a4_anthro_surface_2000climo_0.9x1.25_c20170608.nc</bc_a4_an_srf_file>
+<num_a4_bc_srf_file  ver="cam6" scam="1">atm/cam/chem/emis/CMIP6_emissions_2000climo/emissions-cmip6_num_bc_a4_anthro_surface_2000climo_0.9x1.25_c20170608.nc</num_a4_bc_srf_file>
+<pom_a4_an_srf_file  ver="cam6" scam="1">atm/cam/chem/emis/CMIP6_emissions_2000climo/emissions-cmip6_pom_a4_anthro_surface_2000climo_0.9x1.25_c20170608.nc</pom_a4_an_srf_file>
+<num_a4_oc_srf_file  ver="cam6" scam="1">atm/cam/chem/emis/CMIP6_emissions_2000climo/emissions-cmip6_num_pom_a4_anthro_surface_2000climo_0.9x1.25_c20170608.nc</num_a4_oc_srf_file>
+<num_a1_bb_srf_file  ver="cam6" scam="1">atm/cam/chem/emis/CMIP6_emissions_2000climo/emissions-cmip6_num_so4_a1_bb_surface_2000climo_0.9x1.25_c20170322.nc</num_a1_bb_srf_file>
+<bc_a4_bb_srf_file   ver="cam6" scam="1">atm/cam/chem/emis/CMIP6_emissions_2000climo/emissions-cmip6_bc_a4_bb_surface_2000climo_0.9x1.25_c20170322.nc</bc_a4_bb_srf_file>
+<num_a4_bb_srf_file  ver="cam6" scam="1">atm/cam/chem/emis/CMIP6_emissions_2000climo/emissions-cmip6_num_bc_a4_bb_surface_2000climo_0.9x1.25_c20170322.nc</num_a4_bb_srf_file>
+<pom_a4_bb_srf_file  ver="cam6" scam="1">atm/cam/chem/emis/CMIP6_emissions_2000climo/emissions-cmip6_pom_a4_bb_surface_2000climo_0.9x1.25_c20170322.nc</pom_a4_bb_srf_file>
+<num_pom_bb_srf_file ver="cam6" scam="1">atm/cam/chem/emis/CMIP6_emissions_2000climo/emissions-cmip6_num_pom_a4_bb_surface_2000climo_0.9x1.25_c20170509.nc</num_pom_bb_srf_file>
+<soag_an_srf_file    ver="cam6" scam="1">atm/cam/chem/emis/CMIP6_emissions_2000climo/emissions-cmip6_SOAGx1.5_anthro_surface_2000climo_0.9x1.25_c20170608.nc</soag_an_srf_file>
+<soag_bg_srf_file    ver="cam6" scam="1">atm/cam/chem/emis/CMIP6_emissions_2000climo/emissions-cmip6_SOAGx1.5_biogenic_surface_2000climo_0.9x1.25_c20170322.nc</soag_bg_srf_file>
+<soag_bb_srf_file    ver="cam6" scam="1">atm/cam/chem/emis/CMIP6_emissions_2000climo/emissions-cmip6_SOAGx1.5_bb_surface_2000climo_0.9x1.25_c20170322.nc</soag_bb_srf_file>
+
+<BENZENE_an_srf_file  ver="cam6" scam="1">atm/cam/chem/emis/CMIP6_emissions_2000climo/emissions-cmip6_BENZENE_anthro_surface_2000climo_0.9x1.25_c20170608.nc</BENZENE_an_srf_file>
+<BENZENE_bb_srf_file  ver="cam6" scam="1">atm/cam/chem/emis/CMIP6_emissions_2000climo/emissions-cmip6_BENZENE_bb_surface_2000climo_0.9x1.25_c20170322.nc</BENZENE_bb_srf_file>
+<BIGALK_an_srf_file   ver="cam6" scam="1">atm/cam/chem/emis/CMIP6_emissions_2000climo/emissions-cmip6_BIGALK_anthro_surface_2000climo_0.9x1.25_c20170608.nc</BIGALK_an_srf_file>
+<BIGALK_bb_srf_file   ver="cam6" scam="1">atm/cam/chem/emis/CMIP6_emissions_2000climo/emissions-cmip6_BIGALK_bb_surface_2000climo_0.9x1.25_c20170322.nc</BIGALK_bb_srf_file>
+<BIGENE_an_srf_file   ver="cam6" scam="1">atm/cam/chem/emis/CMIP6_emissions_2000climo/emissions-cmip6_BIGENE_anthro_surface_2000climo_0.9x1.25_c20170608.nc</BIGENE_an_srf_file>
+<BIGENE_bb_srf_file   ver="cam6" scam="1">atm/cam/chem/emis/CMIP6_emissions_2000climo/emissions-cmip6_BIGENE_bb_surface_2000climo_0.9x1.25_c20170322.nc</BIGENE_bb_srf_file>
+<C2H2_an_srf_file     ver="cam6" scam="1">atm/cam/chem/emis/CMIP6_emissions_2000climo/emissions-cmip6_C2H2_anthro_surface_2000climo_0.9x1.25_c20170608.nc</C2H2_an_srf_file>
+<C2H2_bb_srf_file     ver="cam6" scam="1">atm/cam/chem/emis/CMIP6_emissions_2000climo/emissions-cmip6_C2H2_bb_surface_2000climo_0.9x1.25_c20170322.nc</C2H2_bb_srf_file>
+<C2H4_an_srf_file     ver="cam6" scam="1">atm/cam/chem/emis/CMIP6_emissions_2000climo/emissions-cmip6_C2H4_anthro_surface_2000climo_0.9x1.25_c20170608.nc</C2H4_an_srf_file>
+<C2H4_bb_srf_file     ver="cam6" scam="1">atm/cam/chem/emis/CMIP6_emissions_2000climo/emissions-cmip6_C2H4_bb_surface_2000climo_0.9x1.25_c20170322.nc</C2H4_bb_srf_file>
+<C2H4_ot_srf_file     ver="cam6" scam="1">atm/cam/chem/emis/CMIP6_emissions_2000climo/emissions-cmip6_C2H4_other_surface_2000climo_0.9x1.25_c20170322.nc</C2H4_ot_srf_file>
+<C2H5OH_an_srf_file   ver="cam6" scam="1">atm/cam/chem/emis/CMIP6_emissions_2000climo/emissions-cmip6_C2H5OH_anthro_surface_2000climo_0.9x1.25_c20170608.nc</C2H5OH_an_srf_file>
+<C2H5OH_bb_srf_file   ver="cam6" scam="1">atm/cam/chem/emis/CMIP6_emissions_2000climo/emissions-cmip6_C2H5OH_bb_surface_2000climo_0.9x1.25_c20170322.nc</C2H5OH_bb_srf_file>
+<C2H6_an_srf_file     ver="cam6" scam="1">atm/cam/chem/emis/CMIP6_emissions_2000climo/emissions-cmip6_C2H6_anthro_surface_2000climo_0.9x1.25_c20170608.nc</C2H6_an_srf_file>
+<C2H6_bb_srf_file     ver="cam6" scam="1">atm/cam/chem/emis/CMIP6_emissions_2000climo/emissions-cmip6_C2H6_bb_surface_2000climo_0.9x1.25_c20170322.nc</C2H6_bb_srf_file>
+<C2H6_ot_srf_file     ver="cam6" scam="1">atm/cam/chem/emis/CMIP6_emissions_2000climo/emissions-cmip6_C2H6_other_surface_2000climo_0.9x1.25_c20170322.nc</C2H6_ot_srf_file>
+<C3H6_an_srf_file     ver="cam6" scam="1">atm/cam/chem/emis/CMIP6_emissions_2000climo/emissions-cmip6_C3H6_anthro_surface_2000climo_0.9x1.25_c20170608.nc</C3H6_an_srf_file>
+<C3H6_bb_srf_file     ver="cam6" scam="1">atm/cam/chem/emis/CMIP6_emissions_2000climo/emissions-cmip6_C3H6_bb_surface_2000climo_0.9x1.25_c20170322.nc</C3H6_bb_srf_file>
+<C3H6_ot_srf_file     ver="cam6" scam="1">atm/cam/chem/emis/CMIP6_emissions_2000climo/emissions-cmip6_C3H6_other_surface_2000climo_0.9x1.25_c20170322.nc</C3H6_ot_srf_file>
+<C3H8_an_srf_file     ver="cam6" scam="1">atm/cam/chem/emis/CMIP6_emissions_2000climo/emissions-cmip6_C3H8_anthro_surface_2000climo_0.9x1.25_c20170608.nc</C3H8_an_srf_file>
+<C3H8_bb_srf_file     ver="cam6" scam="1">atm/cam/chem/emis/CMIP6_emissions_2000climo/emissions-cmip6_C3H8_bb_surface_2000climo_0.9x1.25_c20170322.nc</C3H8_bb_srf_file>
+<C3H8_ot_srf_file     ver="cam6" scam="1">atm/cam/chem/emis/CMIP6_emissions_2000climo/emissions-cmip6_C3H8_other_surface_2000climo_0.9x1.25_c20170322.nc</C3H8_ot_srf_file>
+<CH2O_an_srf_file     ver="cam6" scam="1">atm/cam/chem/emis/CMIP6_emissions_2000climo/emissions-cmip6_CH2O_anthro_surface_2000climo_0.9x1.25_c20170608.nc</CH2O_an_srf_file>
+<CH2O_bb_srf_file     ver="cam6" scam="1">atm/cam/chem/emis/CMIP6_emissions_2000climo/emissions-cmip6_CH2O_bb_surface_2000climo_0.9x1.25_c20170322.nc</CH2O_bb_srf_file>
+<CH3CHO_an_srf_file   ver="cam6" scam="1">atm/cam/chem/emis/CMIP6_emissions_2000climo/emissions-cmip6_CH3CHO_anthro_surface_2000climo_0.9x1.25_c20170608.nc</CH3CHO_an_srf_file>
+<CH3CHO_bb_srf_file   ver="cam6" scam="1">atm/cam/chem/emis/CMIP6_emissions_2000climo/emissions-cmip6_CH3CHO_bb_surface_2000climo_0.9x1.25_c20170322.nc</CH3CHO_bb_srf_file>
+<CH3CN_an_srf_file    ver="cam6" scam="1">atm/cam/chem/emis/CMIP6_emissions_2000climo/emissions-cmip6_CH3CN_anthro_surface_2000climo_0.9x1.25_c20170608.nc</CH3CN_an_srf_file>
+<CH3CN_bb_srf_file    ver="cam6" scam="1">atm/cam/chem/emis/CMIP6_emissions_2000climo/emissions-cmip6_CH3CN_bb_surface_2000climo_0.9x1.25_c20170322.nc</CH3CN_bb_srf_file>
+<CH3COCH3_an_srf_file ver="cam6" scam="1">atm/cam/chem/emis/CMIP6_emissions_2000climo/emissions-cmip6_CH3COCH3_anthro_surface_2000climo_0.9x1.25_c20170608.nc</CH3COCH3_an_srf_file>
+<CH3COCH3_bb_srf_file ver="cam6" scam="1">atm/cam/chem/emis/CMIP6_emissions_2000climo/emissions-cmip6_CH3COCH3_bb_surface_2000climo_0.9x1.25_c20170322.nc</CH3COCH3_bb_srf_file>
+<CH3COCHO_bb_srf_file ver="cam6" scam="1">atm/cam/chem/emis/CMIP6_emissions_2000climo/emissions-cmip6_CH3COCHO_bb_surface_2000climo_0.9x1.25_c20170322.nc</CH3COCHO_bb_srf_file>
+<CH3COOH_an_srf_file  ver="cam6" scam="1">atm/cam/chem/emis/CMIP6_emissions_2000climo/emissions-cmip6_CH3COOH_anthro_surface_2000climo_0.9x1.25_c20170608.nc</CH3COOH_an_srf_file>
+<CH3COOH_bb_srf_file  ver="cam6" scam="1">atm/cam/chem/emis/CMIP6_emissions_2000climo/emissions-cmip6_CH3COOH_bb_surface_2000climo_0.9x1.25_c20170322.nc</CH3COOH_bb_srf_file>
+<CH3OH_an_srf_file    ver="cam6" scam="1">atm/cam/chem/emis/CMIP6_emissions_2000climo/emissions-cmip6_CH3OH_anthro_surface_2000climo_0.9x1.25_c20170608.nc</CH3OH_an_srf_file>
+<CH3OH_bb_srf_file    ver="cam6" scam="1">atm/cam/chem/emis/CMIP6_emissions_2000climo/emissions-cmip6_CH3OH_bb_surface_2000climo_0.9x1.25_c20170322.nc</CH3OH_bb_srf_file>
+<CO_an_srf_file       ver="cam6" scam="1">atm/cam/chem/emis/CMIP6_emissions_2000climo/emissions-cmip6_CO_anthro_surface_2000climo_0.9x1.25_c20180504.nc</CO_an_srf_file>
+<CO_bb_srf_file       ver="cam6" scam="1">atm/cam/chem/emis/CMIP6_emissions_2000climo/emissions-cmip6_CO_bb_surface_2000climo_0.9x1.25_c20170322.nc</CO_bb_srf_file>
+<CO_ot_srf_file       ver="cam6" scam="1">atm/cam/chem/emis/CMIP6_emissions_2000climo/emissions-cmip6_CO_other_surface_2000climo_0.9x1.25_c20170322.nc</CO_ot_srf_file>
+<GLYALD_bb_srf_file   ver="cam6" scam="1">atm/cam/chem/emis/CMIP6_emissions_2000climo/emissions-cmip6_GLYALD_bb_surface_2000climo_0.9x1.25_c20170322.nc</GLYALD_bb_srf_file>
+<HCN_an_srf_file      ver="cam6" scam="1">atm/cam/chem/emis/CMIP6_emissions_2000climo/emissions-cmip6_HCN_anthro_surface_2000climo_0.9x1.25_c20170608.nc</HCN_an_srf_file>
+<HCN_bb_srf_file      ver="cam6" scam="1">atm/cam/chem/emis/CMIP6_emissions_2000climo/emissions-cmip6_HCN_bb_surface_2000climo_0.9x1.25_c20170322.nc</HCN_bb_srf_file>
+<HCOOH_an_srf_file    ver="cam6" scam="1">atm/cam/chem/emis/CMIP6_emissions_2000climo/emissions-cmip6_HCOOH_anthro_surface_2000climo_0.9x1.25_c20170608.nc</HCOOH_an_srf_file>
+<HCOOH_bb_srf_file    ver="cam6" scam="1">atm/cam/chem/emis/CMIP6_emissions_2000climo/emissions-cmip6_HCOOH_bb_surface_2000climo_0.9x1.25_c20170322.nc</HCOOH_bb_srf_file>
+<ISOP_bb_srf_file     ver="cam6" scam="1">atm/cam/chem/emis/CMIP6_emissions_2000climo/emissions-cmip6_ISOP_bb_surface_2000climo_0.9x1.25_c20170322.nc</ISOP_bb_srf_file>
+<IVOC_an_srf_file     ver="cam6" scam="1">atm/cam/chem/emis/CMIP6_emissions_2000climo/emissions-cmip6_IVOC_anthro_surface_2000climo_0.9x1.25_c20170608.nc</IVOC_an_srf_file>
+<IVOC_bb_srf_file     ver="cam6" scam="1">atm/cam/chem/emis/CMIP6_emissions_2000climo/emissions-cmip6_IVOC_bb_surface_2000climo_0.9x1.25_c20170322.nc</IVOC_bb_srf_file>
+<MEK_an_srf_file      ver="cam6" scam="1">atm/cam/chem/emis/CMIP6_emissions_2000climo/emissions-cmip6_MEK_anthro_surface_2000climo_0.9x1.25_c20170608.nc</MEK_an_srf_file>
+<MEK_bb_srf_file      ver="cam6" scam="1">atm/cam/chem/emis/CMIP6_emissions_2000climo/emissions-cmip6_MEK_bb_surface_2000climo_0.9x1.25_c20170322.nc</MEK_bb_srf_file>
+<MTERP_bb_srf_file    ver="cam6" scam="1">atm/cam/chem/emis/CMIP6_emissions_2000climo/emissions-cmip6_MTERP_bb_surface_2000climo_0.9x1.25_c20170322.nc</MTERP_bb_srf_file>
+<NH3_an_srf_file      ver="cam6" scam="1">atm/cam/chem/emis/CMIP6_emissions_2000climo/emissions-cmip6_NH3_anthro_surface_2000climo_0.9x1.25_c20170608.nc</NH3_an_srf_file>
+<NH3_bb_srf_file      ver="cam6" scam="1">atm/cam/chem/emis/CMIP6_emissions_2000climo/emissions-cmip6_NH3_bb_surface_2000climo_0.9x1.25_c20170322.nc</NH3_bb_srf_file>
+<NH3_ot_srf_file      ver="cam6" scam="1">atm/cam/chem/emis/CMIP6_emissions_2000climo/emissions-cmip6_NH3_other_surface_2000climo_0.9x1.25_c20170322.nc</NH3_ot_srf_file>
+<NO_an_srf_file       ver="cam6" scam="1">atm/cam/chem/emis/CMIP6_emissions_2000climo/emissions-cmip6_NO_anthro_surface_2000climo_0.9x1.25_c20170608.nc</NO_an_srf_file>
+<NO_bb_srf_file       ver="cam6" scam="1">atm/cam/chem/emis/CMIP6_emissions_2000climo/emissions-cmip6_NO_bb_surface_2000climo_0.9x1.25_c20170322.nc</NO_bb_srf_file>
+<NO_ot_srf_file       ver="cam6" scam="1">atm/cam/chem/emis/CMIP6_emissions_2000climo/emissions-cmip6_NO_other_surface_2000climo_0.9x1.25_c20170322.nc</NO_ot_srf_file>
+<SVOC_an_srf_file     ver="cam6" scam="1">atm/cam/chem/emis/CMIP6_emissions_2000climo/emissions-cmip6_SVOC_anthro_surface_2000climo_0.9x1.25_c20170608.nc</SVOC_an_srf_file>
+<SVOC_bb_srf_file     ver="cam6" scam="1">atm/cam/chem/emis/CMIP6_emissions_2000climo/emissions-cmip6_SVOC_bb_surface_2000climo_0.9x1.25_c20170322.nc</SVOC_bb_srf_file>
+<TOLUENE_an_srf_file  ver="cam6" scam="1">atm/cam/chem/emis/CMIP6_emissions_2000climo/emissions-cmip6_TOLUENE_anthro_surface_2000climo_0.9x1.25_c20170608.nc</TOLUENE_an_srf_file>
+<TOLUENE_bb_srf_file  ver="cam6" scam="1">atm/cam/chem/emis/CMIP6_emissions_2000climo/emissions-cmip6_TOLUENE_bb_surface_2000climo_0.9x1.25_c20170322.nc</TOLUENE_bb_srf_file>
+<XYLENES_an_srf_file  ver="cam6" scam="1">atm/cam/chem/emis/CMIP6_emissions_2000climo/emissions-cmip6_XYLENES_anthro_surface_2000climo_0.9x1.25_c20170608.nc</XYLENES_an_srf_file>
+<XYLENES_bb_srf_file  ver="cam6" scam="1">atm/cam/chem/emis/CMIP6_emissions_2000climo/emissions-cmip6_XYLENES_bb_surface_2000climo_0.9x1.25_c20170322.nc</XYLENES_bb_srf_file>
+<h2o_ch4ox_ext_file    ver="cam6" scam="1">atm/cam/chem/emis/elev/H2O_emission_CH4_oxidationx2_elev_2000climo_CCMI_RCP6_0_c160219.nc</h2o_ch4ox_ext_file>
+<so2_cv_ext_file       ver="cam6" scam="1">atm/cam/chem/emis/CMIP6_emissions_2000climo/emissions-cmip6_SO2_contvolcano_vertical_2000climo_0.9x1.25_c20170322.nc</so2_cv_ext_file>
+<so4_a1_cv_ext_file    ver="cam6" scam="1">atm/cam/chem/emis/CMIP6_emissions_2000climo/emissions-cmip6_so4_a1_contvolcano_vertical_2000climo_0.9x1.25_c20170724.nc</so4_a1_cv_ext_file>
+<num_a1_cv_ext_file    ver="cam6" scam="1">atm/cam/chem/emis/CMIP6_emissions_2000climo/emissions-cmip6_num_a1_so4_contvolcano_vertical_2000climo_0.9x1.25_c20170724.nc</num_a1_cv_ext_file>
+<so4_a2_cv_ext_file    ver="cam6" scam="1">atm/cam/chem/emis/CMIP6_emissions_2000climo/emissions-cmip6_so4_a2_contvolcano_vertical_2000climo_0.9x1.25_c20170724.nc</so4_a2_cv_ext_file>
+<num_a2_cv_ext_file    ver="cam6" scam="1">atm/cam/chem/emis/CMIP6_emissions_2000climo/emissions-cmip6_num_a2_so4_contvolcano_vertical_2000climo_0.9x1.25_c20170724.nc</num_a2_cv_ext_file>
+<so4_a1_an_ext_file    ver="cam6" scam="1">atm/cam/chem/emis/CMIP6_emissions_2000climo/emissions-cmip6_so4_a1_anthro-ene_vertical_2000climo_0.9x1.25_c20170616.nc</so4_a1_an_ext_file>
+<num_a1_an_ext_file    ver="cam6" scam="1">atm/cam/chem/emis/CMIP6_emissions_2000climo/emissions-cmip6_num_so4_a1_anthro-ene_vertical_2000climo_0.9x1.25_c20170616.nc</num_a1_an_ext_file>
+
+<bc_a4_ar_ext_file     ver="cam6" scam="1">atm/cam/chem/emis/CMIP6_emissions_2000climo/emissions-cmip6_bc_a4_aircraft_vertical_2000climo_0.9x1.25_c20170608.nc</bc_a4_ar_ext_file>
+<no2_ar_ext_file       ver="cam6" scam="1">atm/cam/chem/emis/CMIP6_emissions_2000climo/emissions-cmip6_NO2_aircraft_vertical_2000climo_0.9x1.25_c20170608.nc</no2_ar_ext_file>
+<num_a4_ar_ext_file    ver="cam6" scam="1">atm/cam/chem/emis/CMIP6_emissions_2000climo/emissions-cmip6_num_bc_a4_aircraft_vertical_2000climo_0.9x1.25_c20170608.nc</num_a4_ar_ext_file>
+<so2_ar_ext_file       ver="cam6" scam="1">atm/cam/chem/emis/CMIP6_emissions_2000climo/emissions-cmip6_SO2_aircraft_vertical_2000climo_0.9x1.25_c20170608.nc</so2_ar_ext_file>
+
+<!-- CAM CMIP emissions  - lightweight set of emissions files for creating IOP files for SCAM -->
+
+<dms_ot_srf_file     ver="cam6" camiop="1">atm/cam/chem/emis/CMIP6_emissions_2000climo/emissions-cmip6_DMS_other_surface_2000climo_0.9x1.25_c20170322.nc</dms_ot_srf_file>
+<dms_bb_srf_file     ver="cam6" camiop="1">atm/cam/chem/emis/CMIP6_emissions_2000climo/emissions-cmip6_DMS_bb_surface_2000climo_0.9x1.25_c20170322.nc</dms_bb_srf_file>
+<so2_ag_sh_file      ver="cam6" camiop="1">atm/cam/chem/emis/CMIP6_emissions_2000climo/emissions-cmip6_SO2_anthro-ag-ship-res_surface_2000climo_0.9x1.25_c20170616.nc</so2_ag_sh_file>
+<so2_an_srf_file     ver="cam6" camiop="1">atm/cam/chem/emis/CMIP6_emissions_2000climo/emissions-cmip6_SO2_anthro-ene_surface_2000climo_0.9x1.25_c20170616.nc</so2_an_srf_file>
+<so2_bb_srf_file     ver="cam6" camiop="1">atm/cam/chem/emis/CMIP6_emissions_2000climo/emissions-cmip6_SO2_bb_surface_2000climo_0.9x1.25_c20170322.nc</so2_bb_srf_file>
+<so4_a1_an_srf_file  ver="cam6" camiop="1">atm/cam/chem/emis/CMIP6_emissions_2000climo/emissions-cmip6_so4_a1_anthro-ag-ship_surface_2000climo_0.9x1.25_c20170616.nc</so4_a1_an_srf_file>
+<so4_a1_bb_srf_file  ver="cam6" camiop="1">atm/cam/chem/emis/CMIP6_emissions_2000climo/emissions-cmip6_so4_a1_bb_surface_2000climo_0.9x1.25_c20170322.nc</so4_a1_bb_srf_file>
+<so4_a2_an_srf_file  ver="cam6" camiop="1">atm/cam/chem/emis/CMIP6_emissions_2000climo/emissions-cmip6_so4_a2_anthro-res_surface_2000climo_0.9x1.25_c20170616.nc</so4_a2_an_srf_file>
+<num_a1_sh_srf_file  ver="cam6" camiop="1">atm/cam/chem/emis/CMIP6_emissions_2000climo/emissions-cmip6_num_so4_a1_anthro-ag-ship_surface_2000climo_0.9x1.25_c20170616.nc</num_a1_sh_srf_file>
+<num_a2_an_srf_file  ver="cam6" camiop="1">atm/cam/chem/emis/CMIP6_emissions_2000climo/emissions-cmip6_num_so4_a2_anthro-res_surface_2000climo_0.9x1.25_c20170616.nc</num_a2_an_srf_file>
+<bc_a4_an_srf_file   ver="cam6" camiop="1">atm/cam/chem/emis/CMIP6_emissions_2000climo/emissions-cmip6_bc_a4_anthro_surface_2000climo_0.9x1.25_c20170608.nc</bc_a4_an_srf_file>
+<num_a4_bc_srf_file  ver="cam6" camiop="1">atm/cam/chem/emis/CMIP6_emissions_2000climo/emissions-cmip6_num_bc_a4_anthro_surface_2000climo_0.9x1.25_c20170608.nc</num_a4_bc_srf_file>
+<pom_a4_an_srf_file  ver="cam6" camiop="1">atm/cam/chem/emis/CMIP6_emissions_2000climo/emissions-cmip6_pom_a4_anthro_surface_2000climo_0.9x1.25_c20170608.nc</pom_a4_an_srf_file>
+<num_a4_oc_srf_file  ver="cam6" camiop="1">atm/cam/chem/emis/CMIP6_emissions_2000climo/emissions-cmip6_num_pom_a4_anthro_surface_2000climo_0.9x1.25_c20170608.nc</num_a4_oc_srf_file>
+<num_a1_bb_srf_file  ver="cam6" camiop="1">atm/cam/chem/emis/CMIP6_emissions_2000climo/emissions-cmip6_num_so4_a1_bb_surface_2000climo_0.9x1.25_c20170322.nc</num_a1_bb_srf_file>
+<bc_a4_bb_srf_file   ver="cam6" camiop="1">atm/cam/chem/emis/CMIP6_emissions_2000climo/emissions-cmip6_bc_a4_bb_surface_2000climo_0.9x1.25_c20170322.nc</bc_a4_bb_srf_file>
+<num_a4_bb_srf_file  ver="cam6" camiop="1">atm/cam/chem/emis/CMIP6_emissions_2000climo/emissions-cmip6_num_bc_a4_bb_surface_2000climo_0.9x1.25_c20170322.nc</num_a4_bb_srf_file>
+<pom_a4_bb_srf_file  ver="cam6" camiop="1">atm/cam/chem/emis/CMIP6_emissions_2000climo/emissions-cmip6_pom_a4_bb_surface_2000climo_0.9x1.25_c20170322.nc</pom_a4_bb_srf_file>
+<num_pom_bb_srf_file ver="cam6" camiop="1">atm/cam/chem/emis/CMIP6_emissions_2000climo/emissions-cmip6_num_pom_a4_bb_surface_2000climo_0.9x1.25_c20170509.nc</num_pom_bb_srf_file>
+<soag_an_srf_file    ver="cam6" camiop="1">atm/cam/chem/emis/CMIP6_emissions_2000climo/emissions-cmip6_SOAGx1.5_anthro_surface_2000climo_0.9x1.25_c20170608.nc</soag_an_srf_file>
+<soag_bg_srf_file    ver="cam6" camiop="1">atm/cam/chem/emis/CMIP6_emissions_2000climo/emissions-cmip6_SOAGx1.5_biogenic_surface_2000climo_0.9x1.25_c20170322.nc</soag_bg_srf_file>
+<soag_bb_srf_file    ver="cam6" camiop="1">atm/cam/chem/emis/CMIP6_emissions_2000climo/emissions-cmip6_SOAGx1.5_bb_surface_2000climo_0.9x1.25_c20170322.nc</soag_bb_srf_file>
+
+<BENZENE_an_srf_file  ver="cam6" camiop="1">atm/cam/chem/emis/CMIP6_emissions_2000climo/emissions-cmip6_BENZENE_anthro_surface_2000climo_0.9x1.25_c20170608.nc</BENZENE_an_srf_file>
+<BENZENE_bb_srf_file  ver="cam6" camiop="1">atm/cam/chem/emis/CMIP6_emissions_2000climo/emissions-cmip6_BENZENE_bb_surface_2000climo_0.9x1.25_c20170322.nc</BENZENE_bb_srf_file>
+<BIGALK_an_srf_file   ver="cam6" camiop="1">atm/cam/chem/emis/CMIP6_emissions_2000climo/emissions-cmip6_BIGALK_anthro_surface_2000climo_0.9x1.25_c20170608.nc</BIGALK_an_srf_file>
+<BIGALK_bb_srf_file   ver="cam6" camiop="1">atm/cam/chem/emis/CMIP6_emissions_2000climo/emissions-cmip6_BIGALK_bb_surface_2000climo_0.9x1.25_c20170322.nc</BIGALK_bb_srf_file>
+<BIGENE_an_srf_file   ver="cam6" camiop="1">atm/cam/chem/emis/CMIP6_emissions_2000climo/emissions-cmip6_BIGENE_anthro_surface_2000climo_0.9x1.25_c20170608.nc</BIGENE_an_srf_file>
+<BIGENE_bb_srf_file   ver="cam6" camiop="1">atm/cam/chem/emis/CMIP6_emissions_2000climo/emissions-cmip6_BIGENE_bb_surface_2000climo_0.9x1.25_c20170322.nc</BIGENE_bb_srf_file>
+<C2H2_an_srf_file     ver="cam6" camiop="1">atm/cam/chem/emis/CMIP6_emissions_2000climo/emissions-cmip6_C2H2_anthro_surface_2000climo_0.9x1.25_c20170608.nc</C2H2_an_srf_file>
+<C2H2_bb_srf_file     ver="cam6" camiop="1">atm/cam/chem/emis/CMIP6_emissions_2000climo/emissions-cmip6_C2H2_bb_surface_2000climo_0.9x1.25_c20170322.nc</C2H2_bb_srf_file>
+<C2H4_an_srf_file     ver="cam6" camiop="1">atm/cam/chem/emis/CMIP6_emissions_2000climo/emissions-cmip6_C2H4_anthro_surface_2000climo_0.9x1.25_c20170608.nc</C2H4_an_srf_file>
+<C2H4_bb_srf_file     ver="cam6" camiop="1">atm/cam/chem/emis/CMIP6_emissions_2000climo/emissions-cmip6_C2H4_bb_surface_2000climo_0.9x1.25_c20170322.nc</C2H4_bb_srf_file>
+<C2H4_ot_srf_file     ver="cam6" camiop="1">atm/cam/chem/emis/CMIP6_emissions_2000climo/emissions-cmip6_C2H4_other_surface_2000climo_0.9x1.25_c20170322.nc</C2H4_ot_srf_file>
+<C2H5OH_an_srf_file   ver="cam6" camiop="1">atm/cam/chem/emis/CMIP6_emissions_2000climo/emissions-cmip6_C2H5OH_anthro_surface_2000climo_0.9x1.25_c20170608.nc</C2H5OH_an_srf_file>
+<C2H5OH_bb_srf_file   ver="cam6" camiop="1">atm/cam/chem/emis/CMIP6_emissions_2000climo/emissions-cmip6_C2H5OH_bb_surface_2000climo_0.9x1.25_c20170322.nc</C2H5OH_bb_srf_file>
+<C2H6_an_srf_file     ver="cam6" camiop="1">atm/cam/chem/emis/CMIP6_emissions_2000climo/emissions-cmip6_C2H6_anthro_surface_2000climo_0.9x1.25_c20170608.nc</C2H6_an_srf_file>
+<C2H6_bb_srf_file     ver="cam6" camiop="1">atm/cam/chem/emis/CMIP6_emissions_2000climo/emissions-cmip6_C2H6_bb_surface_2000climo_0.9x1.25_c20170322.nc</C2H6_bb_srf_file>
+<C2H6_ot_srf_file     ver="cam6" camiop="1">atm/cam/chem/emis/CMIP6_emissions_2000climo/emissions-cmip6_C2H6_other_surface_2000climo_0.9x1.25_c20170322.nc</C2H6_ot_srf_file>
+<C3H6_an_srf_file     ver="cam6" camiop="1">atm/cam/chem/emis/CMIP6_emissions_2000climo/emissions-cmip6_C3H6_anthro_surface_2000climo_0.9x1.25_c20170608.nc</C3H6_an_srf_file>
+<C3H6_bb_srf_file     ver="cam6" camiop="1">atm/cam/chem/emis/CMIP6_emissions_2000climo/emissions-cmip6_C3H6_bb_surface_2000climo_0.9x1.25_c20170322.nc</C3H6_bb_srf_file>
+<C3H6_ot_srf_file     ver="cam6" camiop="1">atm/cam/chem/emis/CMIP6_emissions_2000climo/emissions-cmip6_C3H6_other_surface_2000climo_0.9x1.25_c20170322.nc</C3H6_ot_srf_file>
+<C3H8_an_srf_file     ver="cam6" camiop="1">atm/cam/chem/emis/CMIP6_emissions_2000climo/emissions-cmip6_C3H8_anthro_surface_2000climo_0.9x1.25_c20170608.nc</C3H8_an_srf_file>
+<C3H8_bb_srf_file     ver="cam6" camiop="1">atm/cam/chem/emis/CMIP6_emissions_2000climo/emissions-cmip6_C3H8_bb_surface_2000climo_0.9x1.25_c20170322.nc</C3H8_bb_srf_file>
+<C3H8_ot_srf_file     ver="cam6" camiop="1">atm/cam/chem/emis/CMIP6_emissions_2000climo/emissions-cmip6_C3H8_other_surface_2000climo_0.9x1.25_c20170322.nc</C3H8_ot_srf_file>
+<CH2O_an_srf_file     ver="cam6" camiop="1">atm/cam/chem/emis/CMIP6_emissions_2000climo/emissions-cmip6_CH2O_anthro_surface_2000climo_0.9x1.25_c20170608.nc</CH2O_an_srf_file>
+<CH2O_bb_srf_file     ver="cam6" camiop="1">atm/cam/chem/emis/CMIP6_emissions_2000climo/emissions-cmip6_CH2O_bb_surface_2000climo_0.9x1.25_c20170322.nc</CH2O_bb_srf_file>
+<CH3CHO_an_srf_file   ver="cam6" camiop="1">atm/cam/chem/emis/CMIP6_emissions_2000climo/emissions-cmip6_CH3CHO_anthro_surface_2000climo_0.9x1.25_c20170608.nc</CH3CHO_an_srf_file>
+<CH3CHO_bb_srf_file   ver="cam6" camiop="1">atm/cam/chem/emis/CMIP6_emissions_2000climo/emissions-cmip6_CH3CHO_bb_surface_2000climo_0.9x1.25_c20170322.nc</CH3CHO_bb_srf_file>
+<CH3CN_an_srf_file    ver="cam6" camiop="1">atm/cam/chem/emis/CMIP6_emissions_2000climo/emissions-cmip6_CH3CN_anthro_surface_2000climo_0.9x1.25_c20170608.nc</CH3CN_an_srf_file>
+<CH3CN_bb_srf_file    ver="cam6" camiop="1">atm/cam/chem/emis/CMIP6_emissions_2000climo/emissions-cmip6_CH3CN_bb_surface_2000climo_0.9x1.25_c20170322.nc</CH3CN_bb_srf_file>
+<CH3COCH3_an_srf_file ver="cam6" camiop="1">atm/cam/chem/emis/CMIP6_emissions_2000climo/emissions-cmip6_CH3COCH3_anthro_surface_2000climo_0.9x1.25_c20170608.nc</CH3COCH3_an_srf_file>
+<CH3COCH3_bb_srf_file ver="cam6" camiop="1">atm/cam/chem/emis/CMIP6_emissions_2000climo/emissions-cmip6_CH3COCH3_bb_surface_2000climo_0.9x1.25_c20170322.nc</CH3COCH3_bb_srf_file>
+<CH3COCHO_bb_srf_file ver="cam6" camiop="1">atm/cam/chem/emis/CMIP6_emissions_2000climo/emissions-cmip6_CH3COCHO_bb_surface_2000climo_0.9x1.25_c20170322.nc</CH3COCHO_bb_srf_file>
+<CH3COOH_an_srf_file  ver="cam6" camiop="1">atm/cam/chem/emis/CMIP6_emissions_2000climo/emissions-cmip6_CH3COOH_anthro_surface_2000climo_0.9x1.25_c20170608.nc</CH3COOH_an_srf_file>
+<CH3COOH_bb_srf_file  ver="cam6" camiop="1">atm/cam/chem/emis/CMIP6_emissions_2000climo/emissions-cmip6_CH3COOH_bb_surface_2000climo_0.9x1.25_c20170322.nc</CH3COOH_bb_srf_file>
+<CH3OH_an_srf_file    ver="cam6" camiop="1">atm/cam/chem/emis/CMIP6_emissions_2000climo/emissions-cmip6_CH3OH_anthro_surface_2000climo_0.9x1.25_c20170608.nc</CH3OH_an_srf_file>
+<CH3OH_bb_srf_file    ver="cam6" camiop="1">atm/cam/chem/emis/CMIP6_emissions_2000climo/emissions-cmip6_CH3OH_bb_surface_2000climo_0.9x1.25_c20170322.nc</CH3OH_bb_srf_file>
+<CO_an_srf_file       ver="cam6" camiop="1">atm/cam/chem/emis/CMIP6_emissions_2000climo/emissions-cmip6_CO_anthro_surface_2000climo_0.9x1.25_c20180504.nc</CO_an_srf_file>
+<CO_bb_srf_file       ver="cam6" camiop="1">atm/cam/chem/emis/CMIP6_emissions_2000climo/emissions-cmip6_CO_bb_surface_2000climo_0.9x1.25_c20170322.nc</CO_bb_srf_file>
+<CO_ot_srf_file       ver="cam6" camiop="1">atm/cam/chem/emis/CMIP6_emissions_2000climo/emissions-cmip6_CO_other_surface_2000climo_0.9x1.25_c20170322.nc</CO_ot_srf_file>
+<GLYALD_bb_srf_file   ver="cam6" camiop="1">atm/cam/chem/emis/CMIP6_emissions_2000climo/emissions-cmip6_GLYALD_bb_surface_2000climo_0.9x1.25_c20170322.nc</GLYALD_bb_srf_file>
+<HCN_an_srf_file      ver="cam6" camiop="1">atm/cam/chem/emis/CMIP6_emissions_2000climo/emissions-cmip6_HCN_anthro_surface_2000climo_0.9x1.25_c20170608.nc</HCN_an_srf_file>
+<HCN_bb_srf_file      ver="cam6" camiop="1">atm/cam/chem/emis/CMIP6_emissions_2000climo/emissions-cmip6_HCN_bb_surface_2000climo_0.9x1.25_c20170322.nc</HCN_bb_srf_file>
+<HCOOH_an_srf_file    ver="cam6" camiop="1">atm/cam/chem/emis/CMIP6_emissions_2000climo/emissions-cmip6_HCOOH_anthro_surface_2000climo_0.9x1.25_c20170608.nc</HCOOH_an_srf_file>
+<HCOOH_bb_srf_file    ver="cam6" camiop="1">atm/cam/chem/emis/CMIP6_emissions_2000climo/emissions-cmip6_HCOOH_bb_surface_2000climo_0.9x1.25_c20170322.nc</HCOOH_bb_srf_file>
+<ISOP_bb_srf_file     ver="cam6" camiop="1">atm/cam/chem/emis/CMIP6_emissions_2000climo/emissions-cmip6_ISOP_bb_surface_2000climo_0.9x1.25_c20170322.nc</ISOP_bb_srf_file>
+<IVOC_an_srf_file     ver="cam6" camiop="1">atm/cam/chem/emis/CMIP6_emissions_2000climo/emissions-cmip6_IVOC_anthro_surface_2000climo_0.9x1.25_c20170608.nc</IVOC_an_srf_file>
+<IVOC_bb_srf_file     ver="cam6" camiop="1">atm/cam/chem/emis/CMIP6_emissions_2000climo/emissions-cmip6_IVOC_bb_surface_2000climo_0.9x1.25_c20170322.nc</IVOC_bb_srf_file>
+<MEK_an_srf_file      ver="cam6" camiop="1">atm/cam/chem/emis/CMIP6_emissions_2000climo/emissions-cmip6_MEK_anthro_surface_2000climo_0.9x1.25_c20170608.nc</MEK_an_srf_file>
+<MEK_bb_srf_file      ver="cam6" camiop="1">atm/cam/chem/emis/CMIP6_emissions_2000climo/emissions-cmip6_MEK_bb_surface_2000climo_0.9x1.25_c20170322.nc</MEK_bb_srf_file>
+<MTERP_bb_srf_file    ver="cam6" camiop="1">atm/cam/chem/emis/CMIP6_emissions_2000climo/emissions-cmip6_MTERP_bb_surface_2000climo_0.9x1.25_c20170322.nc</MTERP_bb_srf_file>
+<NH3_an_srf_file      ver="cam6" camiop="1">atm/cam/chem/emis/CMIP6_emissions_2000climo/emissions-cmip6_NH3_anthro_surface_2000climo_0.9x1.25_c20170608.nc</NH3_an_srf_file>
+<NH3_bb_srf_file      ver="cam6" camiop="1">atm/cam/chem/emis/CMIP6_emissions_2000climo/emissions-cmip6_NH3_bb_surface_2000climo_0.9x1.25_c20170322.nc</NH3_bb_srf_file>
+<NH3_ot_srf_file      ver="cam6" camiop="1">atm/cam/chem/emis/CMIP6_emissions_2000climo/emissions-cmip6_NH3_other_surface_2000climo_0.9x1.25_c20170322.nc</NH3_ot_srf_file>
+<NO_an_srf_file       ver="cam6" camiop="1">atm/cam/chem/emis/CMIP6_emissions_2000climo/emissions-cmip6_NO_anthro_surface_2000climo_0.9x1.25_c20170608.nc</NO_an_srf_file>
+<NO_bb_srf_file       ver="cam6" camiop="1">atm/cam/chem/emis/CMIP6_emissions_2000climo/emissions-cmip6_NO_bb_surface_2000climo_0.9x1.25_c20170322.nc</NO_bb_srf_file>
+<NO_ot_srf_file       ver="cam6" camiop="1">atm/cam/chem/emis/CMIP6_emissions_2000climo/emissions-cmip6_NO_other_surface_2000climo_0.9x1.25_c20170322.nc</NO_ot_srf_file>
+<SVOC_an_srf_file     ver="cam6" camiop="1">atm/cam/chem/emis/CMIP6_emissions_2000climo/emissions-cmip6_SVOC_anthro_surface_2000climo_0.9x1.25_c20170608.nc</SVOC_an_srf_file>
+<SVOC_bb_srf_file     ver="cam6" camiop="1">atm/cam/chem/emis/CMIP6_emissions_2000climo/emissions-cmip6_SVOC_bb_surface_2000climo_0.9x1.25_c20170322.nc</SVOC_bb_srf_file>
+<TOLUENE_an_srf_file  ver="cam6" camiop="1">atm/cam/chem/emis/CMIP6_emissions_2000climo/emissions-cmip6_TOLUENE_anthro_surface_2000climo_0.9x1.25_c20170608.nc</TOLUENE_an_srf_file>
+<TOLUENE_bb_srf_file  ver="cam6" camiop="1">atm/cam/chem/emis/CMIP6_emissions_2000climo/emissions-cmip6_TOLUENE_bb_surface_2000climo_0.9x1.25_c20170322.nc</TOLUENE_bb_srf_file>
+<XYLENES_an_srf_file  ver="cam6" camiop="1">atm/cam/chem/emis/CMIP6_emissions_2000climo/emissions-cmip6_XYLENES_anthro_surface_2000climo_0.9x1.25_c20170608.nc</XYLENES_an_srf_file>
+<XYLENES_bb_srf_file  ver="cam6" camiop="1">atm/cam/chem/emis/CMIP6_emissions_2000climo/emissions-cmip6_XYLENES_bb_surface_2000climo_0.9x1.25_c20170322.nc</XYLENES_bb_srf_file>
+<h2o_ch4ox_ext_file    ver="cam6" camiop="1">atm/cam/chem/emis/elev/H2O_emission_CH4_oxidationx2_elev_2000climo_CCMI_RCP6_0_c160219.nc</h2o_ch4ox_ext_file>
+<so2_cv_ext_file       ver="cam6" camiop="1">atm/cam/chem/emis/CMIP6_emissions_2000climo/emissions-cmip6_SO2_contvolcano_vertical_2000climo_0.9x1.25_c20170322.nc</so2_cv_ext_file>
+<so4_a1_cv_ext_file    ver="cam6" camiop="1">atm/cam/chem/emis/CMIP6_emissions_2000climo/emissions-cmip6_so4_a1_contvolcano_vertical_2000climo_0.9x1.25_c20170724.nc</so4_a1_cv_ext_file>
+<num_a1_cv_ext_file    ver="cam6" camiop="1">atm/cam/chem/emis/CMIP6_emissions_2000climo/emissions-cmip6_num_a1_so4_contvolcano_vertical_2000climo_0.9x1.25_c20170724.nc</num_a1_cv_ext_file>
+<so4_a2_cv_ext_file    ver="cam6" camiop="1">atm/cam/chem/emis/CMIP6_emissions_2000climo/emissions-cmip6_so4_a2_contvolcano_vertical_2000climo_0.9x1.25_c20170724.nc</so4_a2_cv_ext_file>
+<num_a2_cv_ext_file    ver="cam6" camiop="1">atm/cam/chem/emis/CMIP6_emissions_2000climo/emissions-cmip6_num_a2_so4_contvolcano_vertical_2000climo_0.9x1.25_c20170724.nc</num_a2_cv_ext_file>
+<so4_a1_an_ext_file    ver="cam6" camiop="1">atm/cam/chem/emis/CMIP6_emissions_2000climo/emissions-cmip6_so4_a1_anthro-ene_vertical_2000climo_0.9x1.25_c20170616.nc</so4_a1_an_ext_file>
+<num_a1_an_ext_file    ver="cam6" camiop="1">atm/cam/chem/emis/CMIP6_emissions_2000climo/emissions-cmip6_num_so4_a1_anthro-ene_vertical_2000climo_0.9x1.25_c20170616.nc</num_a1_an_ext_file>
+
+<bc_a4_ar_ext_file     ver="cam6" camiop="1">atm/cam/chem/emis/CMIP6_emissions_2000climo/emissions-cmip6_bc_a4_aircraft_vertical_2000climo_0.9x1.25_c20170608.nc</bc_a4_ar_ext_file>
+<no2_ar_ext_file       ver="cam6" camiop="1">atm/cam/chem/emis/CMIP6_emissions_2000climo/emissions-cmip6_NO2_aircraft_vertical_2000climo_0.9x1.25_c20170608.nc</no2_ar_ext_file>
+<num_a4_ar_ext_file    ver="cam6" camiop="1">atm/cam/chem/emis/CMIP6_emissions_2000climo/emissions-cmip6_num_bc_a4_aircraft_vertical_2000climo_0.9x1.25_c20170608.nc</num_a4_ar_ext_file>
+<so2_ar_ext_file       ver="cam6" camiop="1">atm/cam/chem/emis/CMIP6_emissions_2000climo/emissions-cmip6_SO2_aircraft_vertical_2000climo_0.9x1.25_c20170608.nc</so2_ar_ext_file>
+
+
+
+
+<!-- without forest fires and grass fires sources -->
+<so2_ext_wofire_file        >atm/cam/chem/trop_mozart_aero/emis/ar5_mam3_so2_elev_2000_wofire_c150317.nc</so2_ext_wofire_file>
+<so4_a1_ext_wofire_file     >atm/cam/chem/trop_mozart_aero/emis/ar5_mam3_so4_a1_elev_2000_wofire_c150317.nc</so4_a1_ext_wofire_file>
+<num_a1_ext_wofire_file     >atm/cam/chem/trop_mozart_aero/emis/ar5_mam3_num_a1_elev_2000_wofire_c150317.nc</num_a1_ext_wofire_file>
+<mam4_num_a1_ext_wofire_file>atm/cam/chem/trop_mozart_aero/emis/ar5_mam4_num_a1_elev_2000_wofire_c150722.nc</mam4_num_a1_ext_wofire_file>
+
+<so2_ocs_ox_file>atm/cam/chem/emis/elev/SO2_emission_OCS_oxidation_elev_1849-2101_WACCM5_c150302.nc</so2_ocs_ox_file>
+<h2o_ch4_ox_file>atm/cam/chem/emis/elev/H2O_emission_CH4_oxidationx2_elev_1850-2100_CCMI_RCP6_0_c160219.nc</h2o_ch4_ox_file>
+
+<mam4_num_a1_emis_file >atm/cam/chem/trop_mozart_aero/emis/ar5_mam4_num_a1_surf_2000_c120716.nc</mam4_num_a1_emis_file>
+<mam4_num_a4_emis_file >atm/cam/chem/trop_mozart_aero/emis/ar5_mam4_num_a4_surf_2000_c120716.nc</mam4_num_a4_emis_file>
+<mam4_num_a1_ext_file  >atm/cam/chem/trop_mozart_aero/emis/ar5_mam4_num_a1_elev_2000_c120716.nc</mam4_num_a1_ext_file>
+<mam4_num_a4_ext_file  >atm/cam/chem/trop_mozart_aero/emis/ar5_mam4_num_a4_elev_2000_c120716.nc</mam4_num_a4_ext_file>
+
+<mam7_num_a1_emis_file >atm/cam/chem/trop_mozart_aero/emis/ar5_mam7_num_a1_surf_2000_c120716.nc</mam7_num_a1_emis_file>
+<mam7_num_a3_emis_file >atm/cam/chem/trop_mozart_aero/emis/ar5_mam7_num_a3_surf_2000_c120716.nc</mam7_num_a3_emis_file>
+<mam7_num_a1_ext_file  >atm/cam/chem/trop_mozart_aero/emis/ar5_mam7_num_a1_elev_2000_c120716.nc</mam7_num_a1_ext_file>
+<mam7_num_a3_ext_file  >atm/cam/chem/trop_mozart_aero/emis/ar5_mam7_num_a3_elev_2000_c120716.nc</mam7_num_a3_ext_file>
+
+<ivocbb_emis_file>atm/cam/chem/emis/rcp85_finn_2002-2013/rcp85_finn_2000.IVOCbb.surface.1.9x2.5_c20150914.nc</ivocbb_emis_file>
+<ivocff_emis_file>atm/cam/chem/emis/rcp85_finn_2002-2013/rcp85_finn_2000.IVOCff.surface.1.9x2.5_c20150914.nc</ivocff_emis_file>
+<ivocbb_ext_file>atm/cam/chem/emis/rcp85_finn_2002-2013/rcp85_finn_2000.IVOCbb.elev.1.9x2.5_mol_c20150914.nc</ivocbb_ext_file>
+<svocbb_ext_file>atm/cam/chem/emis/rcp85_finn_2002-2014/rcp85_finn_2000.SVOCbb.elev.1.9x2.5_c160601.nc</svocbb_ext_file>
+
+<!-- prescribed oxidants for prognostic aerosol chemistry -->
+<tracer_cnst_file     ver="fixed_ox">oxid_1.9x2.5_L26_1850-2005_c091123.nc</tracer_cnst_file>
+
+<!-- prescribed oxidants for prognostic aerosol chemistry -lightweight set for running SCAM and producing SCAM IOP boundary data -->
+<tracer_cnst_file     phys="cam6"     ver="fixed_ox" scam="1">oxid_1.9x2.5_L26_1850clim_c091123.nc</tracer_cnst_file>
+<tracer_cnst_cycle_yr phys="cam6"     ver="fixed_ox" scam="1">1850</tracer_cnst_cycle_yr>
+<tracer_cnst_file     phys="cam6"     ver="fixed_ox" camiop="1">oxid_1.9x2.5_L26_1850clim_c091123.nc</tracer_cnst_file>
+<tracer_cnst_cycle_yr phys="cam6"     ver="fixed_ox" camiop="1">1850</tracer_cnst_cycle_yr>
+<tracer_cnst_file     phys="cam7"     ver="fixed_ox" scam="1">oxid_1.9x2.5_L26_1850clim_c091123.nc</tracer_cnst_file>
+<tracer_cnst_cycle_yr phys="cam7"     ver="fixed_ox" scam="1">1850</tracer_cnst_cycle_yr>
+<tracer_cnst_file     phys="cam7"     ver="fixed_ox" camiop="1">oxid_1.9x2.5_L26_1850clim_c091123.nc</tracer_cnst_file>
+<tracer_cnst_cycle_yr phys="cam7"     ver="fixed_ox" camiop="1">1850</tracer_cnst_cycle_yr>
+
+<tracer_cnst_datapath ver="fixed_ox">atm/cam/chem/trop_mozart_aero/oxid</tracer_cnst_datapath>
+<tracer_cnst_type     ver="fixed_ox">CYCLICAL</tracer_cnst_type>
+<tracer_cnst_cycle_yr ver="fixed_ox">2000</tracer_cnst_cycle_yr>
+<tracer_cnst_filelist ver="fixed_ox">oxid_1.9x2.5_L26_clim_list.c090805.txt</tracer_cnst_filelist>
+
+<!-- prescribed oxidants for prognostic aerosol chemistry plus halons for radiative forcings -->
+<tracer_cnst_file     ver="fixed_ox_halons">halons_oxid_1.9x2.5zm_L66_1849-2099_c160714.nc</tracer_cnst_file>
+<tracer_cnst_datapath ver="fixed_ox_halons">atm/waccm/halons</tracer_cnst_datapath>
+<tracer_cnst_type     ver="fixed_ox_halons">CYCLICAL</tracer_cnst_type>
+<tracer_cnst_cycle_yr ver="fixed_ox_halons">2000</tracer_cnst_cycle_yr>
+
+<!-- prescribed methane  -->
+<tracer_cnst_file     ver="fixed_ch4">CH4_1990-1999_clim_c090605.nc</tracer_cnst_file>
+<tracer_cnst_filelist ver="fixed_ch4">filelist_c090605.txt</tracer_cnst_filelist>
+<tracer_cnst_datapath ver="fixed_ch4">atm/cam/chem/methane</tracer_cnst_datapath>
+<tracer_cnst_type     ver="fixed_ch4">CYCLICAL</tracer_cnst_type>
+<tracer_cnst_cycle_yr ver="fixed_ch4">1995</tracer_cnst_cycle_yr>
+
+<tracer_cnst_file     chem="waccm_sc_mam4">halons_oxid_1.9x2.5zm_L66_1849-2099_c160714.nc</tracer_cnst_file>
+<tracer_cnst_datapath chem="waccm_sc_mam4">atm/waccm/halons</tracer_cnst_datapath>
+<tracer_cnst_file     chem="ghg_mam4">halons_oxid_1.9x2.5zm_L66_1849-2099_c160714.nc</tracer_cnst_file>
+<tracer_cnst_datapath chem="ghg_mam4">atm/waccm/halons</tracer_cnst_datapath>
+<tracer_cnst_type     >CYCLICAL</tracer_cnst_type>
+<tracer_cnst_cycle_yr >2000</tracer_cnst_cycle_yr>
+
+<prescribed_ghg_file      ver="fixed_ch4">CH4_1990-1999_clim_c090605.nc</prescribed_ghg_file>
+<prescribed_ghg_filelist  ver="fixed_ch4">filelist_c090605.txt</prescribed_ghg_filelist>
+<prescribed_ghg_datapath  ver="fixed_ch4">atm/cam/chem/methane</prescribed_ghg_datapath>
+<prescribed_ghg_type      ver="fixed_ch4">CYCLICAL</prescribed_ghg_type>
+<prescribed_ghg_cycle_yr  ver="fixed_ch4">1995</prescribed_ghg_cycle_yr>
+
+<!-- SAD data -->
+<prescribed_strataero_file                                >CESM_1949_2100_sad_V2_c130627.nc</prescribed_strataero_file>
+<prescribed_strataero_datapath                            >atm/waccm/sulf</prescribed_strataero_datapath>
+<prescribed_strataero_file                  phys="cam6"   >CESM_1849_2100_sad_V3_c160211.nc</prescribed_strataero_file>
+<prescribed_strataero_datapath              phys="cam6"   >atm/cam/volc</prescribed_strataero_datapath>
+<prescribed_strataero_file     ver="3modes" phys="cam6"   >ozone_strataero_CAM6chem_1849-2014_zm_5day_c170924.nc</prescribed_strataero_file>
+<prescribed_strataero_datapath ver="3modes" phys="cam6"   >atm/cam/ozone</prescribed_strataero_datapath>
+<prescribed_strataero_file     ver="3modes" phys="cam6"    chem="waccm_sc_mam4">ozone_strataero_WACCM6_L70_zm5day_19750101-20141229_c180216.nc</prescribed_strataero_file>
+<prescribed_strataero_datapath ver="3modes" phys="cam6"    chem="waccm_sc_mam4">atm/cam/ozone_strataero</prescribed_strataero_datapath>
+<prescribed_strataero_file                  phys="cam7"   >CESM_1849_2100_sad_V3_c160211.nc</prescribed_strataero_file>
+<prescribed_strataero_datapath              phys="cam7"   >atm/cam/volc</prescribed_strataero_datapath>
+<prescribed_strataero_file     ver="3modes" phys="cam7"   >ozone_strataero_CAM6chem_1849-2014_zm_5day_c170924.nc</prescribed_strataero_file>
+<prescribed_strataero_datapath ver="3modes" phys="cam7"   >atm/cam/ozone</prescribed_strataero_datapath>
+<prescribed_strataero_file     ver="3modes" phys="cam7"    chem="waccm_sc_mam4">ozone_strataero_WACCM6_L70_zm5day_19750101-20141229_c180216.nc</prescribed_strataero_file>
+<prescribed_strataero_datapath ver="3modes" phys="cam7"    chem="waccm_sc_mam4">atm/cam/ozone_strataero</prescribed_strataero_datapath>
+
+<!-- sulfate data -->
+<sulf_file>atm/waccm/sulf/sulfate.ar5_camchem_c130304.nc</sulf_file>
+
+<!-- rain out method -->
+<gas_wetdep_method>NEU</gas_wetdep_method>
+
+<!-- Dry Dep surface data file needed by prognostic MAM on unstructured grid only. -->
+
+<drydep_srf_file hgrid="ne3np4"          >atm/cam/chem/trop_mam/atmsrf_ne3np4_230718.nc</drydep_srf_file>
+<drydep_srf_file hgrid="ne3np4"  npg="3" >atm/cam/chem/trop_mam/atmsrf_ne3np4.pg3_221214.nc</drydep_srf_file>
+<drydep_srf_file hgrid="ne5np4"          >atm/cam/chem/trop_mam/atmsrf_ne5np4_110920.nc</drydep_srf_file>
+<drydep_srf_file hgrid="ne5np4"   npg="3">atm/cam/chem/trop_mam/atmsrf_ne5pg3_201105.nc</drydep_srf_file>
+<drydep_srf_file hgrid="ne16np4"         >atm/cam/chem/trop_mam/atmsrf_ne16np4_110920.nc</drydep_srf_file>
+<drydep_srf_file hgrid="ne16np4"  npg="3">atm/cam/chem/trop_mam/atmsrf_ne16pg3_c230520.nc</drydep_srf_file>
+<drydep_srf_file hgrid="ne30np4"         >atm/cam/chem/trop_mam/atmsrf_ne30np4_110920.nc</drydep_srf_file>
+<drydep_srf_file hgrid="ne30np4"  npg="2">atm/cam/chem/trop_mam/atmsrf_ne30np4.pg2_200108.nc</drydep_srf_file>
+<drydep_srf_file hgrid="ne30np4"  npg="3">atm/cam/chem/trop_mam/atmsrf_ne30pg3_180522.nc</drydep_srf_file>
+<drydep_srf_file hgrid="ne60np4"         >atm/cam/chem/trop_mam/atmsrf_ne60np4_110920.nc</drydep_srf_file>
+<drydep_srf_file hgrid="ne120np4"        >atm/cam/chem/trop_mam/atmsrf_ne120np4_110920.nc</drydep_srf_file>
+<drydep_srf_file hgrid="ne120np4" npg="2">atm/cam/chem/trop_mam/atmsrf_ne120np4.pg2_200109.nc</drydep_srf_file>
+<drydep_srf_file hgrid="ne120np4" npg="3">atm/cam/chem/trop_mam/atmsrf_ne120np4.pg3_c210324.nc</drydep_srf_file>
+<drydep_srf_file hgrid="ne240np4"        >atm/cam/chem/trop_mam/atmsrf_ne240np4_110920.nc</drydep_srf_file>
+
+<drydep_srf_file hgrid="ne0np4CONUS.ne30x8"      >atm/cam/chem/trop_mam/atmsrf_ne0np4conus30x8_161116.nc</drydep_srf_file>
+<drydep_srf_file hgrid="ne0np4.ARCTIC.ne30x4"    >atm/cam/chem/trop_mam/atmsrf_ne30x4_ARCTIC_191011.nc</drydep_srf_file>
+<drydep_srf_file hgrid="ne0np4.ARCTICGRIS.ne30x8">atm/cam/chem/trop_mam/atmsrf_ne30x8_ARCTICGRIS_191212.nc</drydep_srf_file>
+<drydep_srf_file hgrid="ne0np4.POLARCAP.ne30x4"  >atm/cam/chem/trop_mam/atmsrf_POLARCAP_250322.nc</drydep_srf_file>
+<drydep_srf_file hgrid="ne0np4.NATL.ne30x8"      >atm/cam/chem/trop_mam/atmsrf_ne0np4.NATL.ne30x8_201109.nc</drydep_srf_file>
+
+<drydep_srf_file hgrid="C24">atm/cam/chem/trop_mam/atmsrf_C24_c200625.nc</drydep_srf_file>
+<drydep_srf_file hgrid="C48">atm/cam/chem/trop_mam/atmsrf_C48_c200625.nc</drydep_srf_file>
+<drydep_srf_file hgrid="C96">atm/cam/chem/trop_mam/atmsrf_C96_c200625.nc</drydep_srf_file>
+<drydep_srf_file hgrid="C192">atm/cam/chem/trop_mam/atmsrf_C192_c200625.nc</drydep_srf_file>
+<drydep_srf_file hgrid="C384">atm/cam/chem/trop_mam/atmsrf_C384_c200625.nc</drydep_srf_file>
+
+<drydep_srf_file hgrid="mpasa480">atm/cam/chem/trop_mam/atmsrf_mpasa480_c090720.nc</drydep_srf_file>
+<drydep_srf_file hgrid="mpasa120">atm/cam/chem/trop_mam/atmsrf_mpasa120_c090720.nc</drydep_srf_file>
+<drydep_srf_file hgrid="mpasa60">atm/cam/chem/trop_mam/atmsrf_mpasa60_c210511.nc</drydep_srf_file>
+<drydep_srf_file hgrid="mpasa30">atm/cam/chem/trop_mam/atmsrf_mpasa30_c210601.nc</drydep_srf_file>
+<drydep_srf_file hgrid="mpasa15">atm/cam/chem/trop_mam/atmsrf_mpasa15_c20210804.nc</drydep_srf_file>
+
+<!-- depvel data -->
+<depvel_lnd_file>atm/cam/chem/trop_mozart/dvel/regrid_vegetation.nc</depvel_lnd_file>
+<depvel_lnd_file   aquaplanet="1" >atm/cam/chem/trop_mozart/dvel/regrid_vegetation_all_zero_aquaplanet_1deg_regularGrid_c20170421.nc</depvel_lnd_file>
+
+<!-- effective Henry's coef data for wet and dry deposition -->
+<dep_data_file>atm/cam/chem/trop_mozart/dvel/dep_data_c20221208.nc</dep_data_file>
+<dep_data_file chem="geoschem_mam4">atm/cam/chem/geoschem/dvel/dep_data_file_geoschem_v14.5_2025Feb14.nc</dep_data_file>
+
+<!-- photolysis inputs -->
+<xs_coef_file>atm/waccm/phot/effxstex.txt</xs_coef_file>
+<xs_short_file>atm/waccm/phot/xs_short_c221005mm_slh_c250930.nc</xs_short_file>
+<xs_long_file >atm/waccm/phot/temp_prs_GT200nm_c221005mm_slh_c250930.nc</xs_long_file>
+<xs_short_file phys="cam7">atm/waccm/phot/xs_short_c250124mm.nc</xs_short_file>
+<xs_long_file  phys="cam7">atm/waccm/phot/temp_prs_GT200nm_c250124mm.nc</xs_long_file>
+<rsf_file     >atm/waccm/phot/RSF_GT200nm_v3.0_c080811.nc</rsf_file>
+<exo_coldens_file>atm/cam/chem/trop_mozart/phot/exo_coldens.nc</exo_coldens_file>
+
+<!-- WACCM Upper boundary conditions -->
+<tgcm_ubc_file>atm/waccm/ub/tgcm_ubc_1993_c100204.nc</tgcm_ubc_file>
+<snoe_ubc_file>atm/waccm/ub/snoe_eof.nc</snoe_ubc_file>
+<ubc_specifier ver="waccmchem">
+  'T->MSIS','Q->2.d-8vmr','CH4->2.d-10vmr','F->1.0D-15mmr','HF->1.0D-15mmr','H->MSIS','N->MSIS','O->MSIS','O2->MSIS','H2->TGCM','NO->SNOE'
+</ubc_specifier>
+<ubc_specifier ver="waccmsc">
+  'T->MSIS','Q->2.d-8vmr','CH4->2.d-10vmr'
+</ubc_specifier>
+<!-- WACCM7 -- do not include water vapor for now -->
+<ubc_specifier ver="waccm7chem">
+  'T->MSIS','CH4->2.d-10vmr','F->1.0D-15mmr','HF->1.0D-15mmr','H->MSIS','N->MSIS','O->MSIS','O2->MSIS','H2->TGCM','NO->SNOE'
+</ubc_specifier>
+<ubc_specifier ver="waccm7sc">
+  'T->MSIS','CH4->2.d-10vmr'
+</ubc_specifier>
+
+<!-- Boundary data for Tropopheric Chemistry -->
+<fstrat_file    >atm/cam/chem/trop_mozart/ub/ubvals_b40.20th.track1_1996-2005_c110315.nc</fstrat_file>
+
+<!-- soil erodibility factors -->
+<soil_erod_file              >atm/cam/dst/dst_source2x2tunedcam6-2x2-04062017.nc </soil_erod_file>
+<soil_erod_file phys="cam5"  >atm/cam/dst/dst_source2x2_cam5.4_c150327.nc</soil_erod_file>
+<soil_erod_file phys="cam4"  >atm/cam/dst/dst_source2x2tuned-cam4-06132012.nc</soil_erod_file>
+<soil_erod_file phys="cam4" hgrid="0.9x1.25">atm/cam/dst/dst_source1x1tuned-cam4-06202012.nc</soil_erod_file>
+
+<!-- nitrogen deposition to surface models -->
+<stream_ndep_mesh_filename>share/meshes/fv0.9x1.25_141008_polemod_ESMFmesh.nc</stream_ndep_mesh_filename>
+
+<stream_ndep_data_filename >lnd/clm2/ndepdata/fndep_clm_hist_b.e21.BWHIST.f09_g17.CMIP6-historical-WACCM.ensmean_1849-2015_monthly_0.9x1.25_c180926.nc</stream_ndep_data_filename>
+<stream_ndep_data_filename sim_year="1850">atm/cam/chem/trop_strat_mam5_ts4_aero_spinup/ndep/fndep_clm_B1850C_MT4s.1850monthly.ne30_c251220.nc</stream_ndep_data_filename>
+
+<!-- Turbulent Mountain Stress -->
+<do_tms                                                     > .false. </do_tms>
+<do_tms                   waccm_phys="1"      phys="cam4"   > .true.  </do_tms>
+<do_tms                                       phys="cam5"   > .true.  </do_tms>
+<do_tms                                       phys="cam6"   > .false. </do_tms>
+<do_tms                                       phys="cam7"   > .false. </do_tms>
+
+<tms_z0fac                                                  > 0.075D0 </tms_z0fac>
+<tms_z0fac                waccm_phys="1"      phys="cam4"   > 0.100D0 </tms_z0fac>
+
+<tms_orocnst                                                > 1.0D0   </tms_orocnst>
+
+<!-- Beljaars -->
+<do_beljaars                                                > .false. </do_beljaars>
+<do_beljaars                                  phys="cam6"   > .true.  </do_beljaars>
+<do_beljaars                                  phys="cam7"   > .true.  </do_beljaars>
+
+<!-- Implicit Turbulent Surface Stress -->
+<do_iss                  > .false. </do_iss>
+<do_iss phys="cam5"      > .true.  </do_iss>
+<do_iss phys="cam6"      > .true.  </do_iss>
+<do_iss phys="cam7"      > .true.  </do_iss>
+
+<!-- Sponge layer vertical diffusion factor -->
+<diff_sponge_fac               > 0.0D0 </diff_sponge_fac>
+
+<!-- Use convective water in radiation calculation -->
+<conv_water_in_rad                  > 0 </conv_water_in_rad>
+<conv_water_in_rad phys="cam5"      > 1 </conv_water_in_rad>
+<conv_water_in_rad phys="cam6"      > 1 </conv_water_in_rad>
+<conv_water_in_rad phys="cam7"      > 1 </conv_water_in_rad>
+
+<conv_water_frac_limit            > 0.01d0  </conv_water_frac_limit>
+
+<!-- CLUBB_SGS -->
+<do_clubb_sgs                                 > .false. </do_clubb_sgs>
+<do_clubb_sgs   clubb_sgs="1"                 > .true.  </do_clubb_sgs>
+
+<!-- CLUBB_history -->
+<clubb_history               > .false. </clubb_history>
+<clubb_rad_history           > .false. </clubb_rad_history>
+
+<!-- CLUBB pbl diff options -->
+<clubb_cloudtop_cooling                           > .false. </clubb_cloudtop_cooling>
+<clubb_rainevap_turb                              > .false. </clubb_rainevap_turb>
+<clubb_do_adv                                     > .false. </clubb_do_adv>
+<clubb_timestep                                   > 300.0D0 </clubb_timestep>
+<clubb_rnevap_effic                               > 1.0D0   </clubb_rnevap_effic>
+<clubb_do_icesuper                                > .false. </clubb_do_icesuper>
+<clubb_l_ascending_grid                           > .false. </clubb_l_ascending_grid>
+
+
+<!-- Lscale_from_tau set by clubb_opts config option -->
+<clubb_l_diag_Lscale_from_tau                     > .false. </clubb_l_diag_Lscale_from_tau>
+
+<!-- CLUBB options -->
+<clubb_beta                                       > 2.4     </clubb_beta>
+<clubb_bv_efold                                   > 5.0     </clubb_bv_efold>
+<clubb_c1                                         > 1.0     </clubb_c1>
+<clubb_c1b                                        > 1.0     </clubb_c1b>
+<clubb_c11                                        > 0.7D0   </clubb_c11>
+<clubb_c11b                                       > 0.35D0  </clubb_c11b>
+<clubb_c14                                        > 2.2D0   </clubb_c14>
+<clubb_c14 dyn="se"                               > 1.6D0   </clubb_c14>
+<clubb_C2rt                                       > 1.0     </clubb_C2rt>
+<clubb_C2rtthl                                    > 1.3     </clubb_C2rtthl>
+<clubb_C2thl                                      > 1.0     </clubb_C2thl>
+<clubb_C4                                         > 5.2     </clubb_C4>
+<clubb_c6rt                                       > 4.0     </clubb_c6rt>
+<clubb_c6rtb                                      > 6.0     </clubb_c6rtb>
+<clubb_c6rtc                                      > 1.0     </clubb_c6rtc>
+<clubb_c6thl                                      > 4.0     </clubb_c6thl>
+<clubb_c6thlb                                     > 6.0     </clubb_c6thlb>
+<clubb_c6thlc                                     > 1.0     </clubb_c6thlc>
+<clubb_C7                                         > 0.5     </clubb_C7>
+<clubb_C7 phys="cam7"                             > 0.1     </clubb_C7>
+<clubb_C7b                                        > 0.5     </clubb_C7b>
+<clubb_C8                                         > 4.2     </clubb_C8>
+<clubb_C8 phys="cam7"                             > 4.6     </clubb_C8>
+<clubb_C8b                                        > 0.0     </clubb_C8b>
+<clubb_C_invrs_tau_bkgnd                          > 1.0     </clubb_C_invrs_tau_bkgnd>
+<clubb_C_invrs_tau_sfc                            > 0.1     </clubb_C_invrs_tau_sfc>
+<clubb_C_invrs_tau_shear                          > 0.02    </clubb_C_invrs_tau_shear>
+<clubb_C_invrs_tau_N2                             > 0.1     </clubb_C_invrs_tau_N2>
+<clubb_C_invrs_tau_N2_clear_wp3                   > 0.0     </clubb_C_invrs_tau_N2_clear_wp3>
+<clubb_C_invrs_tau_N2_wp2                         > 0.2     </clubb_C_invrs_tau_N2_wp2>
+<clubb_C_invrs_tau_N2_wpxp                        > 0.0     </clubb_C_invrs_tau_N2_wpxp>
+<clubb_C_invrs_tau_N2_xp2                         > 0.2     </clubb_C_invrs_tau_N2_xp2>
+<clubb_c_K1                                       > 0.75    </clubb_c_K1>
+<clubb_c_K10                                      > 0.5     </clubb_c_K10>
+<clubb_c_K10h                                     > 0.3     </clubb_c_K10h>
+<clubb_c_K10h phys="cam7"                         > 0.280   </clubb_c_K10h>
+<clubb_c_K2                                       > 0.125   </clubb_c_K2>
+<clubb_c_K8                                       > 1.25    </clubb_c_K8>
+<clubb_c_K9                                       > 0.25    </clubb_c_K9>
+<clubb_C_uu_shr                                   > 0.3     </clubb_C_uu_shr>
+<clubb_C_uu_shr phys="cam7"                       > 0.1     </clubb_C_uu_shr>
+<clubb_C_uu_buoy                                  > 0.3     </clubb_C_uu_buoy>
+<clubb_C_wp2_splat                                > 0.0     </clubb_C_wp2_splat>
+<clubb_C_wp3_pr_turb                              > 0.4     </clubb_C_wp3_pr_turb>
+<clubb_detice_rad                                 > 25.0D-6             </clubb_detice_rad>
+<clubb_detice_rad phys="cam7"                     > 61.0D-6             </clubb_detice_rad>
+<clubb_detliq_rad                                 > 8.0D-6              </clubb_detliq_rad>
+<clubb_detphase_lowtemp                           > 238.15D0            </clubb_detphase_lowtemp>
+<clubb_do_energyfix                               > .true.  </clubb_do_energyfix>
+<clubb_do_liqsupersat                             > .false. </clubb_do_liqsupersat>
+<clubb_gamma_coef                                 > 0.308   </clubb_gamma_coef>
+<clubb_gamma_coef phys="cam7"                     > 0.3     </clubb_gamma_coef>
+<clubb_gamma_coef hgrid="1.9x2.5" phys="cam6"     > 0.280   </clubb_gamma_coef>
+<clubb_gamma_coefb                                > 0.32    </clubb_gamma_coefb>
+<clubb_gamma_coefb phys="cam7"                    > 0.3     </clubb_gamma_coefb>
+<clubb_grid_adapt_in_time_method                  > 0       </clubb_grid_adapt_in_time_method>
+<clubb_fill_holes_type                            > 2       </clubb_fill_holes_type>
+<clubb_grid_remap_method                          > 1       </clubb_grid_remap_method>
+<clubb_ipdf_call_placement                        > 2       </clubb_ipdf_call_placement>
+<clubb_lambda0_stability_coef                     > 0.04    </clubb_lambda0_stability_coef>
+<clubb_lmin_coef                                  > 0.1     </clubb_lmin_coef>
+<clubb_l_add_dycore_grid                          > .false. </clubb_l_add_dycore_grid>
+<clubb_l_brunt_vaisala_freq_moist                 > .false. </clubb_l_brunt_vaisala_freq_moist>
+<clubb_l_C2_cloud_frac                            > .false. </clubb_l_C2_cloud_frac>
+<clubb_l_calc_thlp2_rad                           > .true.  </clubb_l_calc_thlp2_rad>
+<clubb_l_calc_w_corr                              > .false. </clubb_l_calc_w_corr>
+<clubb_l_call_pdf_closure_twice                   > .true.  </clubb_l_call_pdf_closure_twice>
+<clubb_l_const_Nc_in_cloud                        > .false. </clubb_l_const_Nc_in_cloud>
+<clubb_l_damp_wp2_using_em                        > .false. </clubb_l_damp_wp2_using_em>
+<clubb_l_damp_wp3_Skw_squared                     > .false. </clubb_l_damp_wp3_Skw_squared>
+<clubb_l_diagnose_correlations                    > .false. </clubb_l_diagnose_correlations>
+<clubb_l_diffuse_rtm_and_thlm                     > .false. </clubb_l_diffuse_rtm_and_thlm>
+<clubb_l_do_expldiff_rtm_thlm                        > .false. </clubb_l_do_expldiff_rtm_thlm>
+<clubb_l_do_expldiff_rtm_thlm clubb_sgs="1"          > .true.  </clubb_l_do_expldiff_rtm_thlm>
+<clubb_l_do_expldiff_rtm_thlm clubb_sgs="1" silhs="1"> .false.  </clubb_l_do_expldiff_rtm_thlm>
+<clubb_l_e3sm_config                              > .false. </clubb_l_e3sm_config>
+<clubb_l_enable_relaxed_clipping                  > .false. </clubb_l_enable_relaxed_clipping>
+<clubb_l_fix_w_chi_eta_correlations               > .true.  </clubb_l_fix_w_chi_eta_correlations>
+<clubb_l_godunov_upwind_wpxp_ta                   > .false. </clubb_l_godunov_upwind_wpxp_ta>
+<clubb_l_godunov_upwind_xpyp_ta                   > .false. </clubb_l_godunov_upwind_xpyp_ta>
+<clubb_l_intr_sfc_flux_smooth                     > .false. </clubb_l_intr_sfc_flux_smooth>
+<clubb_l_intr_sfc_flux_smooth phys="cam7"         > .true.  </clubb_l_intr_sfc_flux_smooth>
+<clubb_l_lmm_stepping                             > .false. </clubb_l_lmm_stepping>
+<clubb_l_lscale_plume_centered                    > .false. </clubb_l_lscale_plume_centered>
+<clubb_l_min_wp2_from_corr_wx                     > .false.  </clubb_l_min_wp2_from_corr_wx>
+<clubb_l_min_xp2_from_corr_wx                     > .true.  </clubb_l_min_xp2_from_corr_wx>
+<clubb_l_mono_flux_lim_rtm                        > .true.  </clubb_l_mono_flux_lim_rtm>
+<clubb_l_mono_flux_lim_spikefix                   > .true.  </clubb_l_mono_flux_lim_spikefix>
+<clubb_l_mono_flux_lim_thlm                       > .true.  </clubb_l_mono_flux_lim_thlm>
+<clubb_l_mono_flux_lim_um                         > .true.  </clubb_l_mono_flux_lim_um>
+<clubb_l_mono_flux_lim_vm                         > .true.  </clubb_l_mono_flux_lim_vm>
+<clubb_l_partial_upwind_wp3                       > .false. </clubb_l_partial_upwind_wp3>
+<clubb_l_predict_upwp_vpwp                        > .false. </clubb_l_predict_upwp_vpwp>
+<clubb_l_predict_upwp_vpwp phys="cam7"            > .true.  </clubb_l_predict_upwp_vpwp>
+<clubb_l_ho_nontrad_coriolis                      > .false. </clubb_l_ho_nontrad_coriolis>
+<clubb_l_ho_trad_coriolis                         > .false. </clubb_l_ho_trad_coriolis>
+<clubb_l_prescribed_avg_deltaz                    > .false. </clubb_l_prescribed_avg_deltaz>
+<clubb_l_rcm_supersat_adj                         > .false. </clubb_l_rcm_supersat_adj>
+<clubb_l_rtm_nudge                                > .false. </clubb_l_rtm_nudge>
+<clubb_l_smooth_Heaviside_tau_wpxp                > .false. </clubb_l_smooth_Heaviside_tau_wpxp>
+<clubb_l_standard_term_ta                         > .false. </clubb_l_standard_term_ta>
+<clubb_l_stability_correct_tau_zm                 > .true.  </clubb_l_stability_correct_tau_zm>
+<clubb_l_stability_correct_Kh_N2_zm               > .false. </clubb_l_stability_correct_Kh_N2_zm>
+<clubb_l_tke_aniso                                > .true.  </clubb_l_tke_aniso>
+<clubb_l_trapezoidal_rule_zm                      > .true.  </clubb_l_trapezoidal_rule_zm>
+<clubb_l_trapezoidal_rule_zt                      > .true.  </clubb_l_trapezoidal_rule_zt>
+<clubb_l_upwind_xm_ma                             > .true.  </clubb_l_upwind_xm_ma>
+<clubb_l_upwind_xpyp_ta                           > .true.  </clubb_l_upwind_xpyp_ta>
+<clubb_l_use_C11_Richardson                       > .false. </clubb_l_use_C11_Richardson>
+<clubb_l_use_C7_Richardson                        > .false. </clubb_l_use_C7_Richardson>
+<clubb_l_use_cloud_cover                          > .true.  </clubb_l_use_cloud_cover>
+<clubb_l_use_precip_frac                          > .true.  </clubb_l_use_precip_frac>
+<clubb_l_use_shear_Richardson                     > .false. </clubb_l_use_shear_Richardson>
+<clubb_l_use_thvm_in_bv_freq                      > .false. </clubb_l_use_thvm_in_bv_freq>
+<clubb_l_use_tke_in_wp2_wp3_K_dfsn                > .false. </clubb_l_use_tke_in_wp2_wp3_K_dfsn>
+<clubb_l_use_tke_in_wp3_pr_turb_term              > .false. </clubb_l_use_tke_in_wp3_pr_turb_term>
+<clubb_l_vary_convect_depth                       > .false. </clubb_l_vary_convect_depth>
+<clubb_l_vert_avg_closure                         > .true.  </clubb_l_vert_avg_closure>
+<clubb_mult_coef                                  > 1.0D0   </clubb_mult_coef>
+<clubb_nu2                                        > 5.0     </clubb_nu2>
+<clubb_nu9                                        > 20.0    </clubb_nu9>
+<clubb_penta_solve_method                         > 1       </clubb_penta_solve_method>
+<clubb_Skw_denom_coef                             > 0.0     </clubb_Skw_denom_coef>
+<clubb_skw_max_mag                                > 4.5     </clubb_skw_max_mag>
+<clubb_tridiag_solve_method                       > 1       </clubb_tridiag_solve_method>
+<clubb_up2_sfc_coef                               > 2.0     </clubb_up2_sfc_coef>
+<clubb_wpxp_L_thresh                              > 60.0    </clubb_wpxp_L_thresh>
+<clubb_wpxp_Ri_exp                                > 0.5     </clubb_wpxp_Ri_exp>
+<clubb_z_displace                                 > 25.0    </clubb_z_displace>
+<do_hb_above_clubb                                >.false.  </do_hb_above_clubb>
+<do_hb_above_clubb phys="cam6"                    >.true.   </do_hb_above_clubb>
+<do_hb_above_clubb phys="cam7"                    >.true.   </do_hb_above_clubb>
+
+<!-- SILHS options -->
+<clubb_do_icesuper                      silhs="1" > .true.  </clubb_do_icesuper>
+<clubb_C2rt                             silhs="1" > 0.2     </clubb_C2rt>
+<clubb_C2thl                            silhs="1" > 0.2     </clubb_C2thl>
+<clubb_C2rtthl                          silhs="1" > 0.2     </clubb_C2rtthl>
+<clubb_C4                               silhs="1" > 5.2     </clubb_C4>
+<clubb_C7b                              silhs="1" > 0.8     </clubb_C7b>
+<clubb_C8                               silhs="1" > 2.5     </clubb_C8>
+<clubb_C8b                              silhs="1" > 0.02    </clubb_C8b>
+<clubb_C11                              silhs="1" > 0.5     </clubb_C11>
+<clubb_C11b                             silhs="1" > 0.5     </clubb_C11b>
+<clubb_c14                              silhs="1" > 0.5     </clubb_c14>
+<clubb_c_K9                             silhs="1" > 0.25    </clubb_c_K9>
+<clubb_nu9                              silhs="1" > 20.0    </clubb_nu9>
+<clubb_c_K10                            silhs="1" > 2.0     </clubb_c_K10>
+<clubb_c_K10h                           silhs="1" > 1.0     </clubb_c_K10h>
+<clubb_gamma_coef                       silhs="1" > 0.24    </clubb_gamma_coef>
+<clubb_gamma_coefb                      silhs="1" > 0.37    </clubb_gamma_coefb>
+<clubb_lambda0_stability_coef           silhs="1" > 0.03    </clubb_lambda0_stability_coef>
+<clubb_lmin_coef                        silhs="1" > 0.5     </clubb_lmin_coef>
+<clubb_mult_coef                        silhs="1" > 1.5     </clubb_mult_coef>
+<clubb_Skw_denom_coef                   silhs="1" > 4.0     </clubb_Skw_denom_coef>
+<clubb_skw_max_mag                      silhs="1" > 10.0    </clubb_skw_max_mag>
+<clubb_up2_sfc_coef                     silhs="1" > 4.0     </clubb_up2_sfc_coef>
+<clubb_C_wp2_splat                      silhs="1" > 0.0     </clubb_C_wp2_splat>
+<clubb_bv_efold                         silhs="1" > 5.0     </clubb_bv_efold>
+
+<clubb_l_brunt_vaisala_freq_moist       silhs="1" > .true.  </clubb_l_brunt_vaisala_freq_moist>
+<clubb_l_call_pdf_closure_twice         silhs="1" > .false. </clubb_l_call_pdf_closure_twice>
+<clubb_l_damp_wp3_Skw_squared           silhs="1" > .true.  </clubb_l_damp_wp3_Skw_squared>
+<clubb_l_min_wp2_from_corr_wx           silhs="1" > .true.  </clubb_l_min_wp2_from_corr_wx>
+<clubb_l_min_xp2_from_corr_wx           silhs="1" > .true.  </clubb_l_min_xp2_from_corr_wx>
+<clubb_l_predict_upwp_vpwp              silhs="1" > .true.  </clubb_l_predict_upwp_vpwp>
+<clubb_l_rcm_supersat_adj               silhs="1" > .false. </clubb_l_rcm_supersat_adj>
+<clubb_l_stability_correct_tau_zm       silhs="1" > .false. </clubb_l_stability_correct_tau_zm>
+<clubb_l_trapezoidal_rule_zm            silhs="1" > .false. </clubb_l_trapezoidal_rule_zm>
+<clubb_l_trapezoidal_rule_zt            silhs="1" > .false. </clubb_l_trapezoidal_rule_zt>
+<clubb_l_use_C7_Richardson              silhs="1" > .true.  </clubb_l_use_C7_Richardson>
+<clubb_l_use_C11_Richardson             silhs="1" > .true.  </clubb_l_use_C11_Richardson>
+<clubb_l_use_cloud_cover                silhs="1" > .false. </clubb_l_use_cloud_cover>
+<clubb_l_use_thvm_in_bv_freq            silhs="1" > .true.  </clubb_l_use_thvm_in_bv_freq>
+<clubb_l_vert_avg_closure               silhs="1" > .false. </clubb_l_vert_avg_closure>
+<clubb_l_diag_Lscale_from_tau           silhs="1" > .false. </clubb_l_diag_Lscale_from_tau>
+<clubb_l_damp_wp2_using_em              silhs="1" > .false. </clubb_l_damp_wp2_using_em>
+<clubb_wpxp_Ri_exp                      silhs="1" > 0.5     </clubb_wpxp_Ri_exp>
+<clubb_z_displace                       silhs="1" > 25.00   </clubb_z_displace>
+
+
+<!-- CLUBB+MF options -->
+<do_clubb_mf                       > .false. </do_clubb_mf>
+<do_clubb_mf_diag                  > .false. </do_clubb_mf_diag>
+<clubb_mf_L0                       > 50.0    </clubb_mf_L0>
+<clubb_mf_ent0                     > 0.22    </clubb_mf_ent0>
+<clubb_mf_nup                      > 10      </clubb_mf_nup>
+
+<!-- Set radiation intervals based on mpas hgrids -->
+<iradlw hgrid="mpasa15"  > 10 </iradlw>
+<iradsw hgrid="mpasa15"  > 10 </iradsw>
+<iradlw hgrid="mpasa7p5" > 10 </iradlw>
+<iradsw hgrid="mpasa7p5" > 10 </iradsw>
+<iradlw hgrid="mpas3p75" > 10 </iradlw>
+<iradsw hgrid="mpas3p75" > 10 </iradsw>
+
+<!-- Microphysics scheme -->
+<micro_mg_do_hail                       > .false. </micro_mg_do_hail>
+<micro_mg_do_graupel                    > .false. </micro_mg_do_graupel>
+<micro_mg_do_graupel microphys="mg3"    > .true. </micro_mg_do_graupel>
+<graupel_in_rad                         > .false. </graupel_in_rad>
+
+<microp_scheme                          >NONE         </microp_scheme>
+<microp_scheme microphys="rk"           >RK           </microp_scheme>
+<microp_scheme microphys="mg1"          >MG           </microp_scheme>
+<microp_scheme microphys="mg2"          >MG           </microp_scheme>
+<microp_scheme microphys="mg3"          >MG           </microp_scheme>
+<microp_scheme microphys="pumas"        >MG           </microp_scheme>
+
+<micro_mg_version     microphys="mg1">    1          </micro_mg_version>
+<micro_mg_sub_version microphys="mg1">    0          </micro_mg_sub_version>
+<micro_mg_num_steps   microphys="mg1">    1          </micro_mg_num_steps>
+
+<micro_mg_version     microphys="mg2">    2          </micro_mg_version>
+<micro_mg_sub_version microphys="mg2">    0          </micro_mg_sub_version>
+<micro_mg_num_steps   microphys="mg2">    1          </micro_mg_num_steps>
+
+<micro_mg_version     microphys="mg3">    3          </micro_mg_version>
+<micro_mg_sub_version microphys="mg3">    0          </micro_mg_sub_version>
+<micro_mg_num_steps   microphys="mg3">    1          </micro_mg_num_steps>
+
+<micro_do_massless_droplet_destroyer                             >  .false. </micro_do_massless_droplet_destroyer>
+<micro_do_massless_droplet_destroyer   microphys="mg2" silhs="1" >  .true.  </micro_do_massless_droplet_destroyer>
+
+<micro_mg_precip_frac_method                        >  max_overlap </micro_mg_precip_frac_method>
+<micro_mg_precip_frac_method   clubb_sgs="1"        >  in_cloud    </micro_mg_precip_frac_method>
+
+<micro_mg_berg_eff_factor                  >  1.D0    </micro_mg_berg_eff_factor>
+<micro_mg_berg_eff_factor microphys="mg2"  >  1.D0    </micro_mg_berg_eff_factor>
+
+<micro_mg_accre_enhan_fact                  >  1.D0    </micro_mg_accre_enhan_fact>
+<micro_mg_accre_enhan_fact microphys="mg2"  >  1.D0    </micro_mg_accre_enhan_fact>
+<micro_mg_accre_enhan_fact phys="cam7"      >  0.731D0    </micro_mg_accre_enhan_fact>
+
+<micro_mg_autocon_fact                  >  0.01D0    </micro_mg_autocon_fact>
+<micro_mg_autocon_fact microphys="mg2"  >  0.01D0    </micro_mg_autocon_fact>
+
+<micro_mg_autocon_nd_exp                  >  -1.1D0    </micro_mg_autocon_nd_exp>
+<micro_mg_autocon_nd_exp microphys="mg2"  >  -1.1D0    </micro_mg_autocon_nd_exp>
+
+<micro_mg_autocon_lwp_exp                 >  2.47D0    </micro_mg_autocon_lwp_exp>
+<micro_mg_autocon_lwp_exp microphys="mg2" >  2.47D0    </micro_mg_autocon_lwp_exp>
+<micro_mg_autocon_lwp_exp phys="cam7"     >  2.37D0    </micro_mg_autocon_lwp_exp>
+
+<microp_aero_bulk_scale                  >  2.D0    </microp_aero_bulk_scale>
+
+<microp_aero_npccn_scale                  >  1.D0    </microp_aero_npccn_scale>
+<microp_aero_npccn_scale microphys="mg2"  >  1.D0    </microp_aero_npccn_scale>
+
+<microp_aero_wsub_scale                  >  1.D0     </microp_aero_wsub_scale>
+<microp_aero_wsub_scale phys="cam7"      >  0.9D0     </microp_aero_wsub_scale>
+
+<microp_aero_wsubi_scale                  >  1.D0    </microp_aero_wsubi_scale>
+<microp_aero_wsubi_scale phys="cam7"      >  1.5D0    </microp_aero_wsubi_scale>
+
+<microp_aero_wsub_min                  >  0.2D0    </microp_aero_wsub_min>
+<microp_aero_wsub_min phys="cam7"      >  0.1D0    </microp_aero_wsub_min>
+
+<microp_aero_wsub_min_asf                  >  0.1D0    </microp_aero_wsub_min_asf>
+<microp_aero_wsub_min_asf phys="cam7"      >  0.0D0    </microp_aero_wsub_min_asf>
+
+<microp_aero_wsubi_min                  >  0.001D0    </microp_aero_wsubi_min>
+
+<micro_mg_homog_size                  >  25.D-6    </micro_mg_homog_size>
+<micro_mg_homog_size  microphys="mg2"  >  25.D-6    </micro_mg_homog_size>
+
+<micro_mg_vtrmi_factor                  >  1.D0    </micro_mg_vtrmi_factor>
+<micro_mg_vtrmi_factor phys="cam7"      >  1.39D0    </micro_mg_vtrmi_factor>
+<micro_mg_vtrms_factor                  >  1.D0    </micro_mg_vtrms_factor>
+
+<micro_mg_effi_factor                  >  1.D0    </micro_mg_effi_factor>
+<micro_mg_effi_factor microphys="mg2"  >  1.D0    </micro_mg_effi_factor>
+
+<micro_mg_iaccr_factor                  >  1.D0    </micro_mg_iaccr_factor>
+<micro_mg_iaccr_factor microphys="mg2"  >  1.D0    </micro_mg_iaccr_factor>
+
+<micro_mg_max_nicons                  >  1.D8    </micro_mg_max_nicons>
+<micro_mg_max_nicons  microphys="mg2"  > 1.D8    </micro_mg_max_nicons>
+
+<micro_mg_implicit_fall    phys="cam7" > .true. </micro_mg_implicit_fall>
+<micro_mg_accre_sees_auto  phys="cam7" > .true. </micro_mg_accre_sees_auto>
+<micro_mg_warm_rain        phys="cam7" > kk2000 </micro_mg_warm_rain>
+<micro_mg_precip_fall_corr phys="cam7" > .true. </micro_mg_precip_fall_corr>
+
+<cld_macmic_num_steps>                                            1 </cld_macmic_num_steps>
+<cld_macmic_num_steps microphys="mg2" clubb_sgs="1"             > 3 </cld_macmic_num_steps>
+<cld_macmic_num_steps microphys="mg2" clubb_sgs="1" silhs="1"   > 6 </cld_macmic_num_steps>
+<cld_macmic_num_steps microphys="mg2" clubb_sgs="1" waccmx="1"  > 1 </cld_macmic_num_steps>
+<!-- The following adjustments to cld_macmic_num_steps are to allow clubb -->
+<!-- to substep with clubb_timestep=300 -->
+<cld_macmic_num_steps microphys="mg2" clubb_sgs="1" dtime="1200"> 2 </cld_macmic_num_steps>
+<cld_macmic_num_steps microphys="mg2" clubb_sgs="1" dtime="600" > 1 </cld_macmic_num_steps>
+<cld_macmic_num_steps microphys="mg2" clubb_sgs="1" dtime="300" > 1 </cld_macmic_num_steps>
+<cld_macmic_num_steps microphys="mg3" clubb_sgs="1"> 3 </cld_macmic_num_steps>
+<!-- hi-res and var-res support for ne120, ARCTIC, ARCTICGRIS, POLARCAP, CONUS, NATL -->
+<cld_macmic_num_steps microphys="mg2" clubb_sgs="1" dtime="450" > 2 </cld_macmic_num_steps>
+<cld_macmic_num_steps microphys="mg2" clubb_sgs="1" dtime="225" > 1 </cld_macmic_num_steps>
+<cld_macmic_num_steps microphys="mg3" clubb_sgs="1" dtime="450" > 2 </cld_macmic_num_steps>
+<cld_macmic_num_steps microphys="mg3" clubb_sgs="1" dtime="225" > 1 </cld_macmic_num_steps>
+
+<!-- Ice nucleation -->
+<nucleate_ice_subgrid                                  >1.0D0</nucleate_ice_subgrid>
+<nucleate_ice_subgrid microphys="mg1"                  >1.2D0</nucleate_ice_subgrid>
+<nucleate_ice_subgrid microphys="mg2"                  >1.2D0</nucleate_ice_subgrid>
+<nucleate_ice_subgrid microphys="mg3"                  >1.2D0</nucleate_ice_subgrid>
+<nucleate_ice_subgrid microphys="mg2" silhs="1"        >1.0D0</nucleate_ice_subgrid>
+
+
+<nucleate_ice_subgrid_strat                            >1.0D0</nucleate_ice_subgrid_strat>
+<nucleate_ice_subgrid_strat microphys="mg1"            >1.2D0</nucleate_ice_subgrid_strat>
+<nucleate_ice_subgrid_strat microphys="mg2"            >1.2D0</nucleate_ice_subgrid_strat>
+<nucleate_ice_subgrid_strat microphys="mg3"            >1.2D0</nucleate_ice_subgrid_strat>
+
+<use_hetfrz_classnuc               >.false.</use_hetfrz_classnuc>
+<use_hetfrz_classnuc phys="cam6"   >.true.</use_hetfrz_classnuc>
+<use_hetfrz_classnuc phys="cam7"   >.true.</use_hetfrz_classnuc>
+<hetfrz_bc_scalfac>0.01D0</hetfrz_bc_scalfac>
+<hetfrz_dust_scalfac>0.05D0</hetfrz_dust_scalfac>
+
+<use_preexisting_ice               >.false.</use_preexisting_ice>
+<use_preexisting_ice phys="cam6"   >.true.</use_preexisting_ice>
+<use_preexisting_ice phys="cam7"   >.true.</use_preexisting_ice>
+
+<nucleate_ice_incloud                   >.true.</nucleate_ice_incloud>
+<nucleate_ice_incloud    phys="cam6"    >.false.</nucleate_ice_incloud>
+<nucleate_ice_incloud    phys="cam7"    >.false.</nucleate_ice_incloud>
+<nucleate_ice_strat                     >1.0D0</nucleate_ice_strat>
+<nucleate_ice_use_troplev               >.true.</nucleate_ice_use_troplev>
+
+<chem_use_chemtrop>.true.</chem_use_chemtrop>
+
+<prescribed_strataero_use_chemtrop>.false.</prescribed_strataero_use_chemtrop>
+
+<!-- Macrophysics scheme -->
+<macrop_scheme                           >none</macrop_scheme>
+<macrop_scheme macrophys="rk"            >rk</macrop_scheme>
+<macrop_scheme macrophys="park"          >park</macrop_scheme>
+<macrop_scheme macrophys="clubb_sgs"     >CLUBB_SGS</macrop_scheme>
+
+<!-- Vertical limit on troposphere cloud physics -->
+
+<trop_cloud_top_press>      1.D2 </trop_cloud_top_press>
+
+<!-- Vertical limit for modal aerosol processes -->
+
+<clim_modal_aero_top_press> 1.D-4 </clim_modal_aero_top_press>
+
+<!-- Scaling eddy diffusivities -->
+  <!-- NOTE: the kv and eddy values are alternate ways of trying to -->
+  <!-- limit high diffusivities with diag_TKE. -->
+<kv_top_pressure                      >0.D0</kv_top_pressure>
+
+<kv_top_scale                               >1.D0</kv_top_scale>
+<kv_top_scale phys="cam5"    waccm_phys="1" >0.D0</kv_top_scale>
+<kv_top_scale phys="cam6"    waccm_phys="1" >0.D0</kv_top_scale>
+<kv_top_scale phys="cam7"    waccm_phys="1" >0.D0</kv_top_scale>
+
+<kv_freetrop_scale                    >1.D0</kv_freetrop_scale>
+
+<eddy_lbulk_max                       >40.D3</eddy_lbulk_max>
+
+<eddy_leng_max                               >40.D3</eddy_leng_max>
+<eddy_leng_max carma="cirrus"                >30.D0</eddy_leng_max>
+<eddy_leng_max phys="cam5"    waccm_phys="1" >100.D0</eddy_leng_max>
+<eddy_leng_max phys="cam6"    waccm_phys="1" >100.D0</eddy_leng_max>
+<eddy_leng_max phys="cam7"    waccm_phys="1" >100.D0</eddy_leng_max>
+
+<eddy_max_bot_pressure                               >100.D3</eddy_max_bot_pressure>
+<eddy_max_bot_pressure phys="cam5"    waccm_phys="1" >100.D0</eddy_max_bot_pressure>
+<eddy_max_bot_pressure phys="cam6"    waccm_phys="1" >100.D0</eddy_max_bot_pressure>
+<eddy_max_bot_pressure phys="cam7"    waccm_phys="1" >100.D0</eddy_max_bot_pressure>
+
+<eddy_moist_entrain_a2l           >30.D0</eddy_moist_entrain_a2l>
+
+<diff_cnsrv_mass_check> .false. </diff_cnsrv_mass_check>
+
+<!-- Molecular diffusion limits -->
+
+<do_molec_press> 0.1D0 </do_molec_press>
+<molec_diff_bot_press> 50.D0 </molec_diff_bot_press>
+
+<!-- dust emission tuning factor -->
+<!-- NOTE: by default cam7 uses dust_emis_method=Leung_2023, otherwise dust_emis_method = Zender_2003 -->
+<!-- if, e.g., one uses cam6 but selects Leung_2023, dust_emis_fact will need to be rechanged -->
+<dust_emis_fact                                                         >0.37D0</dust_emis_fact>
+<dust_emis_fact                            phys="cam5"                  >0.35D0</dust_emis_fact>
+<dust_emis_fact          hgrid="0.47x0.63" phys="cam5"                  >0.45D0</dust_emis_fact>
+<dust_emis_fact          hgrid="0.23x0.31" phys="cam5"                  >0.45D0</dust_emis_fact>
+<dust_emis_fact                            phys="cam6"                  >0.88D0</dust_emis_fact>
+<dust_emis_fact                            phys="cam7"                  >3.20D0</dust_emis_fact>
+<dust_emis_fact                            phys="cam6"      silhs="1"   >0.75D0</dust_emis_fact>
+<dust_emis_fact                            phys="cam7"      silhs="1"   >4.00D0</dust_emis_fact>
+<dust_emis_fact          hgrid="0.47x0.63" phys="cam6"                  >1.13D0</dust_emis_fact>
+<dust_emis_fact          hgrid="0.47x0.63" phys="cam7"                  >4.00D0</dust_emis_fact>
+<dust_emis_fact          hgrid="0.23x0.31" phys="cam6"                  >1.13D0</dust_emis_fact>
+<dust_emis_fact          hgrid="0.23x0.31" phys="cam7"                  >4.00D0</dust_emis_fact>
+
+<dust_emis_fact dyn="se"                   phys="cam5"                    >0.55D0</dust_emis_fact>
+<dust_emis_fact dyn="fv"                   phys="cam5"   clubb_sgs="1"    >0.22D0</dust_emis_fact>
+<dust_emis_fact dyn="se"                   phys="cam6"                    >1.75D0</dust_emis_fact>
+<dust_emis_fact dyn="se"                   phys="cam7"                    >3.20D0</dust_emis_fact>
+<dust_emis_fact dyn="mpas"                 phys="cam7"                    >3.20D0</dust_emis_fact>
+<dust_emis_fact dyn="se" hgrid="ne30np4"   phys="cam6"                    >2.0D0</dust_emis_fact>
+<dust_emis_fact dyn="se" hgrid="ne30np4"   phys="cam7"                    >3.2D0</dust_emis_fact>
+<dust_emis_fact dyn="se" hgrid="ne0np4CONUS.ne30x8" phys="cam6"    chem="trop_strat_mam4_vbs">2.0D0</dust_emis_fact>
+<dust_emis_fact dyn="se" hgrid="ne0np4CONUS.ne30x8" phys="cam7"    chem="trop_strat_mam4_vbs">4.0D0</dust_emis_fact>
+<dust_emis_fact dyn="se" hgrid="ne0np4CONUS.ne30x8" phys="cam6"    chem="trop_strat_mam5_t1s1">2.0D0</dust_emis_fact>
+<dust_emis_fact dyn="se" hgrid="ne0np4CONUS.ne30x8" phys="cam7"    chem="trop_strat_mam5_t1s1">4.0D0</dust_emis_fact>
+<dust_emis_fact dyn="se" hgrid="ne30np4"   phys="cam6"             waccm_phys="1">2.0D0</dust_emis_fact>
+<dust_emis_fact dyn="se" hgrid="ne30np4"   phys="cam7"             waccm_phys="1">3.2D0</dust_emis_fact>
+<dust_emis_fact dyn="se" hgrid="ne0np4CONUS.ne30x8" phys="cam6"    waccm_phys="1">2.0D0</dust_emis_fact>
+<dust_emis_fact dyn="se" hgrid="ne0np4CONUS.ne30x8" phys="cam7"    waccm_phys="1">4.0D0</dust_emis_fact>
+<dust_emis_fact dyn="fv"                   phys="cam6"                    >1.75D0</dust_emis_fact>
+<dust_emis_fact dyn="fv"                   phys="cam7"                    >3.2D0</dust_emis_fact>
+
+<dust_emis_fact hgrid="1.9x2.5"                   phys="cam6"    ver="chem">0.65D0</dust_emis_fact>
+<dust_emis_fact hgrid="1.9x2.5"                   phys="cam7"    ver="chem">4.0D0</dust_emis_fact>
+<dust_emis_fact hgrid="0.9x1.25"                  phys="cam6"    ver="chem">1.75D0</dust_emis_fact>
+<dust_emis_fact hgrid="0.9x1.25"                  phys="cam7"    ver="chem">4.0D0</dust_emis_fact>
+<dust_emis_fact hgrid="1.9x2.5"   offline_dyn="1" phys="cam6"    ver="chem">0.6D0</dust_emis_fact>
+<dust_emis_fact hgrid="1.9x2.5"   offline_dyn="1" phys="cam7"    ver="chem">4.0D0</dust_emis_fact>
+<dust_emis_fact hgrid="0.47x0.63" offline_dyn="1" phys="cam6"    ver="chem">2.25D0</dust_emis_fact>
+<dust_emis_fact hgrid="0.47x0.63" offline_dyn="1" phys="cam7"    ver="chem">4.0D0</dust_emis_fact>
+
+<!-- dust emissions method -->
+<dust_emis_method>              Zender_2003</dust_emis_method>
+<dust_emis_method phys="cam7" >  Leung_2023</dust_emis_method>
+<zender_soil_erod_source>atm</zender_soil_erod_source>
+
+<!-- seasalt emission tuning factor -->
+<!-- Note that ver="strat" when modal_accum_coarse_exch=.true. -->
+<seasalt_emis_scale                                                      >1.35D0</seasalt_emis_scale>
+<seasalt_emis_scale ver="mam7"                                           >1.62D0</seasalt_emis_scale>
+<seasalt_emis_scale ver="strat"                                          >0.90D0</seasalt_emis_scale>
+<seasalt_emis_scale ver="strat" clubb_sgs="1"                            >1.00D0</seasalt_emis_scale>
+<seasalt_emis_scale ver="strat" clubb_sgs="1" phys="cam7"                >1.55D0</seasalt_emis_scale>
+<seasalt_emis_scale ver="strat" clubb_sgs="1" hgrid="1.9x2.5" phys="cam6">1.10D0</seasalt_emis_scale>
+<seasalt_emis_scale ver="strat" clubb_sgs="1" silhs="1"                  >0.60D0</seasalt_emis_scale>
+
+<!-- Wet scavenging of modal aerosols -->
+<sol_facti_cloud_borne                                                >1.0D0</sol_facti_cloud_borne>
+<sol_facti_cloud_borne clubb_sgs="1"                                  >0.6D0</sol_facti_cloud_borne>
+<sol_facti_cloud_borne clubb_sgs="1" microphys="mg2"                  >1.0D0</sol_facti_cloud_borne>
+<sol_facti_cloud_borne clubb_sgs="1" microphys="mg3"                  >1.0D0</sol_facti_cloud_borne>
+
+<sol_factb_interstitial                >0.1D0</sol_factb_interstitial>
+
+<sol_factic_interstitial                >0.4D0</sol_factic_interstitial>
+
+<!-- sub-column switches for physics packages -->
+<use_subcol_microp                  >.false.</use_subcol_microp>
+<use_subcol_microp        silhs="1" >.true.</use_subcol_microp>
+<subcol_scheme                      >off    </subcol_scheme>
+<subcol_scheme            silhs="1" >SILHS    </subcol_scheme>
+
+<!-- sub-column tstcp switches for testing purposes -->
+<subcol_tstcp_noAvg  >.false.</subcol_tstcp_noAvg>
+<subcol_tstcp_filter >.false.</subcol_tstcp_filter>
+<subcol_tstcp_weight >.false.</subcol_tstcp_weight>
+<subcol_tstcp_perturb>.false.</subcol_tstcp_perturb>
+<subcol_tstcp_restart>.false.</subcol_tstcp_restart>
+
+<!-- sub-column vamp switches  -->
+<subcol_vamp_ctyp  > 3 </subcol_vamp_ctyp>
+<subcol_vamp_otyp  > 1 </subcol_vamp_otyp>
+<subcol_vamp_nsubc > 10 </subcol_vamp_nsubc>
+
+<!-- sub-column SILHS switches -->
+<subcol_silhs_weight >           .true.   </subcol_silhs_weight>
+<subcol_silhs_numsubcol >        4        </subcol_silhs_numsubcol>
+<subcol_silhs_corr_file_path >   .        </subcol_silhs_corr_file_path>
+<subcol_silhs_corr_file_name>    default  </subcol_silhs_corr_file_name>
+<subcol_silhs_meanice>           .false.  </subcol_silhs_meanice>
+<subcol_silhs_q_to_micro>        .true.   </subcol_silhs_q_to_micro>
+<subcol_silhs_n_to_micro>        .true.   </subcol_silhs_n_to_micro>
+<subcol_silhs_constrainmn>       .false.  </subcol_silhs_constrainmn>
+<subcol_silhs_use_clear_col>     .false.  </subcol_silhs_use_clear_col>
+<subcol_silhs_var_covar_src>     .true.   </subcol_silhs_var_covar_src>
+<subcol_silhs_ncnp2_on_ncnm2>    0.05     </subcol_silhs_ncnp2_on_ncnm2>
+
+<subcol_silhs_hmp2_ip_on_hmm2_ip_intrcpt%rr > 1.0 </subcol_silhs_hmp2_ip_on_hmm2_ip_intrcpt%rr>
+<subcol_silhs_hmp2_ip_on_hmm2_ip_intrcpt%Nr > 1.0 </subcol_silhs_hmp2_ip_on_hmm2_ip_intrcpt%Nr>
+<subcol_silhs_hmp2_ip_on_hmm2_ip_intrcpt%rs > 1.0 </subcol_silhs_hmp2_ip_on_hmm2_ip_intrcpt%rs>
+<subcol_silhs_hmp2_ip_on_hmm2_ip_intrcpt%Ns > 1.0 </subcol_silhs_hmp2_ip_on_hmm2_ip_intrcpt%Ns>
+<subcol_silhs_hmp2_ip_on_hmm2_ip_intrcpt%ri > 1.0 </subcol_silhs_hmp2_ip_on_hmm2_ip_intrcpt%ri>
+<subcol_silhs_hmp2_ip_on_hmm2_ip_intrcpt%Ni > 1.0 </subcol_silhs_hmp2_ip_on_hmm2_ip_intrcpt%Ni>
+<subcol_silhs_hmp2_ip_on_hmm2_ip_slope%rr   > 0.0 </subcol_silhs_hmp2_ip_on_hmm2_ip_slope%rr>
+<subcol_silhs_hmp2_ip_on_hmm2_ip_slope%Nr   > 0.0 </subcol_silhs_hmp2_ip_on_hmm2_ip_slope%Nr>
+<subcol_silhs_hmp2_ip_on_hmm2_ip_slope%rs   > 0.0 </subcol_silhs_hmp2_ip_on_hmm2_ip_slope%rs>
+<subcol_silhs_hmp2_ip_on_hmm2_ip_slope%Ns   > 0.0 </subcol_silhs_hmp2_ip_on_hmm2_ip_slope%Ns>
+<subcol_silhs_hmp2_ip_on_hmm2_ip_slope%ri   > 0.0 </subcol_silhs_hmp2_ip_on_hmm2_ip_slope%ri>
+<subcol_silhs_hmp2_ip_on_hmm2_ip_slope%Ni   > 0.0 </subcol_silhs_hmp2_ip_on_hmm2_ip_slope%Ni>
+
+<subcol_silhs_l_lh_importance_sampling   > .true.  </subcol_silhs_l_lh_importance_sampling>
+<subcol_silhs_l_Lscale_vert_avg          > .false. </subcol_silhs_l_Lscale_vert_avg>
+<subcol_silhs_l_lh_straight_mc           > .false. </subcol_silhs_l_lh_straight_mc>
+<subcol_silhs_l_lh_clustered_sampling    > .true.  </subcol_silhs_l_lh_clustered_sampling>
+<subcol_silhs_l_rcm_in_cloud_k_lh_start  > .true.  </subcol_silhs_l_rcm_in_cloud_k_lh_start>
+<subcol_silhs_l_random_k_lh_start        > .false. </subcol_silhs_l_random_k_lh_start>
+<subcol_silhs_l_max_overlap_in_cloud     > .true.  </subcol_silhs_l_max_overlap_in_cloud>
+<subcol_silhs_l_lh_instant_var_covar_src > .true.  </subcol_silhs_l_lh_instant_var_covar_src>
+<subcol_silhs_l_lh_limit_weights         > .true.  </subcol_silhs_l_lh_limit_weights>
+<subcol_silhs_l_lh_var_frac              > .false. </subcol_silhs_l_lh_var_frac>
+<subcol_silhs_l_lh_normalize_weights     > .true.  </subcol_silhs_l_lh_normalize_weights>
+
+<!-- PBL scheme -->
+<eddy_scheme pbl="none"           >NONE           </eddy_scheme>
+<eddy_scheme pbl="uw"             >diag_TKE       </eddy_scheme>
+<eddy_scheme pbl="hb"             >HB             </eddy_scheme>
+<eddy_scheme pbl="hbr"            >HBR            </eddy_scheme>
+<eddy_scheme pbl="clubb_sgs"      >CLUBB_SGS      </eddy_scheme>
+
+<!-- convection schemes -->
+<deep_scheme                     >ZM       </deep_scheme>
+<deep_scheme           silhs="1" >off      </deep_scheme>
+<deep_scheme pbl="none"          >NONE     </deep_scheme>
+
+<yog_scheme                      >off </yog_scheme>
+<yog_nn_weights                  >NONE</yog_nn_weights>
+<yog_nn_scale                    >NONE</yog_nn_scale>
+<SAM_sounding                    >NONE</SAM_sounding>
+
+
+<shallow_scheme pbl="none"         >NONE     </shallow_scheme>
+<shallow_scheme pbl="uw"           >UW       </shallow_scheme>
+<shallow_scheme pbl="hb"           >Hack     </shallow_scheme>
+<shallow_scheme pbl="hbr"          >Hack     </shallow_scheme>
+<shallow_scheme pbl="clubb_sgs"    >CLUBB_SGS</shallow_scheme>
+
+<!-- Cloud fraction -->
+<cldfrc_freeze_dry             >.true.</cldfrc_freeze_dry>
+
+<cldfrc_ice               >.false.</cldfrc_ice>
+<cldfrc_ice phys="cam5"   >.true.</cldfrc_ice>
+<cldfrc_ice phys="cam6"   >.true.</cldfrc_ice>
+<cldfrc_ice phys="cam7"   >.true.</cldfrc_ice>
+
+<cldfrc_rhminl                                                        > 0.900D0 </cldfrc_rhminl>
+<cldfrc_rhminl                   phys="cam5" carma="cirrus"           > 0.910D0 </cldfrc_rhminl>
+<cldfrc_rhminl                   phys="cam5" microphys="mg2"          > 0.950D0 </cldfrc_rhminl>
+<cldfrc_rhminl                   phys="cam5" microphys="mg3"          > 0.950D0 </cldfrc_rhminl>
+
+<cldfrc_rhminl                   phys="cam5"                          > 0.8975D0 </cldfrc_rhminl>
+<cldfrc_rhminl hgrid="1.9x2.5"   phys="cam5" microphys="mg1"          > 0.8875D0 </cldfrc_rhminl>
+<cldfrc_rhminl hgrid="1.9x2.5"   phys="cam5"                          > 0.9125D0 </cldfrc_rhminl>
+
+<cldfrc_rhminl                   phys="cam6"    carma="cirrus"        > 0.910D0 </cldfrc_rhminl>
+<cldfrc_rhminl                   phys="cam6"    microphys="mg2"       > 0.950D0 </cldfrc_rhminl>
+<cldfrc_rhminl                   phys="cam6"    microphys="mg3"       > 0.950D0 </cldfrc_rhminl>
+<cldfrc_rhminl                   phys="cam6"                          > 0.8975D0 </cldfrc_rhminl>
+<cldfrc_rhminl hgrid="1.9x2.5"   phys="cam6"    microphys="mg1"       > 0.8875D0 </cldfrc_rhminl>
+<cldfrc_rhminl hgrid="1.9x2.5"   phys="cam6"                          > 0.9125D0 </cldfrc_rhminl>
+
+<cldfrc_rhminl                   phys="cam7"    carma="cirrus"        > 0.910D0 </cldfrc_rhminl>
+<cldfrc_rhminl                   phys="cam7"    microphys="mg2"       > 0.950D0 </cldfrc_rhminl>
+<cldfrc_rhminl                   phys="cam7"    microphys="mg3"       > 0.950D0 </cldfrc_rhminl>
+<cldfrc_rhminl                   phys="cam7"                          > 0.8975D0 </cldfrc_rhminl>
+<cldfrc_rhminl hgrid="1.9x2.5"   phys="cam7"    microphys="mg1"       > 0.8875D0 </cldfrc_rhminl>
+<cldfrc_rhminl hgrid="1.9x2.5"   phys="cam7"                          > 0.9125D0 </cldfrc_rhminl>
+
+<cldfrc_rhminl hgrid="1.9x2.5"   phys="cam4"                          > 0.910D0 </cldfrc_rhminl>
+<cldfrc_rhminl hgrid="0.9x1.25"  phys="cam4"                          > 0.920D0 </cldfrc_rhminl>
+<cldfrc_rhminl hgrid="0.47x0.63" phys="cam4"                          > 0.920D0 </cldfrc_rhminl>
+<cldfrc_rhminl dyn="se"          phys="cam4"                          > 0.910D0 </cldfrc_rhminl>
+
+<cldfrc_rhminl_adj_land                                               > 0.100D0 </cldfrc_rhminl_adj_land>
+<cldfrc_rhminl_adj_land          phys="cam6"                          > 0.000D0 </cldfrc_rhminl_adj_land>
+<cldfrc_rhminl_adj_land          phys="cam7"                          > 0.000D0 </cldfrc_rhminl_adj_land>
+<cldfrc_rhminl_adj_land                      carma="cirrus"           > 0.000D0 </cldfrc_rhminl_adj_land>
+
+<cldfrc_rhminh                                                        > 0.800D0 </cldfrc_rhminh>
+<cldfrc_rhminh hgrid="0.23x0.31" phys="cam4"                          > 0.770D0 </cldfrc_rhminh>
+<cldfrc_rhminh hgrid="0.47x0.63" phys="cam4"                          > 0.700D0 </cldfrc_rhminh>
+<cldfrc_rhminh hgrid="0.9x1.25"  phys="cam4"                          > 0.770D0 </cldfrc_rhminh>
+<cldfrc_rhminh hgrid="4x5"       phys="cam4" waccm_phys="1"           > 0.900D0 </cldfrc_rhminh>
+<cldfrc_rhminh hgrid="10x15"     phys="cam4" waccm_phys="1"           > 0.900D0 </cldfrc_rhminh>
+
+<cldfrc_sh1                                                           > 0.07D0 </cldfrc_sh1>
+<cldfrc_sh1 dyn="fv"                                                  > 0.04D0 </cldfrc_sh1>
+<cldfrc_sh1 dyn="fv"     hgrid="0.47x0.63"  phys="cam4"               > 0.10D0 </cldfrc_sh1>
+<cldfrc_sh1 dyn="se"                                                  > 0.04D0 </cldfrc_sh1>
+
+<cldfrc_sh2                                                           > 500.0D0 </cldfrc_sh2>
+
+<cldfrc_dp1                                                           > 0.14D0 </cldfrc_dp1>
+<cldfrc_dp1             phys="cam5"                                   > 0.10D0 </cldfrc_dp1>
+<cldfrc_dp1             phys="cam6"                                   > 0.10D0 </cldfrc_dp1>
+<cldfrc_dp1             phys="cam7"                                   > 0.129D0 </cldfrc_dp1>
+<cldfrc_dp1 dyn="fv"    phys="cam4"                                   > 0.10D0 </cldfrc_dp1>
+<cldfrc_dp1 dyn="se"    phys="cam4"                                   > 0.10D0 </cldfrc_dp1>
+
+<cldfrc_dp2                                                           > 500.0D0 </cldfrc_dp2>
+
+<cldfrc_premit                                                        > 75000.0D0 </cldfrc_premit>
+<cldfrc_premit dyn="fv"  hgrid="0.23x0.31"                            > 25000.0D0 </cldfrc_premit>
+<cldfrc_premit dyn="fv"  hgrid="0.47x0.63"                            > 25000.0D0 </cldfrc_premit>
+<cldfrc_premit dyn="fv"  hgrid="0.5x0.625"                            > 25000.0D0 </cldfrc_premit>
+<cldfrc_premit                                      pbl="uw"          > 40000.0D0 </cldfrc_premit>
+<cldfrc_premit dyn="fv"  hgrid="0.23x0.31"          pbl="uw"          > 40000.0D0 </cldfrc_premit>
+<cldfrc_premit dyn="fv"  hgrid="0.47x0.63"          pbl="uw"          > 40000.0D0 </cldfrc_premit>
+<cldfrc_premit dyn="fv"  hgrid="0.5x0.625"          pbl="uw"          > 40000.0D0 </cldfrc_premit>
+<cldfrc_premit dyn="se"                             pbl="uw"          > 40000.0D0 </cldfrc_premit>
+
+<cldfrc_premib                > 750.0D2 </cldfrc_premib>
+<cldfrc_premib  phys="cam5"   > 700.0D2 </cldfrc_premib>
+<cldfrc_premib  phys="cam6"   > 700.0D2 </cldfrc_premib>
+<cldfrc_premib  phys="cam7"   > 700.0D2 </cldfrc_premib>
+
+<cldfrc_iceopt                               > 1 </cldfrc_iceopt>
+<cldfrc_iceopt  phys="cam5"                  > 5 </cldfrc_iceopt>
+<cldfrc_iceopt  phys="cam6"                  > 5 </cldfrc_iceopt>
+<cldfrc_iceopt  phys="cam7"                  > 5 </cldfrc_iceopt>
+<cldfrc_iceopt  phys="cam4"    carma="cirrus"> 4 </cldfrc_iceopt>
+<cldfrc_iceopt  phys="cam5"    carma="cirrus"> 4 </cldfrc_iceopt>
+<cldfrc_iceopt  phys="cam6"    carma="cirrus"> 4 </cldfrc_iceopt>
+<cldfrc_iceopt  phys="cam7"    carma="cirrus"> 4 </cldfrc_iceopt>
+
+<cldfrc_icecrit                              > 0.95D0 </cldfrc_icecrit>
+<cldfrc_icecrit phys="cam5"                  > 0.93D0 </cldfrc_icecrit>
+<cldfrc_icecrit phys="cam6"                  > 0.93D0 </cldfrc_icecrit>
+<cldfrc_icecrit phys="cam7"                  > 0.93D0 </cldfrc_icecrit>
+<cldfrc_icecrit                carma="cirrus"> 0.70D0 </cldfrc_icecrit>
+<cldfrc_icecrit phys="cam5"    carma="cirrus"> 0.70D0 </cldfrc_icecrit>
+<cldfrc_icecrit phys="cam6"    carma="cirrus"> 0.70D0 </cldfrc_icecrit>
+<cldfrc_icecrit phys="cam7"    carma="cirrus"> 0.70D0 </cldfrc_icecrit>
+
+<cldfrc2m_rhmini               >  0.80D0  </cldfrc2m_rhmini>
+<cldfrc2m_rhmini clubb_sgs="1" >  0.80D0  </cldfrc2m_rhmini>
+
+<cldfrc2m_rhminis               >  1.0D0 </cldfrc2m_rhminis>
+
+<cldfrc2m_rhmaxi                                     >  1.1D0  </cldfrc2m_rhmaxi>
+<cldfrc2m_rhmaxi    clubb_sgs="1"                    >  1.0D0  </cldfrc2m_rhmaxi>
+<cldfrc2m_rhmaxi    clubb_sgs="1"     silhs="1"      >  1.05D0 </cldfrc2m_rhmaxi>
+<cldfrc2m_rhmaxis                                    >  1.1D0  </cldfrc2m_rhmaxis>
+<cldfrc2m_rhmaxis   clubb_sgs="1"                    >  1.0D0  </cldfrc2m_rhmaxis>
+
+<cldfrc2m_qist_min               >1.e-7 </cldfrc2m_qist_min>
+<cldfrc2m_qist_max               >5.e-3 </cldfrc2m_qist_max>
+
+<micro_mg_adjust_cpt>.false.</micro_mg_adjust_cpt>
+
+<cldfrc2m_do_subgrid_growth               >.false.</cldfrc2m_do_subgrid_growth>
+<cldfrc2m_do_subgrid_growth phys="cam6"   >.true.</cldfrc2m_do_subgrid_growth>
+<cldfrc2m_do_subgrid_growth phys="cam7"   >.true.</cldfrc2m_do_subgrid_growth>
+
+<cldfrc2m_do_avg_aist_algs                >.false.</cldfrc2m_do_avg_aist_algs>
+
+<!-- Cldwat -->
+<rk_strat_icritc                                                        >  5.0e-6  </rk_strat_icritc>
+<rk_strat_icritc  hgrid="0.23x0.31"                                     > 45.0e-6  </rk_strat_icritc>
+<rk_strat_icritc  hgrid="0.47x0.63"                                     > 45.0e-6  </rk_strat_icritc>
+<rk_strat_icritc  hgrid="0.5x0.625"                                     > 45.0e-6  </rk_strat_icritc>
+<rk_strat_icritc  hgrid="0.9x1.25"                                      > 18.0e-6  </rk_strat_icritc>
+<rk_strat_icritc  hgrid="1x1.25"                                        > 18.0e-6  </rk_strat_icritc>
+<rk_strat_icritc  hgrid="1.9x2.5"                                       >  9.5e-6  </rk_strat_icritc>
+<rk_strat_icritc  hgrid="2x2.5"                                         >  9.5e-6  </rk_strat_icritc>
+<rk_strat_icritc  hgrid="4x5"                                           >  9.5e-6  </rk_strat_icritc>
+<rk_strat_icritc  hgrid="10x15"                                         >  9.5e-6  </rk_strat_icritc>
+
+<rk_strat_icritc  dyn="se"                                              > 18.0e-6  </rk_strat_icritc>
+
+<rk_strat_icritw                                                        >  4.0e-4  </rk_strat_icritw>
+<rk_strat_icritw  dyn="fv"                                              >  2.0e-4  </rk_strat_icritw>
+<rk_strat_icritw  dyn="fv"  hgrid="0.47x0.63"   phys="cam4"             >  2.0e-6  </rk_strat_icritw>
+<rk_strat_icritw  dyn="se"                                              >  2.0e-4  </rk_strat_icritw>
+
+<rk_strat_conke                                                        >  10.0e-6 </rk_strat_conke>
+<rk_strat_conke dyn="fv"                                               >  5.0e-6  </rk_strat_conke>
+<rk_strat_conke dyn="se"                                               >  5.0e-6  </rk_strat_conke>
+
+<rk_strat_r3lcrit                                                      >  10.0e-6  </rk_strat_r3lcrit>
+
+<!-- hkconv Moist Convection -->
+<hkconv_cmftau> 1800.0D0 </hkconv_cmftau>
+<hkconv_c0 dyn="fv"                                                >  1.0e-4 </hkconv_c0>
+<hkconv_c0 dyn="fv"   hgrid="0.23x0.31"                            >  5.0e-5 </hkconv_c0>
+<hkconv_c0 dyn="fv"   hgrid="0.47x0.63"                            >  5.0e-5 </hkconv_c0>
+<hkconv_c0 dyn="fv"   hgrid="0.5x0.625"                            >  5.0e-5 </hkconv_c0>
+<hkconv_c0 dyn="fv"   hgrid="4x5"                                  >  2.0e-4 </hkconv_c0>
+
+<hkconv_c0                                                         >  2.0e-4 </hkconv_c0>
+<hkconv_c0   dyn="se"                                              >  1.0e-4 </hkconv_c0>
+
+<!-- uwshcu Moist Convection -->
+<uwshcu_rpen                                                       >  10.0 </uwshcu_rpen>
+<uwshcu_rpen hgrid="1.9x2.5"                                       >   5.0 </uwshcu_rpen>
+
+<uwshcu_rpen dyn="se"                                              >   5.0 </uwshcu_rpen>
+
+<!-- zm conv -->
+
+<zmconv_momcu                                                         > 0.4000D0 </zmconv_momcu>
+<zmconv_momcu  clubb_sgs="1" microphys="mg2"                          > 0.7000D0 </zmconv_momcu>
+<zmconv_momcu  clubb_sgs="1" microphys="mg3"                          > 0.7000D0 </zmconv_momcu>
+
+<zmconv_momcd                                                         > 0.4000D0 </zmconv_momcd>
+<zmconv_momcd  clubb_sgs="1" microphys="mg2"                          > 0.7000D0 </zmconv_momcd>
+<zmconv_momcd  clubb_sgs="1" microphys="mg3"                          > 0.7000D0 </zmconv_momcd>
+
+<zmconv_c0_lnd                                                        > 0.0030D0 </zmconv_c0_lnd>
+<zmconv_c0_lnd                                    phys="cam5"         > 0.0059D0 </zmconv_c0_lnd>
+<zmconv_c0_lnd                   hgrid="ne120np4" phys="cam5"         > 0.0035D0 </zmconv_c0_lnd>
+<zmconv_c0_lnd                   hgrid="C384"     phys="cam5"         > 0.0035D0 </zmconv_c0_lnd>
+<zmconv_c0_lnd  microphys="mg2"  clubb_sgs="1"    phys="cam5"         > 0.0075D0 </zmconv_c0_lnd>
+<zmconv_c0_lnd  microphys="mg3"  clubb_sgs="1"    phys="cam5"         > 0.0075D0 </zmconv_c0_lnd>
+<zmconv_c0_lnd                                    phys="cam6"         > 0.0059D0 </zmconv_c0_lnd>
+<zmconv_c0_lnd                   hgrid="ne120np4" phys="cam6"         > 0.0035D0 </zmconv_c0_lnd>
+<zmconv_c0_lnd                   hgrid="C384"     phys="cam6"         > 0.0035D0 </zmconv_c0_lnd>
+<zmconv_c0_lnd  microphys="mg2"  clubb_sgs="1"    phys="cam6"         > 0.0075D0 </zmconv_c0_lnd>
+<zmconv_c0_lnd  microphys="mg3"  clubb_sgs="1"    phys="cam6"         > 0.0075D0 </zmconv_c0_lnd>
+<zmconv_c0_lnd                                    phys="cam7"         > 0.0059D0 </zmconv_c0_lnd>
+<zmconv_c0_lnd                   hgrid="ne120np4" phys="cam7"         > 0.0035D0 </zmconv_c0_lnd>
+<zmconv_c0_lnd                   hgrid="C384"     phys="cam7"         > 0.0035D0 </zmconv_c0_lnd>
+<zmconv_c0_lnd  microphys="mg2"  clubb_sgs="1"    phys="cam7"         > 0.0075D0 </zmconv_c0_lnd>
+<zmconv_c0_lnd  microphys="mg3"  clubb_sgs="1"    phys="cam7"         > 0.00549D0 </zmconv_c0_lnd>
+<zmconv_c0_lnd  dyn="fv"                          phys="cam4"         > 0.0035D0 </zmconv_c0_lnd>
+<zmconv_c0_lnd  dyn="se"                          phys="cam4"         > 0.0035D0 </zmconv_c0_lnd>
+
+<zmconv_c0_ocn                                                        > 0.0030D0 </zmconv_c0_ocn>
+<zmconv_c0_ocn                                    phys="cam5"         > 0.0450D0 </zmconv_c0_ocn>
+<zmconv_c0_ocn                   hgrid="ne120np4" phys="cam5"         > 0.0035D0 </zmconv_c0_ocn>
+<zmconv_c0_ocn                   hgrid="C384"     phys="cam5"         > 0.0035D0 </zmconv_c0_ocn>
+<zmconv_c0_ocn                                    phys="cam6"         > 0.0450D0 </zmconv_c0_ocn>
+<zmconv_c0_ocn                   hgrid="ne120np4" phys="cam6"         > 0.0035D0 </zmconv_c0_ocn>
+<zmconv_c0_ocn                   hgrid="C384"     phys="cam6"         > 0.0035D0 </zmconv_c0_ocn>
+<zmconv_c0_ocn  microphys="mg2"  clubb_sgs="1"    phys="cam6"         > 0.0300D0 </zmconv_c0_ocn>
+<zmconv_c0_ocn  microphys="mg3"  clubb_sgs="1"    phys="cam6"         > 0.0300D0 </zmconv_c0_ocn>
+<zmconv_c0_ocn                                    phys="cam7"         > 0.0450D0 </zmconv_c0_ocn>
+<zmconv_c0_ocn                   hgrid="ne120np4" phys="cam7"         > 0.0035D0 </zmconv_c0_ocn>
+<zmconv_c0_ocn                   hgrid="C384"     phys="cam7"         > 0.0035D0 </zmconv_c0_ocn>
+<zmconv_c0_ocn  microphys="mg2"  clubb_sgs="1"    phys="cam7"         > 0.0300D0 </zmconv_c0_ocn>
+<zmconv_c0_ocn  microphys="mg3"  clubb_sgs="1"    phys="cam7"         > 0.0300D0 </zmconv_c0_ocn>
+<zmconv_c0_ocn  dyn="fv"                          phys="cam4"         > 0.0035D0 </zmconv_c0_ocn>
+<zmconv_c0_ocn  dyn="se"                          phys="cam4"         > 0.0035D0 </zmconv_c0_ocn>
+
+<zmconv_ke_lnd                                                        > 3.0E-6 </zmconv_ke_lnd>
+<zmconv_ke_lnd  clubb_sgs="1"  microphys="mg2"                        > 1.0E-5 </zmconv_ke_lnd>
+<zmconv_ke_lnd  clubb_sgs="1"  microphys="mg3"                        > 1.0E-5 </zmconv_ke_lnd>
+
+<zmconv_ke                                                            > 3.0E-6 </zmconv_ke>
+<zmconv_ke      dyn="fv"                                              > 5.0E-6 </zmconv_ke>
+<zmconv_ke      dyn="se"                                              > 5.0E-6 </zmconv_ke>
+
+<zmconv_num_cin                                                       > 5       </zmconv_num_cin>
+<zmconv_num_cin                                       phys="cam6"     > 1       </zmconv_num_cin>
+<zmconv_num_cin                                       phys="cam7"     > 1       </zmconv_num_cin>
+
+<zmconv_dmpdz                                                         > -1.0E-3 </zmconv_dmpdz>
+<zmconv_tiedtke_add                                                    > 0.5     </zmconv_tiedtke_add>
+<zmconv_capelmt                                                       > 70.0    </zmconv_capelmt>
+<zmconv_tau                                                           > 3600.0    </zmconv_tau>
+
+<zmconv_parcel_pbl                                                    > .false. </zmconv_parcel_pbl>
+<zmconv_parcel_hscale                                                 >  0.5    </zmconv_parcel_hscale>
+
+<!-- Cloud sedimentation -->
+
+<cldsed_ice_stokes_fac                                    > 1.0D0 </cldsed_ice_stokes_fac>
+<cldsed_ice_stokes_fac waccm_phys="1"                     > 0.5D0 </cldsed_ice_stokes_fac>
+<cldsed_ice_stokes_fac hgrid="1.9x2.5"   phys="cam4"      > 0.5D0 </cldsed_ice_stokes_fac>
+
+<!-- FV dycore -->
+<fv_fft_flt              >1</fv_fft_flt>
+
+<fv_div24del2flag                                       > 2</fv_div24del2flag>
+<fv_div24del2flag                   phys="cam5"         > 4</fv_div24del2flag>
+<fv_div24del2flag                   phys="cam6"         > 4</fv_div24del2flag>
+<fv_div24del2flag                   phys="cam7"         > 4</fv_div24del2flag>
+<fv_div24del2flag hgrid="0.23x0.31" phys="cam4"         >42</fv_div24del2flag>
+<fv_div24del2flag hgrid="0.47x0.63" phys="cam4"         >42</fv_div24del2flag>
+<fv_div24del2flag hgrid="0.23x0.31" phys="cam5"         >42</fv_div24del2flag>
+<fv_div24del2flag hgrid="0.47x0.63" phys="cam5"         >42</fv_div24del2flag>
+<fv_div24del2flag hgrid="0.23x0.31" phys="cam6"         >42</fv_div24del2flag>
+<fv_div24del2flag hgrid="0.23x0.31" phys="cam7"         >42</fv_div24del2flag>
+<fv_div24del2flag hgrid="0.47x0.63" phys="cam6"         >42</fv_div24del2flag>
+<fv_div24del2flag hgrid="0.47x0.63" phys="cam7"         >42</fv_div24del2flag>
+
+<fv_nspltvrm                  >1</fv_nspltvrm>
+<fv_nspltvrm hgrid="0.9x1.25" >2</fv_nspltvrm>
+<fv_nspltvrm hgrid="0.47x0.63">2</fv_nspltvrm>
+<fv_nspltvrm hgrid="0.23x0.31">2</fv_nspltvrm>
+<fv_nspltvrm                  waccm_phys="1">2</fv_nspltvrm>
+<fv_nspltvrm hgrid="0.9x1.25" waccm_phys="1">4</fv_nspltvrm>
+<fv_nspltvrm hgrid="0.47x0.63"    waccmx="1">16</fv_nspltvrm>
+
+<fv_nspltrac                  waccm_phys="1">2</fv_nspltrac>
+<fv_nspltrac hgrid="0.9x1.25" waccm_phys="1">4</fv_nspltrac>
+<fv_nspltrac hgrid="0.47x0.63"    waccmx="1">16</fv_nspltrac>
+
+<fv_nsplit                  waccm_phys="1"> 8</fv_nsplit>
+<fv_nsplit hgrid="0.9x1.25" waccm_phys="1">16</fv_nsplit>
+<fv_nsplit hgrid="0.47x0.63"    waccmx="1">32</fv_nsplit>
+
+<fv_del2coef                >3.e+5</fv_del2coef>
+
+<fv_filtcw                  >0</fv_filtcw>
+<fv_filtcw hgrid="0.23x0.31">1</fv_filtcw>
+
+<fv_am_correction               > .false.</fv_am_correction>
+<fv_am_fixer                    > .false.</fv_am_fixer>
+<fv_am_fix_lbl                  > .false.</fv_am_fix_lbl>
+<fv_am_diag                     > .false.</fv_am_diag>
+<fv_am_correction     silhs="1" > .true. </fv_am_correction>
+<fv_am_fixer          silhs="1" > .true. </fv_am_fixer>
+<fv_am_fix_lbl        silhs="1" > .true. </fv_am_fix_lbl>
+<fv_am_diag           silhs="1" > .true. </fv_am_diag>
+
+
+<!-- default namelist for SCAM mode -->
+<nhtfrq                          scam="1"                   > 1         </nhtfrq>
+<mfilt                           scam="1"                   > 10000     </mfilt>
+<scm_use_obs_uv                  scam="1"                   > .true.    </scm_use_obs_uv>
+<scale_dry_air_mass              scam="1"        dyn="se"   > 0.0D0     </scale_dry_air_mass>
+<scm_relaxation                  scam="1"                   > .true.    </scm_relaxation>
+<scm_relax_tau_sec               scam="1"                   > 10800._r8 </scm_relax_tau_sec>
+<scm_relax_fincl   phys="cam6"   scam="1"  >
+  'T', 'bc_a1', 'bc_a4', 'dst_a1', 'dst_a2', 'dst_a3', 'ncl_a1', 'ncl_a2', 'ncl_a3',
+  'num_a1', 'num_a2', 'num_a3', 'num_a4', 'pom_a1', 'pom_a4', 'so4_a1', 'so4_a2', 'so4_a3', 'soa_a1', 'soa_a2'
+</scm_relax_fincl>
+<scm_relax_fincl   phys="cam5"   scam="1"  >
+  'T', 'bc_a1', 'bc_a4', 'dst_a1', 'dst_a2', 'dst_a3', 'ncl_a1', 'ncl_a2', 'ncl_a3',
+  'num_a1', 'num_a2', 'num_a3', 'num_a4', 'pom_a1', 'pom_a4', 'so4_a1', 'so4_a2', 'so4_a3', 'soa_a1', 'soa_a2'
+</scm_relax_fincl>
+<scm_relax_fincl   phys="cam7"   scam="1"  >
+  'T', 'bc_a1', 'bc_a4', 'dst_a1', 'dst_a2', 'dst_a3', 'ncl_a1', 'ncl_a2', 'ncl_a3',
+  'num_a1', 'num_a2', 'num_a3', 'num_a4', 'pom_a1', 'pom_a4', 'so4_a1', 'so4_a2', 'so4_a3', 'soa_a1', 'soa_a2'
+</scm_relax_fincl>
+<scm_relax_bot_p                 scam="1"                  > 105000.D0  </scm_relax_bot_p>
+<scm_relax_top_p                 scam="1"                  > 200.D0     </scm_relax_top_p>
+<scm_relax_linear                scam="1"                  > .true.     </scm_relax_linear>
+<scm_relax_tau_bot_sec           scam="1"                  > 864000.D0  </scm_relax_tau_bot_sec>
+<scm_relax_tau_top_sec           scam="1"                  > 172800.D0  </scm_relax_tau_top_sec>
+
+
+<!-- IOP SCAM defaults (The Single Column Atmosphere Model Version 6 (SCAM6), J. Adv. Model. Earth Sy., 11, 1381-1401, https://doi.org/10.1029/2018MS001578-->
+
+<!-- IOP ARM95/ARM Southern Great Plains/lat:36/lon:263/Jul 1995/18d/M. Zhang et al. (2016)/Land convection -->
+<ncdata             hgrid="ne3np4"    nlev="32"       scam_iop="arm95"     >atm/cam/inic/se/CESM2.F2000climo.ne3np4.cam.i.0003-06-01-00000.nc</ncdata>
+<iopfile                                              scam_iop="arm95"     >atm/cam/scam/iop/ARM95_4scam.nc</iopfile>
+<co2vmr                                               scam_iop="arm95"     > 368.9e-6  </co2vmr>
+
+<!-- IOP ARM97/ARM Southern Great Plains/lat:36/lon:263/Jun 1997/30d/M. Zhang et al. (2016) Land convection -->
+<ncdata             hgrid="ne3np4"    nlev="32"       scam_iop="arm95"     >atm/cam/inic/se/CESM2.F2000climo.ne3np4.cam.i.0003-06-01-00000.nc</ncdata>
+<iopfile                                              scam_iop="arm97"     >atm/cam/scam/iop/ARM97_4scam.nc</iopfile>
+<co2vmr                                               scam_iop="arm97"     > 368.9e-6  </co2vmr>
+
+<!-- IOP ATEX/Atlantic Trade Wind Exp/lat:15/lon:345/Feb 1969/2d/Augstein et al. (1973) Shallow cumulus -->
+<ncdata             hgrid="ne3np4"    nlev="32"       scam_iop="atex"      >atm/cam/inic/se/CESM2.F2000climo.ne3np4.cam.i.0003-02-01-00000.nc</ncdata>
+<iopfile                                              scam_iop="atex"      >atm/cam/scam/iop/ATEX_48hr_4scam.nc</iopfile>
+
+<!-- IOP BOMEX/Barbados Ocean and Met Exp/lat:15/lon:300/Jun 1969/5d/Holland and Rasmusson (1973) Shallow cumulus -->
+<ncdata             hgrid="ne3np4"    nlev="32"       scam_iop="bomex"     >atm/cam/inic/se/CESM2.F2000climo.ne3np4.cam.i.0003-06-01-00000.nc</ncdata>
+<iopfile                                              scam_iop="bomex"     >atm/cam/scam/iop/BOMEX_5day_4scam.nc</iopfile>
+
+<!-- IOP CGILSS11/CFMIP-GASS SCM/LES Intercomparison/lat:32/lon:231/Jul 1997/30d/M. Zhang et al. (2013) Stratocumulus -->
+<ncdata             hgrid="ne3np4"    nlev="32"       scam_iop="cgilsS11"  >atm/cam/inic/se/CESM2.F2000climo.ne3np4.cam.i.0003-07-01-00000.nc</ncdata>
+<iopfile                                              scam_iop="cgilsS11"  >atm/cam/scam/iop/S11_CTL_MixedLayerInit_reduced.nc</iopfile>
+
+<!-- IOP CGILSS12/CFMIP-GASS SCM/LES Intercomparison/lat:35/lon:235/Jul 1997/30d/M. Zhang et al. (2013) Stratus -->
+<ncdata             hgrid="ne3np4"    nlev="32"       scam_iop="cgilsS12"  >atm/cam/inic/se/CESM2.F2000climo.ne3np4.cam.i.0003-07-01-00000.nc</ncdata>
+<iopfile                                              scam_iop="cgilsS12"  >atm/cam/scam/iop/S12_CTL_MixedLayerInit_reduced.nc</iopfile>
+
+<!-- IOP CGILSS6/CFMIP-GASS SCM/LES Intercomparison/lat:17/lon:211/Jul 1997/30d/M. Zhang et al. (2013) Shallow cumulus -->
+<ncdata             hgrid="ne3np4"    nlev="32"       scam_iop="cgilsS6"   >atm/cam/inic/se/CESM2.F2000climo.ne3np4.cam.i.0003-07-01-00000.nc</ncdata>
+<iopfile                                              scam_iop="cgilsS6"   >atm/cam/scam/iop/S6_CTL_reduced.nc</iopfile>
+
+<!-- IOP DYCOMSRF01/Dynamics of Marine StratoCu/lat:32/lon:239/Jul 15/2001/2d Stevens et al. (2003) Stratocumulus -->
+<ncdata             hgrid="ne3np4"    nlev="32"       scam_iop="dycomsRF01">atm/cam/inic/se/CESM2.F2000climo.ne3np4.cam.i.0003-07-01-00000.nc</ncdata>
+<iopfile                                              scam_iop="dycomsRF01">atm/cam/scam/iop/DYCOMSrf01_4day_4scam.nc</iopfile>
+
+<!-- IOP DYCOMSRF02/Dynamics of Marine StratoCu/lat:32/lon:239/Jul 11/2001/2d Stevens et al. (2003) Stratocumulus -->
+<ncdata             hgrid="ne3np4"    nlev="32"       scam_iop="dycomsRF02">atm/cam/inic/se/CESM2.F2000climo.ne3np4.cam.i.0003-07-01-00000.nc</ncdata>
+<iopfile                                              scam_iop="dycomsRF02">atm/cam/scam/iop/DYCOMSrf02_48hr_4scam.nc</iopfile>
+
+<!-- IOP GATEIII/GARP Atlantic Tropical Experiment Phase III/lat:9/lon:336/Aug 1974/20d/Thompson et al.(1979) Tropical convection -->
+<ncdata             hgrid="ne3np4"    nlev="32"       scam_iop="gateiii"   >atm/cam/inic/se/CESM2.F2000climo.ne3np4.cam.i.0003-08-01-00000.nc</ncdata>
+<iopfile                                              scam_iop="gateiii"   >atm/cam/scam/iop/GATEIII_4scam_c170809.nc</iopfile>
+
+<!-- IOP MICRE/Macquarie Island Cloud Radiation Experiment/lat:-56/lon:141/2017/90d/Marchand R. 2020/Marine -->
+<ncdata             hgrid="ne3np4"    nlev="32"       scam_iop="micre2017" >atm/cam/scam/iop/micre2017_3mo.cam.i.2017-01-01-00000.regrid.ne3np4.nc</ncdata>
+<iopfile                                              scam_iop="micre2017" >atm/cam/scam/iop/micre2017_3mo.macquarie2017.iop.nc</iopfile>
+
+<!-- IOP MPACE/Mixed Phase Arctic Clouds Exp/lat:71/lon:206/Oct 2004/17d/Verlinde et al. (2007)/Arctic -->
+<ncdata             hgrid="ne3np4"    nlev="32"       scam_iop="mpace"     >atm/cam/inic/se/CESM2.F2000climo.ne3np4.cam.i.0003-10-01-00000.nc</ncdata>
+<iopfile                                              scam_iop="mpace"     >atm/cam/scam/iop/MPACE_4scam.nc</iopfile>
+<fincl1                                               scam_iop="mpace"     >
+        'CLDST', 'CNVCLD',
+        'ICWMR','ICIMR','FREQL','FREQI','LANDFRAC','CDNUMC','FICE','WSUB','CCN3','ICLDIWP',
+        'CDNUMC', 'AQSNOW',  'WSUB', 'CCN3', 'FREQI', 'FREQL', 'FREQR', 'FREQS', 'CLDLIQ', 'CLDICE',
+        'FSDS', 'FLDS','AREL','AREI','NSNOW','QSNOW','DSNOW',
+        'FLNT','FLNTC','FSNT','FSNTC','FSNS','FSNSC','FLNT','FLNTC','QRS','QRSC','QRL','QRLC',
+        'LWCF','SWCF', 'NCAI', 'NCAL', 'NIHF','NIDEP','NIIMM','NIMEY','ICLDIWP','ICLDTWP', 'CONCLD',
+        'QCSEVAP', 'QISEVAP', 'QVRES', 'CMELIQ', 'CMEIOUT', 'EVAPPREC', 'EVAPSNOW', 'TAQ',
+        'ICLMRCU', 'ICIMRCU' ,'ICWMRSH' ,'ICWMRDP', 'ICLMRTOT' , 'ICIMRTOT' , 'SH_CLD' ,  'DP_CLD',
+        'LIQCLDF','ICECLDF', 'ICWMRST', 'ICIMRST', 'EFFLIQ', 'EFFICE','ADRAIN','ADSNOW','WSUBI',
+        'TGCLDLWP','GCLDLWP'
+</fincl1>
+
+<!-- IOP RICO/Rain and Cumulus over Oceans/lat:18/lon:299/Dec 2004/3d/Rauber et al. (2007)/Shallow cumulus -->
+<ncdata             hgrid="ne3np4"    nlev="32"       scam_iop="rico"      >atm/cam/inic/se/CESM2.F2000climo.ne3np4.cam.i.0003-07-01-00000.nc</ncdata>
+<iopfile                                              scam_iop="rico"      >atm/cam/scam/iop/RICO_3day_4scam.nc</iopfile>
+
+<!-- IOP SAS/The Southeast Atmosphere Study (SAS) campaign/lat:32/lon:272/June 2013/30d/Carlton (2018)/Southeast US Air Chemistry -->
+<ncdata             hgrid="ne3np4"    nlev="32"       scam_iop="SAS"       >atm/cam/inic/se/CESM2.F2000climo.ne3np4.cam.i.0003-06-01-00000.nc</ncdata>
+<iopfile                                              scam_iop="SAS"       >atm/cam/scam/iop/SAS_ideal_4scam.nc</iopfile>
+<co2vmr                                               scam_iop="SAS"       > 368.9e-6  </co2vmr>
+<use_gw_front                                         scam_iop="SAS"       > .false.   </use_gw_front>
+<scm_backfill_iop_w_init                              scam_iop="SAS"       > .true.    </scm_backfill_iop_w_init>
+
+<!-- IOP SPARTICUS/Small Particles in Cirrus/lat:37/lon:263/Apr 2010/30d/Mace et al. (2009)/Cirrus, convection -->
+<ncdata             hgrid="ne3np4"    nlev="32"       scam_iop="sparticus" >atm/cam/inic/se/CESM2.F2000climo.ne3np4.cam.i.0003-04-01-00000.nc</ncdata>
+<iopfile                                              scam_iop="sparticus" >atm/cam/scam/iop/SPARTICUS_4scam.nc</iopfile>
+
+<!-- IOP TOGAII/Tropical Ocean Global Atmosphere IOP2/lat:-2/lon:154/Dec 1992/21d/Webster and Lukas (1992)/Tropical convection -->
+<ncdata             hgrid="ne3np4"    nlev="32"       scam_iop="togaII" >atm/cam/inic/se/CESM2.F2000climo.ne3np4.cam.i.0003-12-01-00000.nc</ncdata>
+<iopfile                                              scam_iop="togaII" >atm/cam/scam/iop/TOGAII_4scam.nc</iopfile>
+
+<!-- IOP TWP06/Tropical W. Pacific Convection/lat:-12/lon:131/Jan 2006/26d/May et al. (2008)/Tropical convection -->
+<ncdata             hgrid="ne3np4"    nlev="32"       scam_iop="twp06" >atm/cam/inic/se/CESM2.F2000climo.ne3np4.cam.i.0003-01-01-00000.nc</ncdata>
+<iopfile                                              scam_iop="twp06" >atm/cam/scam/iop/TWP06_4scam.nc</iopfile>
+<iradlw                                               scam_iop="twp06" > 1  </iradlw>
+<iradsw                                               scam_iop="twp06" > 1  </iradsw>
+
+<!-- IOP USER/User specified IOP forcing/lat:yy/lon:xx/Date:Any/Length:Any/-These are just defaults and can be updated by the user via cime_config/usermods_dir -->
+<ncdata            hgrid="ne3np4"    nlev="32"        scam_iop="camfrc"     >atm/cam/inic/se/CESM2.F2000climo.ne3np4.cam.i.0003-06-01-00000.nc</ncdata>
+<iopfile                                              scam_iop="camfrc"     >atm/cam/scam/iop/ARM97_4scam.nc</iopfile>
+
+<!-- Control output to history file(s) -->
+<history_amwg>                 .true.   </history_amwg>
+<history_vdiag>                .false.  </history_vdiag>
+<history_aerosol>              .false.  </history_aerosol>
+<history_aero_optics>          .false.  </history_aero_optics>
+<history_eddy>                 .false.  </history_eddy>
+<history_budget>               .false.  </history_budget>
+<history_waccm>                .false.  </history_waccm>
+<history_waccm waccm_phys="1" model_top="mt">.false.</history_waccm>
+<history_waccm waccm_phys="1"> .true.   </history_waccm>
+<history_waccmx>               .false.  </history_waccmx>
+<history_waccmx waccmx="1">    .true.   </history_waccmx>
+<history_chemistry>            .true.   </history_chemistry>
+<history_chemspecies_srf>      .true.   </history_chemspecies_srf>
+<history_clubb>                .true.   </history_clubb>
+<history_dust>                 .false.  </history_dust>
+
+<cam_snapshot_before_num>  -1 </cam_snapshot_before_num>
+<cam_snapshot_after_num>   -1 </cam_snapshot_after_num>
+
+<!-- ================================================================== -->
+<!-- Defaults for composition of air                                    -->
+<!-- ================================================================== -->
+<dry_air_species                           >''</dry_air_species>
+<dry_air_species    waccmx="1"             >'O', 'O2', 'H', 'N2'</dry_air_species>
+
+<water_species_in_air                                    >'Q'                                             </water_species_in_air>
+<water_species_in_air microphys="none" phys="adiabatic"  >'Q'                                             </water_species_in_air>
+<water_species_in_air microphys="none" phys="held_suarez">'Q'                                             </water_species_in_air>
+<water_species_in_air microphys="none" phys="kessler"    >'Q','CLDLIQ','RAINQM'                           </water_species_in_air>
+<water_species_in_air microphys="rk"                     >'Q','CLDLIQ','CLDICE'                           </water_species_in_air>
+<water_species_in_air microphys="mg1"                    >'Q','CLDLIQ','CLDICE'                           </water_species_in_air>
+<water_species_in_air microphys="mg2"                    >'Q','CLDLIQ','CLDICE','RAINQM','SNOWQM'         </water_species_in_air>
+<water_species_in_air microphys="mg3"                    >'Q','CLDLIQ','CLDICE','RAINQM','SNOWQM','GRAUQM'</water_species_in_air>
+
+<!-- ================================================================== -->
+<!-- Defaults for FV3                                                   -->
+<!-- ================================================================== -->
+
+<fv3_clock_grain dyn="fv3"  >LOOP</fv3_clock_grain>
+
+<fv3_domains_stack_size dyn="fv3">6000000</fv3_domains_stack_size>
+<fv3_stack_size         dyn="fv3">6000000</fv3_stack_size>
+
+<fv3_print_memory_usage dyn="fv3">.true.</fv3_print_memory_usage>
+
+<fv3_adjust_dry_mass                                                        > .false.   </fv3_adjust_dry_mass>
+<fv3_beta                                                                   > 0         </fv3_beta>
+<fv3_consv_am                                                               > .false.   </fv3_consv_am>
+<fv3_consv_te                                                               > 0         </fv3_consv_te>
+<fv3_dddmp                                                                  > 0.0D0     </fv3_dddmp>
+<fv3_delt_max                                                               > 0.0D0     </fv3_delt_max>
+<fv3_dnats                                                                  > 0         </fv3_dnats>
+<fv3_do_sat_adj                                                             > .false.   </fv3_do_sat_adj>
+<fv3_do_vort_damp      dyn="fv3nh"                                          > .true.    </fv3_do_vort_damp>
+<fv3_do_vort_damp      dyn="fv3"                                            > .false.   </fv3_do_vort_damp>
+<fv3_dwind_2d                                                               > .false.   </fv3_dwind_2d>
+<fv3_d_con             dyn="fv3"                                            > 0         </fv3_d_con>
+<fv3_d_con             dyn="fv3nh"                                          > 0         </fv3_d_con>
+<fv3_d_ext                                                                  > 0         </fv3_d_ext>
+<fv3_d2_bg                                                                  > 0         </fv3_d2_bg>
+<fv3_d2_bg_k1                                                               > 0.15D0   </fv3_d2_bg_k1>
+<fv3_d2_bg_k2                                                               > 0.02D0   </fv3_d2_bg_k2>
+<fv3_d4_bg                                                                  > 0.15D0   </fv3_d4_bg>
+<fv3_fill                                                                   > .true.    </fv3_fill>
+<fv3_fv_debug                                                               > .false.   </fv3_fv_debug>
+<fv3_fv_diag                                                                > .false.   </fv3_fv_diag>
+<fv3_lcp_moist dyn="fv3"                                                    > .true.   </fv3_lcp_moist>
+<fv3_lcv_moist dyn="fv3"                                                    > .false.  </fv3_lcv_moist>
+<fv3_nwat                                                                   > 3         </fv3_nwat>
+<fv3_nwat phys="cam4"                                                       > 3         </fv3_nwat>
+<fv3_nwat phys="cam5"                                                       > 3         </fv3_nwat>
+<fv3_nwat phys="cam6"                                                       > 5         </fv3_nwat>
+<fv3_nwat phys="cam7"                                                       > 5         </fv3_nwat>
+<fv3_nwat phys="cam6"    microphys="mg3"                                    > 6         </fv3_nwat>
+<fv3_nwat phys="cam7"    microphys="mg3"                                    > 6         </fv3_nwat>
+<fv3_nwat phys="held_suarez"                                                > 1         </fv3_nwat>
+<fv3_nwat phys="adiabatic"                                                  > 1         </fv3_nwat>
+<fv3_nwat phys="kessler"                                                    > 3         </fv3_nwat>
+<fv3_nwat phys="tj2016"                                                     > 1         </fv3_nwat>
+<fv3_nwat phys="grayrad"                                                    > 1         </fv3_nwat>
+<fv3_fv_sg_adj                                                              > 0         </fv3_fv_sg_adj>
+<fv3_grid_type                                                              > 0         </fv3_grid_type>
+<fv3_hord_dp        dyn="fv3"                                               > -10        </fv3_hord_dp>
+<fv3_hord_mt        dyn="fv3"                                               > 10         </fv3_hord_mt>
+<fv3_hord_tm        dyn="fv3"                                               > 10         </fv3_hord_tm>
+<fv3_hord_tr                                                                > 8          </fv3_hord_tr>
+<fv3_hord_vt        dyn="fv3"                                               > 10         </fv3_hord_vt>
+<fv3_hord_dp        dyn="fv3nh"                                             > -5        </fv3_hord_dp>
+<fv3_hord_mt        dyn="fv3nh"                                             > 5         </fv3_hord_mt>
+<fv3_hord_tm        dyn="fv3nh"                                             > 5         </fv3_hord_tm>
+<fv3_hord_vt        dyn="fv3nh"                                             > 5         </fv3_hord_vt>
+<fv3_hydrostatic    dyn="fv3"                                               > .true.    </fv3_hydrostatic>
+<fv3_hydrostatic    dyn="fv3nh"                                             > .false.   </fv3_hydrostatic>
+<fv3_ke_bg                                                                  > 0         </fv3_ke_bg>
+<fv3_kord_mt                                                                > 9         </fv3_kord_mt>
+<fv3_kord_tm                                                                > -9        </fv3_kord_tm>
+<fv3_kord_tr                                                                > 9         </fv3_kord_tr>
+<fv3_kord_wz                                                                > 9         </fv3_kord_wz>
+<fv3_k_split                                                                > 2         </fv3_k_split>
+<fv3_make_nh                                                                > .false.   </fv3_make_nh>
+<fv3_na_init                                                                > 0         </fv3_na_init>
+<fv3_nord                                                                   > 3         </fv3_nord>
+<fv3_no_dycore                                                              > .false.   </fv3_no_dycore>
+<!-- grid corners in x-direction per tile ============================== -->
+<fv3_npx                                       hgrid="C24"                  > 25        </fv3_npx>
+<fv3_npx                                       hgrid="C48"                  > 49        </fv3_npx>
+<fv3_npx                                       hgrid="C96"                  > 97        </fv3_npx>
+<fv3_npx                                       hgrid="C192"                 > 193       </fv3_npx>
+<fv3_npx                                       hgrid="C384"                 > 385       </fv3_npx>
+<!-- grid corners in y-direction per tile ============================== -->
+<fv3_npy                                       hgrid="C24"                  > 25        </fv3_npy>
+<fv3_npy                                       hgrid="C48"                  > 49        </fv3_npy>
+<fv3_npy                                       hgrid="C96"                  > 97        </fv3_npy>
+<fv3_npy                                       hgrid="C192"                 > 193       </fv3_npy>
+<fv3_npy                                       hgrid="C384"                 > 385       </fv3_npy>
+<fv3_ntiles                                                                 > 6         </fv3_ntiles>
+<fv3_n_split                                                                > 6         </fv3_n_split>
+<fv3_n_sponge                                                               > 0         </fv3_n_sponge>
+<fv3_print_freq                                                             > 1         </fv3_print_freq>
+<fv3_range_warn                                                             > .false.   </fv3_range_warn>
+<fv3_scale_ttend                                                            > .false.   </fv3_scale_ttend>
+<fv3_rf_cutoff                                                              > 750       </fv3_rf_cutoff>
+<fv3_tau                                                                    > 10        </fv3_tau>
+<fv3_vtdm4                                                                  > 0.0D0       </fv3_vtdm4>
+
+<!-- ================================================================== -->
+<!-- Defaults for SE                                                    -->
+<!-- ================================================================== -->
+
+<se_pgf_formulation>           1</se_pgf_formulation>
+<se_pgf_formulation waccmx="1">3</se_pgf_formulation>
+
+<se_dribble_in_rsplit_loop                                           >    0</se_dribble_in_rsplit_loop>
+<se_dribble_in_rsplit_loop  hgrid="ne16np4" waccm_phys="1" waccmx="0">    1</se_dribble_in_rsplit_loop>
+<se_dribble_in_rsplit_loop  hgrid="ne16np4" model_top="ht">               1</se_dribble_in_rsplit_loop>
+
+<se_ftype> 2 </se_ftype>
+
+<se_large_Courant_incr        > .true.  </se_large_Courant_incr>
+
+<se_hypervis_scaling se_refined_mesh="1" hypervis_type="tensor" >3.22D0 </se_hypervis_scaling>
+
+<se_hypervis_subcycle                                                           > 3 </se_hypervis_subcycle>
+<se_hypervis_subcycle  waccm_phys="1"  model_top="mt"                           > 3 </se_hypervis_subcycle>
+<se_hypervis_subcycle  waccm_phys="1"                                           > 2 </se_hypervis_subcycle>
+<se_hypervis_subcycle  hgrid="ne16np4"                                          > 3 </se_hypervis_subcycle>
+<se_hypervis_subcycle  hgrid="ne16np4"  model_top="lt"                          > 1 </se_hypervis_subcycle>
+<se_hypervis_subcycle  hgrid="ne16np4"  waccm_phys="1"            model_top="none"> 10 </se_hypervis_subcycle>
+<se_hypervis_subcycle  hgrid="ne16np4"  waccm_phys="1" waccmx="0" model_top="none"> 9 </se_hypervis_subcycle>
+<se_hypervis_subcycle  hgrid="ne30np4"  waccm_phys="1" waccmx="0" model_top="none"> 8 </se_hypervis_subcycle>
+<se_hypervis_subcycle  hgrid="ne30np4"  waccm_phys="1" waccmx="1" model_top="none"> 5 </se_hypervis_subcycle>
+<se_hypervis_subcycle  hgrid="ne30np4"  model_top="lt"                          > 2 </se_hypervis_subcycle>
+<se_hypervis_subcycle  hgrid="ne30np4"  model_top="mt"                          > 3 </se_hypervis_subcycle>
+<se_hypervis_subcycle  hgrid="ne0np4.ARCTIC.ne30x4"                             > 2  </se_hypervis_subcycle>
+<se_hypervis_subcycle  hgrid="ne0np4.POLARCAP.ne30x4"                           > 2  </se_hypervis_subcycle>
+<se_hypervis_subcycle  hgrid="ne0np4CONUS.ne30x8"                               > 1  </se_hypervis_subcycle>
+<se_hypervis_subcycle  hgrid="ne0np4.ARCTICGRIS.ne30x8"                         > 1  </se_hypervis_subcycle>
+<se_hypervis_subcycle  hgrid="ne0np4.NATL.ne30x8"                               > 1  </se_hypervis_subcycle>
+<se_hypervis_subcycle  hgrid="ne0np4CONUS.ne30x8" waccm_phys="1"                > 1 </se_hypervis_subcycle>
+<se_hypervis_subcycle  hgrid="ne16np4" model_top="ht"                           > 18</se_hypervis_subcycle>
+<se_hypervis_subcycle  hgrid="ne16np4" model_top="xt"                           > 18</se_hypervis_subcycle>
+<se_hypervis_subcycle  hgrid="ne30np4" model_top="ht"                           > 18</se_hypervis_subcycle>
+<se_hypervis_subcycle  hgrid="ne30np4" model_top="xt"                           > 18</se_hypervis_subcycle>
+<se_hypervis_subcycle  waccmx="1" hgrid="ne120np4" nlev="273"                   > 30</se_hypervis_subcycle>
+<se_hypervis_subcycle  hgrid="ne120np4"  model_top="mt"                         > 2 </se_hypervis_subcycle>
+
+<se_hypervis_subcycle_sponge                                                 > 1  </se_hypervis_subcycle_sponge>
+<se_hypervis_subcycle_sponge hgrid="ne30np4"  model_top="mt"                 > 3  </se_hypervis_subcycle_sponge>
+<se_hypervis_subcycle_sponge hgrid="ne30np4" model_top="mt" waccm_phys="1"   > 3  </se_hypervis_subcycle_sponge>
+<se_hypervis_subcycle_sponge hgrid="ne16np4"  waccm_phys="1" waccmx="0"      > 2  </se_hypervis_subcycle_sponge>
+<se_hypervis_subcycle_sponge hgrid="ne30np4"  waccm_phys="1" waccmx="0"      > 4  </se_hypervis_subcycle_sponge>
+<se_hypervis_subcycle_sponge waccmx="1"                                      > 20 </se_hypervis_subcycle_sponge>
+<se_hypervis_subcycle_sponge hgrid="ne30np4" waccmx="1" model_top="none"     > 60 </se_hypervis_subcycle_sponge>
+<se_hypervis_subcycle_sponge hgrid="ne120np4"                                > 4  </se_hypervis_subcycle_sponge>
+<se_hypervis_subcycle_sponge hgrid="ne0np4.ARCTIC.ne30x4"                    > 2  </se_hypervis_subcycle_sponge>
+<se_hypervis_subcycle_sponge hgrid="ne0np4.POLARCAP.ne30x4"                  > 2  </se_hypervis_subcycle_sponge>
+<se_hypervis_subcycle_sponge hgrid="ne0np4CONUS.ne30x8"                      > 5  </se_hypervis_subcycle_sponge>
+<se_hypervis_subcycle_sponge hgrid="ne0np4.ARCTICGRIS.ne30x8"                > 5  </se_hypervis_subcycle_sponge>
+<se_hypervis_subcycle_sponge hgrid="ne0np4.NATL.ne30x8"                      > 5  </se_hypervis_subcycle_sponge>
+<se_hypervis_subcycle_sponge hgrid="ne0np4CONUS.ne30x8" waccm_phys="1"       > 4  </se_hypervis_subcycle_sponge>
+<se_hypervis_subcycle_sponge hgrid="ne16np4" model_top="ht"                  > 2  </se_hypervis_subcycle_sponge>
+<se_hypervis_subcycle_sponge hgrid="ne30np4" model_top="ht"                  > 4  </se_hypervis_subcycle_sponge>
+<se_hypervis_subcycle_sponge hgrid="ne30np4" model_top="xt"                  > 40 </se_hypervis_subcycle_sponge>
+<se_hypervis_subcycle_sponge waccmx="1" hgrid="ne120np4" nlev="273"          > 180</se_hypervis_subcycle_sponge>
+<se_hypervis_subcycle_sponge hgrid="ne120np4"  model_top="mt"                > 10 </se_hypervis_subcycle_sponge>
+<se_hypervis_subcycle_sponge hgrid="ne0np4.ARCTIC.ne30x4" model_top="mt"     > 3  </se_hypervis_subcycle_sponge>
+<se_hypervis_subcycle_sponge hgrid="ne0np4.POLARCAP.ne30x4" model_top="mt"   > 3  </se_hypervis_subcycle_sponge>
+<se_hypervis_subcycle_sponge hgrid="ne0np4CONUS.ne30x8" model_top="mt"       > 6  </se_hypervis_subcycle_sponge>
+<se_hypervis_subcycle_sponge hgrid="ne0np4.ARCTICGRIS.ne30x8" model_top="mt" > 6  </se_hypervis_subcycle_sponge>
+<se_hypervis_subcycle_sponge hgrid="ne0np4.NATL.ne30x8" model_top="mt"       > 6  </se_hypervis_subcycle_sponge>
+
+
+<se_hypervis_subcycle_q>1                 </se_hypervis_subcycle_q>
+<se_hypervis_subcycle_q hgrid="ne16np4">2 </se_hypervis_subcycle_q>
+
+<se_limiter_option> 8 </se_limiter_option>
+
+<se_fine_ne>   0 </se_fine_ne>
+<se_hypervis_power> 0 </se_hypervis_power>
+
+<se_max_hypervis_courant > 1.0e99 </se_max_hypervis_courant>
+<se_max_hypervis_courant se_refined_mesh="1" hypervis_type="scalar" > 1.9 </se_max_hypervis_courant>
+
+<se_nu>-1</se_nu>
+<se_nu hgrid="ne16np4">6.e15</se_nu>
+<se_nu waccmx="1">5.e15</se_nu>
+
+<se_nu_div> -1 </se_nu_div>
+<se_nu_div hgrid="ne16np4">6.e15</se_nu_div>
+<se_nu_div waccmx="1"> 10.e15 </se_nu_div>
+
+<se_nu_p>-1 </se_nu_p>
+<se_nu_p hgrid="ne16np4">6.e15</se_nu_p>
+<se_nu_p waccmx="1">5.e15</se_nu_p>
+
+<se_nu_top                                   > 1.25e5 </se_nu_top>
+<se_nu_top waccmx="1"                        > 1.0e6 </se_nu_top>
+<se_nu_top model_top="mt"                    > 1.0e6 </se_nu_top>
+<se_nu_top model_top="ht"                    > 1.0e6 </se_nu_top>
+<se_nu_top waccm_phys="1"                    > 1.0e6 </se_nu_top>
+
+<se_molecular_diff               >  0.0 </se_molecular_diff>
+<se_molecular_diff waccmx="1"    >  1.0 </se_molecular_diff>
+
+<se_sponge_del4_nu_fac    > -1 </se_sponge_del4_nu_fac>
+<se_sponge_del4_nu_fac hgrid="ne120np4" nlev="273" waccmx="1"> 3.0 </se_sponge_del4_nu_fac>
+<se_sponge_del4_nu_div_fac> -1 </se_sponge_del4_nu_div_fac>
+<se_sponge_del4_nu_div_fac hgrid="ne16np4" waccm_phys="1" waccmx="0"> 7.5 </se_sponge_del4_nu_div_fac>
+<se_sponge_del4_nu_div_fac model_top="ht"                           > 7.5 </se_sponge_del4_nu_div_fac>
+<se_sponge_del4_nu_div_fac hgrid="ne120np4" nlev="273" waccmx="1"   > 5.0 </se_sponge_del4_nu_div_fac>
+<se_sponge_del4_lev       > -1 </se_sponge_del4_lev>
+<se_sponge_del4_lev waccm_phys="1" model_top="mt"> -1 </se_sponge_del4_lev>
+<se_sponge_del4_lev waccm_phys="1"> 30 </se_sponge_del4_lev>
+<se_sponge_del4_lev model_top="ht"> 30 </se_sponge_del4_lev>
+<se_sponge_del4_lev model_top="xt"> 30 </se_sponge_del4_lev>
+<se_sponge_del4_lev waccmx="1" hgrid="ne120np4" nlev="273"> 100 </se_sponge_del4_lev>
+
+<se_qsplit > 1 </se_qsplit>
+<se_qsplit hgrid="ne30np4" waccm_phys="1" waccmx="1" model_top="none"> 2 </se_qsplit>
+
+<se_refined_mesh > .false. </se_refined_mesh>
+<se_refined_mesh hgrid="ne0np4CONUS.ne30x8" > .true. </se_refined_mesh>
+<se_refined_mesh hgrid="ne0np4TESTONLY.ne5x4" > .true. </se_refined_mesh>
+<se_refined_mesh hgrid="ne0np4.ARCTIC.ne30x4" > .true. </se_refined_mesh>
+<se_refined_mesh hgrid="ne0np4.ARCTICGRIS.ne30x8" > .true. </se_refined_mesh>
+<se_refined_mesh hgrid="ne0np4.POLARCAP.ne30x4" > .true. </se_refined_mesh>
+<se_refined_mesh hgrid="ne0np4.NATL.ne30x8" > .true. </se_refined_mesh>
+
+<se_nsplit>                   2 </se_nsplit>
+<se_nsplit hgrid="ne16np4" >  1 </se_nsplit>
+
+<se_nsplit hgrid="ne5np4"   waccm_phys="1"                 > 3 </se_nsplit>
+<se_nsplit hgrid="ne16np4"  waccmx="1" model_top="none"    > 3 </se_nsplit>
+<se_nsplit hgrid="ne16np4"  waccm_phys="1" model_top="none"> 2 </se_nsplit>
+<se_nsplit hgrid="ne16np4"  model_top="ht"                 > 3 </se_nsplit>
+<se_nsplit hgrid="ne16np4"  model_top="xt"                 > 3 </se_nsplit>
+<se_nsplit hgrid="ne30np4" waccm_phys="1" waccmx="1" model_top="none">  4  </se_nsplit>
+<se_nsplit hgrid="ne30np4"                                 > 2 </se_nsplit>
+<se_nsplit hgrid="ne30np4"  waccm_phys="1" model_top="none"> 4 </se_nsplit>
+<se_nsplit hgrid="ne30np4"  model_top="ht"                 > 4 </se_nsplit>
+<se_nsplit hgrid="ne30np4"  model_top="xt"                 > 5 </se_nsplit>
+<se_nsplit hgrid="ne0np4.ARCTIC.ne30x4"                    > 3 </se_nsplit>
+<se_nsplit hgrid="ne0np4.POLARCAP.ne30x4"                  > 3 </se_nsplit>
+<se_nsplit hgrid="ne0np4CONUS.ne30x8"                      > 3 </se_nsplit>
+<se_nsplit hgrid="ne0np4.ARCTICGRIS.ne30x8"                > 3 </se_nsplit>
+<se_nsplit hgrid="ne0np4.NATL.ne30x8"                      > 3 </se_nsplit>
+<se_nsplit hgrid="ne0np4CONUS.ne30x8" waccm_phys="1"       > 10 </se_nsplit>
+<se_nsplit hgrid="ne0np4TESTONLY.ne5x4"                    > 7 </se_nsplit>
+<se_nsplit waccmx="1" hgrid="ne120np4" nlev="273"          > 10 </se_nsplit>
+<se_nsplit hgrid="ne120np4"  model_top="mt"                > 8 </se_nsplit>
+<se_nsplit hgrid="ne0np4CONUS.ne30x8" model_top="mt"       > 4 </se_nsplit>
+<se_nsplit hgrid="ne0np4.ARCTICGRIS.ne30x8" model_top="mt" > 4 </se_nsplit>
+<se_nsplit hgrid="ne0np4.NATL.ne30x8" model_top="mt"       > 4 </se_nsplit>
+
+<se_rsplit                                                 > 3 </se_rsplit>
+<se_rsplit waccm_phys="1" model_top="mt"                   > 3 </se_rsplit>
+<se_rsplit waccm_phys="1" waccmx="0"                       > 2 </se_rsplit>
+<se_rsplit model_top="ht"                                  > 2 </se_rsplit>
+<se_rsplit waccmx="1"                                      > 4 </se_rsplit>
+<se_rsplit hgrid="ne16np4" waccmx="1" model_top="none"     > 2 </se_rsplit>
+<se_rsplit hgrid="ne0np4CONUS.ne30x8" waccm_phys="1"       > 3 </se_rsplit>
+<se_rsplit waccmx="1" hgrid="ne120np4" nlev="273"          > 5 </se_rsplit>
+<se_rsplit hgrid="ne120np4"  model_top="mt"                > 3 </se_rsplit>
+<se_rsplit hgrid="ne0np4.ARCTIC.ne30x4" model_top="mt"     > 6 </se_rsplit>
+<se_rsplit hgrid="ne0np4.POLARCAP.ne30x4" model_top="mt"   > 6 </se_rsplit>
+<se_rsplit hgrid="ne0np4CONUS.ne30x8" model_top="mt"       > 5 </se_rsplit>
+<se_rsplit hgrid="ne0np4.ARCTICGRIS.ne30x8" model_top="mt" > 5 </se_rsplit>
+<se_rsplit hgrid="ne0np4.NATL.ne30x8" model_top="mt"       > 5 </se_rsplit>
+
+<se_fvm_supercycling>-1</se_fvm_supercycling>
+<se_fvm_supercycling_jet>-1</se_fvm_supercycling_jet>
+<se_kmin_jet>-1</se_kmin_jet>
+<se_kmax_jet>-1</se_kmax_jet>
+
+<se_statediag_numtrac>3</se_statediag_numtrac>
+
+<se_statefreq> 0 </se_statefreq>
+
+<se_tstep_type > 4 </se_tstep_type>
+
+<se_vert_remap_T        > thermal_energy_over_P </se_vert_remap_T>
+<se_vert_remap_uvTq_alg  > FV3_CS                </se_vert_remap_uvTq_alg>
+<se_vert_remap_tracer_alg> PPM_bc_linear_extrapolation </se_vert_remap_tracer_alg>
+
+<!-- Option to write SCRIP grid file -->
+<se_write_grid_file> no </se_write_grid_file>
+
+<!-- SE performance (threading) entries -->
+<se_horz_num_threads> 0 </se_horz_num_threads>
+<se_tracer_num_threads> 0 </se_tracer_num_threads>
+<se_vert_num_threads> 0 </se_vert_num_threads>
+
+
+<!-- ================================================================== -->
+<!-- Defaults for MPAS                                                  -->
+<!-- ================================================================== -->
+
+<mpas_time_integration        > SRK3 </mpas_time_integration>
+<mpas_time_integration_order  > 2 </mpas_time_integration_order>
+<mpas_dt                      > 1800.0D0 </mpas_dt>
+<mpas_dt hgrid="mpasa120"     >  900.0D0 </mpas_dt>
+<mpas_dt hgrid="mpasa120" waccm_phys="1"> 600.D0 </mpas_dt>
+<mpas_dt hgrid="mpasa60"      >  450.0D0 </mpas_dt>
+<mpas_dt hgrid="mpasa30"      >  225.0D0 </mpas_dt>
+<!-- With default ATM_NCPL, these next entries do 3 MPAS-A steps per CAM step instead of 2 -->
+<mpas_dt hgrid="mpasa15"      >   80.0D0 </mpas_dt>
+<mpas_dt hgrid="mpasa7p5"     >   40.0D0 </mpas_dt>
+<mpas_dt hgrid="mpasa3p75"    >   20.0D0 </mpas_dt>
+
+<mpas_split_dynamics_transport>.true.</mpas_split_dynamics_transport>
+<mpas_number_of_sub_steps     > 2 </mpas_number_of_sub_steps>
+<mpas_dynamics_split_steps    > 3 </mpas_dynamics_split_steps>
+<mpas_dynamics_split_steps hgrid="mpasa120" waccm_phys="1"> 4 </mpas_dynamics_split_steps>
+<mpas_h_mom_eddy_visc2        > 0.0D0 </mpas_h_mom_eddy_visc2>
+<mpas_h_mom_eddy_visc4        > 0.0D0 </mpas_h_mom_eddy_visc4>
+<mpas_v_mom_eddy_visc2        > 0.0D0 </mpas_v_mom_eddy_visc2>
+<mpas_h_theta_eddy_visc2      > 0.0D0 </mpas_h_theta_eddy_visc2>
+<mpas_h_theta_eddy_visc4      > 0.0D0 </mpas_h_theta_eddy_visc4>
+<mpas_v_theta_eddy_visc2      > 0.0D0 </mpas_v_theta_eddy_visc2>
+<mpas_horiz_mixing            > 2d_smagorinsky </mpas_horiz_mixing>
+
+<mpas_len_disp hgrid="mpasa480">480000.0D0</mpas_len_disp>
+<mpas_len_disp hgrid="mpasa120">120000.0D0</mpas_len_disp>
+<mpas_len_disp hgrid="mpasa60">  60000.0D0</mpas_len_disp>
+<mpas_len_disp hgrid="mpasa30">  30000.0D0</mpas_len_disp>
+<mpas_len_disp hgrid="mpasa15">  15000.0D0</mpas_len_disp>
+<mpas_len_disp hgrid="mpasa7p5">  7500.0D0</mpas_len_disp>
+<mpas_len_disp hgrid="mpasa3p75"> 3750.0D0</mpas_len_disp>
+
+<mpas_visc4_2dsmag            > 0.05D0 </mpas_visc4_2dsmag>
+<mpas_del4u_div_factor        > 10.0D0 </mpas_del4u_div_factor>
+<mpas_w_adv_order             > 3 </mpas_w_adv_order>
+<mpas_theta_adv_order         > 3 </mpas_theta_adv_order>
+<mpas_scalar_adv_order        > 3 </mpas_scalar_adv_order>
+<mpas_u_vadv_order            > 3 </mpas_u_vadv_order>
+<mpas_w_vadv_order            > 3 </mpas_w_vadv_order>
+<mpas_theta_vadv_order        > 3 </mpas_theta_vadv_order>
+<mpas_scalar_vadv_order       > 3 </mpas_scalar_vadv_order>
+<mpas_scalar_advection        > .true. </mpas_scalar_advection>
+<mpas_positive_definite       > .false. </mpas_positive_definite>
+<mpas_monotonic               > .true. </mpas_monotonic>
+<mpas_coef_3rd_order          > 1.0D0 </mpas_coef_3rd_order>
+<mpas_smagorinsky_coef        > 0.125D0 </mpas_smagorinsky_coef>
+<mpas_mix_full                > .true. </mpas_mix_full>
+<mpas_smdiv                   > 0.1D0 </mpas_smdiv>
+<mpas_apvm_upwinding          > 0.5D0 </mpas_apvm_upwinding>
+<mpas_apvm_upwinding hgrid="mpasa120" waccm_phys="1"> 0.0D0 </mpas_apvm_upwinding>
+<mpas_h_ScaleWithMesh         > .true. </mpas_h_ScaleWithMesh>
+<mpas_zd                      > 22000.0D0 </mpas_zd>
+<mpas_zd hgrid="mpasa120" waccm_phys="1"> 80000.0D0 </mpas_zd>
+<mpas_xnutr                   > 0.2D0 </mpas_xnutr>
+<mpas_cam_coef                > 0.0D0 </mpas_cam_coef>
+<mpas_cam_coef hgrid="mpasa120" waccm_phys="1"> 0.2D0 </mpas_cam_coef>
+<mpas_cam_damping_levels      > 0     </mpas_cam_damping_levels>
+<mpas_rayleigh_damp_u         > .true. </mpas_rayleigh_damp_u>
+<mpas_rayleigh_damp_u_timescale_days> 5.0 </mpas_rayleigh_damp_u_timescale_days>
+<mpas_number_rayleigh_damp_u_levels> 5 </mpas_number_rayleigh_damp_u_levels>
+<mpas_epssm_minimum> 0.1D0 </mpas_epssm_minimum>
+<mpas_epssm_maximum> 0.1D0 </mpas_epssm_maximum>
+<mpas_epssm_maximum hgrid="mpasa120" waccm_phys="1"> 0.5D0 </mpas_epssm_maximum>
+<mpas_epssm_transition_bottom_z> 30000.0D0 </mpas_epssm_transition_bottom_z>
+<mpas_epssm_transition_top_z> 50000.0D0 </mpas_epssm_transition_top_z>
+<mpas_apply_lbcs> .false. </mpas_apply_lbcs>
+<mpas_jedi_da> .false. </mpas_jedi_da>
+<mpas_block_decomp_file_prefix hgrid="mpasa480">atm/cam/inic/mpas/mpasa480.graph.info.part.</mpas_block_decomp_file_prefix>
+<mpas_block_decomp_file_prefix hgrid="mpasa120">atm/cam/inic/mpas/mpasa120.graph.info.part.</mpas_block_decomp_file_prefix>
+<mpas_block_decomp_file_prefix hgrid="mpasa60">atm/cam/inic/mpas/mpasa60.graph.info.part.</mpas_block_decomp_file_prefix>
+<mpas_block_decomp_file_prefix hgrid="mpasa30">atm/cam/inic/mpas/mpasa30.graph.info.part.</mpas_block_decomp_file_prefix>
+<mpas_block_decomp_file_prefix hgrid="mpasa15">atm/cam/inic/mpas/mpasa15.graph.info.part.</mpas_block_decomp_file_prefix>
+<mpas_block_decomp_file_prefix hgrid="mpasa12">atm/cam/inic/mpas/mpasa12.graph.info.part.</mpas_block_decomp_file_prefix>
+<mpas_block_decomp_file_prefix hgrid="mpasa15-3">atm/cam/inic/mpas/mpasa15-3.graph.info.part.</mpas_block_decomp_file_prefix>
+
+<mpas_do_restart               > .false. </mpas_do_restart>
+<mpas_print_global_minmax_vel  > .false. </mpas_print_global_minmax_vel>
+<mpas_print_detailed_minmax_vel> .false. </mpas_print_detailed_minmax_vel>
+<mpas_print_global_minmax_sca  > .false. </mpas_print_global_minmax_sca>
+
+<mpas_halo_exch_method> mpas_halo </mpas_halo_exch_method>
+<mpas_gpu_aware_mpi> .false. </mpas_gpu_aware_mpi>
+
+<!-- ================================================================== -->
+<!-- Chemistry Rates Diagnostics                                        -->
+<!-- ================================================================== -->
+
+<rxn_rate_sums chem="waccm_ma_mam5">
+  'O3S_Loss = 2.0*O_O3 + O1D_H2O + HO2_O + HO2_O3 + OH_O + OH_O3 + H_O3 + 2.0*NO2_O + 2.0*jno3_b + 2.0*CLO_O + 2.0*jcl2o2 + ',
+	     '2.0*CLO_CLOa + 2.0*CLO_CLOb + 2.0*BRO_CLOb + 2.0*BRO_CLOc + 2.0*BRO_BRO + 2.0*BRO_O + CLO_HO2 + BRO_HO2 + S_O3'
+</rxn_rate_sums>
+<rxn_rate_sums chem="waccm_ma_mam5" waccmx="1">
+  'O3S_Loss = 2.0*O_O3 + O1D_H2O + HO2_O + HO2_O3 + OH_O + OH_O3 + H_O3 + 2.0*NO2_O + 2.0*jno3_b + 2.0*CLO_O + 2.0*jcl2o2 + ',
+	     '2.0*CLO_CLOa + 2.0*CLO_CLOb + 2.0*BRO_CLOb + 2.0*BRO_CLOc + 2.0*BRO_BRO + 2.0*BRO_O + CLO_HO2 + BRO_HO2 + S_O3',
+  'SolIonRate_Tot = jeuv_1 + jeuv_2 + jeuv_3 + jeuv_4 + jeuv_5 + jeuv_6 + jeuv_7 + jeuv_8 + jeuv_9 + jeuv_10 + jeuv_11 + ',
+                   'jeuv_14 + jeuv_15 + jeuv_16 + jeuv_17 + jeuv_18 + jeuv_19 + jeuv_20 + jeuv_21 + jeuv_22 + jeuv_23',
+</rxn_rate_sums>
+<rxn_rate_sums chem="waccm_ma" waccmx="1">
+  'SolIonRate_Tot = jeuv_1 + jeuv_2 + jeuv_3 + jeuv_4 + jeuv_5 + jeuv_6 + jeuv_7 + jeuv_8 + jeuv_9 + jeuv_10 + jeuv_11 + ',
+                   'jeuv_14 + jeuv_15 + jeuv_16 + jeuv_17 + jeuv_18 + jeuv_19 + jeuv_20 + jeuv_21 + jeuv_22 + jeuv_23',
+</rxn_rate_sums>
+<rxn_rate_sums chem="waccm_mad_mam5" waccmx="1">
+  'SolIonRate_Tot = jeuv_1 + jeuv_2 + jeuv_3 + jeuv_4 + jeuv_5 + jeuv_6 + jeuv_7 + jeuv_8 + jeuv_9 + jeuv_10 + jeuv_11 + ',
+                   'jeuv_14 + jeuv_15 + jeuv_16 + jeuv_17 + jeuv_18 + jeuv_19 + jeuv_20 + jeuv_21 + jeuv_22 + jeuv_23',
+</rxn_rate_sums>
+<rxn_rate_sums chem="trop_strat_mam5_t2s1">
+    'O3_Prod = NO_HO2 + CH3O2_NO + HOCH2OO_NO + C2H5O2_NO + CH3CO3_NO + EO2_NO + C3H7O2_NO + PO2_NO + ',
+               'RO2_NO + ENEO2_NO + MACRO2_NOa + jhonitr + ',
+               'MCO3_NO + MEKO2_NO + ALKO2_NO + jalknit + ACBZO2_NO + BENZO2_NO + BZOO_NO + ',
+               'C6H5O2_NO + DICARBO2_NO + MALO2_NO + MDIALO2_NO + PHENO2_NO + TOLO2_NO + XYLENO2_NO + XYLOLO2_NO + ',
+               'ISOPED1O2_NOa + ISOPB1O2_NOa + ISOPZD1O2_NOa + ISOPED4O2_NOa + ISOPB4O2_NOa + ISOPZD4O2_NOa + ISOPNO3_NOa + IEPOXOO_NOa + MVKO2_NOa + ',
+               '.77*APINO2_NO + .75*BPINO2_NO + .77*LIMONO2_NO + .71*MYRCO2_NO + .93*APINNO3_NO + .93*BPINNO3_NO + .93*LIMONNO3_NO + .93*MYRCNO3_NO + ',
+               '.7*BCARYO2_NO + .93*BCARYNO3_NO + .7*TERPF1O2_NO + .7*TERPF2O2_NO + .7*TERP1OOHO2_NO + .7*TERP2OOHO2_NO + TERPACO3_NO + TERPA2CO3_NO + ',
+               '.7*TERPA1O2_NO + .83*TERPA2O2_NO + .7*TERPA3O2_NO + .91*TERPA4O2_NO + TERPA3CO3_NO + ',
+               'jisopfnc + jisopn2b + jisopn3b + jisopn4d + jisopn1d + 2.0*jisopfdn + .75*jmacrn + .75*jmvkn + ',
+               'jterpfdn + jterpns1 + jterpns + jterpnt + jterpnt1 + ',
+               'jinheb + jinhed + 2.0*jisopfdnc + jisopfnp + jisopnbno3 + jisopnoohb + jnc4cho + ',
+               'jno3ch2cho + jnoa + jonitr + 0.5*jterpnps + 0.46*jterpnps1 + jterpnpt + 0.46*jterpnpt1 + ',
+               'NO3CH2CHO_OH + NOA_OH + 0.5*MACRN_OH + ALKNIT_OH + 0.4*INHEB_OH + 0.19*INHED_OH + ',
+               'ISOPFDNC_OH + 0.5*ISOPFNC_OH + 0.17*ISOPN1D_O3 + 0.08*ISOPN1D_OH + 0.46*ISOPN2BO2_HO2 + ',
+               '0.15*ISOPN2B_OH + 0.13*ISOPN3B_OH + 0.17*ISOPN4D_O3 + 0.04*ISOPN4D_OH + 0.17*ISOPNOOHD_O3 + ',
+               '0.07*ISOPNOOHD_OH + 0.17*NC4CHO_O3 + 0.04*NC4CHO_OH + ISOPN1DO2_NOa + 1.73*ISOPN2BO2_NOa + ',
+               'ISOPN3BO2_NOa + ISOPN4DO2_NOa + ISOPNBNO3O2_NOa + ISOPNOOHBO2_NOa + ISOPNOOHDO2_NOa + ',
+               'NC4CHOO2_NOa + TERPFDN_OH + 0.7*TERPNPS1O2_NO + 0.7*TERPNPT1O2_NO + 0.7*TERPNS1O2_NO + ',
+               'TERPNS_OH + 0.7*TERPNT1O2_NO + TERPNT_OH',
+    'O3_Loss = O1D_H2O + OH_O3 + HO2_O3 + C2H4_O3 + C3H6_O3 + ISOP_O3 + MVK_O3 + MACR_O3 + BCARY_O3 + ',
+               'S_O3 + SO_O3 + APIN_O3 + BPIN_O3 + LIMON_O3 + MYRC_O3 + ',
+               'ISOPN1D_O3 + ISOPN4D_O3 + ISOPNOOHD_O3 + NC4CHO_O3 + TERPF1_O3 + TERPF2_O3',
+    'O3S_Loss = 2.0*O_O3 + O1D_H2O + HO2_O3 + OH_O3 + H_O3 + 2.0*NO2_O + 2.0*jno3_b + 2.0*CLO_O + ',
+               '2.0*jcl2o2 + 2.0*CLO_CLOa + 2.0*CLO_CLOb + ',
+               '2.0*BRO_CLOb + 2.0*BRO_CLOc + 2.0*BRO_BRO + 2.0*BRO_O + CLO_HO2 + BRO_HO2 + ',
+               'C2H4_O3 + C3H6_O3 + ISOP_O3 + MVK_O3 + MACR_O3 + BCARY_O3 + ',
+               'S_O3 + SO_O3 + APIN_O3 + BPIN_O3 + LIMON_O3 + MYRC_O3 + ',
+               'ISOPN1D_O3 + ISOPN4D_O3 + ISOPNOOHD_O3 + NC4CHO_O3 + TERPF1_O3 + TERPF2_O3',
+    'RO2_NO_sum = CH3O2_NO + HOCH2OO_NO + C2H5O2_NO + CH3CO3_NO + EO2_NO + C3H7O2_NO + PO2_NO + RO2_NO + ENEO2_NO + ',
+               'ENEO2_NOb + MACRO2_NOa + MACRO2_NOn + MCO3_NO + MEKO2_NO + ALKO2_NO + ALKO2_NOb + ACBZO2_NO + BENZO2_NO + ',
+               'BZOO_NO + C6H5O2_NO + DICARBO2_NO + MALO2_NO + MDIALO2_NO + PHENO2_NO + TOLO2_NO + XYLENO2_NO + XYLOLO2_NO + ',
+               'ISOPED1O2_NOa + ISOPB1O2_NOa + ISOPZD1O2_NOa + ISOPED4O2_NOa + ISOPB4O2_NOa + ISOPZD4O2_NOa + ISOPNO3_NOa + IEPOXOO_NOa +',
+               'ISOPED1O2_NOn + ISOPB1O2_NOn + ISOPZD1O2_NOn + ISOPED4O2_NOn + ISOPB4O2_NOn + ISOPZD4O2_NOn + ISOPNO3_NOn + IEPOXOO_NOn +',
+               'ISOPN3BO2_NOa + ISOPN2BO2_NOa + ISOPN1DO2_NOa + ISOPN4DO2_NOa + ISOPNBNO3O2_NOa + ISOPNOOHBO2_NOa + ISOPNOOHDO2_NOa + NC4CHOO2_NOa +',
+               'ISOPN3BO2_NOn + ISOPN2BO2_NOn + ISOPN1DO2_NOn + ISOPN4DO2_NOn + ISOPNBNO3O2_NOn + ISOPNOOHBO2_NOn + ISOPNOOHDO2_NOn + NC4CHOO2_NOn +',
+               'MVKO2_NOa + MVKO2_NOn +',
+               'APINNO3_NO + APINO2_NO + BCARYNO3_NO + BCARYO2_NO + BPINNO3_NO + BPINO2_NO + LIMONNO3_NO + LIMONO2_NO + MYRCNO3_NO + MYRCO2_NO +',
+               'TERPA2CO3_NO + TERPACO3_NO + TERP1OOHO2_NO + TERP2OOHO2_NO + TERPF1O2_NO + TERPF2O2_NO + TERPNPS1O2_NO +',
+               'TERPNPT1O2_NO + TERPNS1O2_NO + TERPNT1O2_NO + ',
+               'TERPA1O2_NO + TERPA2O2_NO + TERPA3O2_NO + TERPA4O2_NO + TERPA3CO3_NO',
+    'O3_alkenes = C2H4_O3 + C3H6_O3 + ISOP_O3 + MVK_O3 + MACR_O3 + BCARY_O3 + ',
+               'APIN_O3 + BPIN_O3 + LIMON_O3 + MYRC_O3 + ',
+               'ISOPN1D_O3 + ISOPN4D_O3 + ISOPNOOHD_O3 + NC4CHO_O3 + TERPF1_O3 + TERPF2_O3',
+    'RO2_NO3_sum = MCO3_NO3 + ISOPNO3_NO3 + ',
+               'APINNO3_NO3 + BCARYNO3_NO3 + BPINNO3_NO3 + LIMONNO3_NO3 + MYRCNO3_NO3 + ',
+               'TERPA2CO3_NO3 + TERPACO3_NO3 + TERPA1O2_NO3 + TERPA2O2_NO3 + TERPA3O2_NO3 + TERPA4O2_NO3 + APINO2_NO3 + BCARYO2_NO3 + BPINO2_NO3 +',
+               'LIMONO2_NO3 + MYRCO2_NO3 + TERPA3CO3_NO3',
+    'RO2_HO2_sum = CH3O2_HO2 + HOCH2OO_HO2 + C2H5O2_HO2 + CH3CO3_HO2 + EO2_HO2 + C3H7O2_HO2 + PO2_HO2 + RO2_HO2 + ',
+               'MACRO2_HO2 + MCO3_HO2 + MEKO2_HO2 + ',
+               'ALKO2_HO2 + ACBZO2_HO2 + BENZO2_HO2 + BZOO_HO2 + C6H5O2_HO2 + DICARBO2_HO2 + ',
+               'MALO2_HO2 + MDIALO2_HO2 + PHENO2_HO2 + TOLO2_HO2 + XYLENO2_HO2 + XYLOLO2_HO2 + ',
+               'ISOPED1O2_HO2 + ISOPB1O2_HO2 + ISOPZD1O2_HO2 + ISOPED4O2_HO2 + ISOPB4O2_HO2 + ISOPZD4O2_HO2 + ISOPNO3_HO2 + IEPOXOO_HO2 +',
+               'ISOPN3BO2_HO2 + ISOPN2BO2_HO2 + ISOPN1DO2_HO2 + ISOPN4DO2_HO2 + ISOPNBNO3O2_HO2 + ISOPNOOHBO2_HO2 + ISOPNOOHDO2_HO2 + NC4CHOO2_HO2 +',
+               'MVKO2_HO2 + APINNO3_HO2 + APINO2_HO2 + BCARYNO3_HO2 + BCARYO2_HO2 + ',
+               'BPINNO3_HO2 + BPINO2_HO2 + LIMONNO3_HO2 + LIMONO2_HO2 + MYRCNO3_HO2 + MYRCO2_HO2 +',
+               'TERPA2CO3_HO2 + TERPACO3_HO2 + TERP1OOHO2_HO2 + TERP2OOHO2_HO2 + TERPF1O2_HO2 + TERPF2O2_HO2 + TERPNPS1O2_HO2 +',
+               'TERPNPT1O2_HO2 + TERPNS1O2_HO2 + TERPNT1O2_HO2 + TERPA3CO3_HO2 +',
+               'TERPA1O2_HO2 + TERPA2O2_HO2 + TERPA3O2_HO2 + TERPA4O2_HO2',
+    'RO2_RO2_sum = CH3O2_CH3O2a + CH3O2_CH3O2b + C2H5O2_CH3O2 + C2H5O2_C2H5O2 + CH3CO3_CH3O2 + CH3CO3_CH3CO3 + C3H7O2_CH3O2 + RO2_CH3O2 + MACRO2_CH3O2 + ',
+               'MACRO2_CH3CO3 + MCO3_CH3O2 + MCO3_CH3CO3 + MCO3_MCO3 + ',
+               'ISOPED1O2_CH3O2 + ISOPB1O2_CH3O2 + ISOPZD1O2_CH3O2 + ISOPED4O2_CH3O2 + ISOPB4O2_CH3O2 + ISOPZD4O2_CH3O2 + ISOPNO3_CH3O2 +',
+               'ISOPED1O2_CH3CO3 + ISOPB1O2_CH3CO3 + ISOPZD1O2_CH3CO3 + ISOPED4O2_CH3CO3 + ISOPB4O2_CH3CO3 + ISOPZD4O2_CH3CO3 + ISOPNO3_CH3CO3 + ISOPNO3_ISOPNO3 +',
+               'MVKO2_CH3O2 + MVKO2_CH3CO3 + ',
+               'APINNO3_APINNO3 + APINNO3_CH3CO3 + APINNO3_CH3O2 + APINO2_CH3CO3 + APINO2_CH3O2 + BCARYNO3_BCARYNO3 + BCARYNO3_CH3CO3 + BCARYNO3_CH3O2 + ',
+               'BCARYO2_CH3CO3 + BCARYO2_CH3O2 + BPINNO3_BPINNO3 + BPINNO3_CH3CO3 + BPINNO3_CH3O2 + BPINO2_CH3CO3 + BPINO2_CH3O2 + ',
+               'LIMONNO3_LIMONNO3 + LIMONNO3_CH3CO3 + LIMONNO3_CH3O2 + LIMONO2_CH3CO3 + LIMONO2_CH3O2 + MYRCNO3_MYRCNO3 + MYRCNO3_CH3CO3 + MYRCNO3_CH3O2 + ',
+               'MYRCO2_CH3CO3 + MYRCO2_CH3O2 +',
+               'TERPA2CO3_CH3CO3 + TERPA2CO3_CH3O2 +TERPA2CO3_TERPA2CO3 +TERPA2CO3_TERPACO3 + TERPA1O2_TERPA2CO3 +TERPA2O2_TERPA2CO3 +TERPA3O2_TERPA2CO3 +',
+               'TERPA4O2_TERPA2CO3 +TERPACO3_CH3CO3 +TERPACO3_CH3O2 +TERPACO3_TERPACO3 + TERPA1O2_TERPACO3+ TERPA2O2_TERPACO3+ TERPA3O2_TERPACO3 + TERPA4O2_TERPACO3 +',
+               'TERPA1O2_CH3O2+TERPA1O2_CH3CO3 + TERPA2O2_CH3O2+TERPA2O2_CH3CO3 + TERPA3O2_CH3O2+TERPA3O2_CH3CO3 + TERPA4O2_CH3O2+TERPA4O2_CH3CO3 + ',
+               'TERPA3CO3_CH3CO3 + TERPA3CO3_CH3O2 +TERPA3CO3_TERPA3CO3 +TERPA3CO3_TERPACO3 +TERPA3CO3_TERPA2CO3 + TERPA1O2_TERPA3CO3 + TERPA2O2_TERPA3CO3 +',
+               'TERPA3O2_TERPA3CO3 +TERPA4O2_TERPA3CO3 + APINO2_TERPACO3 + APINO2_TERPA2CO3 + APINO2_TERPA3CO3 + APINNO3_TERPACO3 + APINNO3_TERPA2CO3 +',
+               'APINNO3_TERPA3CO3 + BCARYNO3_TERPACO3 + BCARYNO3_TERPA2CO3 + BCARYNO3_TERPA3CO3 + BCARYO2_TERPACO3 + BCARYO2_TERPA2CO3 + BCARYO2_TERPA3CO3 +',
+               'BPINNO3_TERPACO3 + BPINNO3_TERPA2CO3 + BPINNO3_TERPA3CO3 + BPINO2_TERPACO3 + BPINO2_TERPA2CO3 + BPINO2_TERPA3CO3 + LIMONNO3_TERPACO3 +',
+               'LIMONNO3_TERPA2CO3 + LIMONNO3_TERPA3CO3 + LIMONO2_TERPACO3 + LIMONO2_TERPA2CO3 + LIMONO2_TERPA3CO3 + MYRCNO3_TERPACO3 + MYRCNO3_TERPA2CO3 +',
+               'MYRCNO3_TERPA3CO3 + MYRCO2_TERPACO3 + MYRCO2_TERPA2CO3 + MYRCO2_TERPA3CO3',
+    'RCO2_NO2_sum = CH3CO3_NO2 + MCO3_NO2 + ACBZO2_NO2 + ',
+               'TERPACO3_NO2 + TERPA2CO3_NO2 + TERPA3CO3_NO2',
+    'OddOx_Ox_Loss  = 2.0*O_O3 + O1D_H2O',
+    'OddOx_HOx_Loss = HO2_O + HO2_O3 + OH_O + OH_O3 + H_O3',
+    'OddOx_NOx_Loss = 2.0*NO2_O + 2.0*jno3_b',
+    'OddOx_CLOxBROx_Loss = 2.0*CLO_O + 2.0*jcl2o2 + 2.0*CLO_CLOa + 2.0*CLO_CLOb + 2.0*BRO_CLOb + 2.0*BRO_CLOc + 2.0*BRO_BRO + 2.0*BRO_O + CLO_HO2 + BRO_HO2',
+    'OddOx_Loss_Tot = 2.0*O_O3 + O1D_H2O + HO2_O + HO2_O3 + OH_O + OH_O3 + H_O3 + 2.0*NO2_O + 2.0*jno3_b + 2.0*CLO_O + ',
+              '2.0*jcl2o2 + 2.0*CLO_CLOa + 2.0*CLO_CLOb + 2.0*BRO_CLOb + 2.0*BRO_CLOc + 2.0*BRO_BRO + 2.0*BRO_O + CLO_HO2 + BRO_HO2',
+    'OddOx_Prod_Tot = 2.0*jo2_a + 2.0*jo2_b',
+    'Ox_Prod = 2.0*jo2_a + 2.0*jo2_b + NO_HO2 + CH3O2_NO + HOCH2OO_NO + C2H5O2_NO + CH3CO3_NO + EO2_NO + C3H7O2_NO + PO2_NO + ',
+               'RO2_NO + ENEO2_NO + MACRO2_NOa + jhonitr + ',
+               'MCO3_NO + MEKO2_NO + ALKO2_NO + jalknit + ACBZO2_NO + BENZO2_NO + BZOO_NO + ',
+               'C6H5O2_NO + DICARBO2_NO + MALO2_NO + MDIALO2_NO + PHENO2_NO + TOLO2_NO + XYLENO2_NO + XYLOLO2_NO + ',
+               'ISOPED1O2_NOa + ISOPB1O2_NOa + ISOPZD1O2_NOa + ISOPED4O2_NOa + ISOPB4O2_NOa + ISOPZD4O2_NOa + ISOPNO3_NOa + IEPOXOO_NOa + MVKO2_NOa + ',
+               '.77*APINO2_NO + .75*BPINO2_NO + .77*LIMONO2_NO + .71*MYRCO2_NO + .93*APINNO3_NO + .93*BPINNO3_NO + .93*LIMONNO3_NO + .93*MYRCNO3_NO + ',
+               '.7*BCARYO2_NO + .93*BCARYNO3_NO + .7*TERPF1O2_NO + .7*TERPF2O2_NO + .7*TERP1OOHO2_NO + .7*TERP2OOHO2_NO + TERPACO3_NO + TERPA2CO3_NO + ',
+               '.7*TERPA1O2_NO + .83*TERPA2O2_NO + .7*TERPA3O2_NO + .91*TERPA4O2_NO + TERPA3CO3_NO + ',
+               'jisopfnc + jisopn2b + jisopn3b + jisopn4d + jisopn1d + 2.0*jisopfdn + .75*jmacrn + .75*jmvkn + ',
+               'jterpfdn + jterpns1 + jterpns + jterpnt + jterpnt1 + ',
+               'jinheb + jinhed + 2.0*jisopfdnc + jisopfnp + jisopnbno3 + jisopnoohb + jnc4cho + ',
+               'jno3ch2cho + jnoa + jonitr + 0.5*jterpnps + 0.46*jterpnps1 + jterpnpt + 0.46*jterpnpt1 + ',
+               'NO3CH2CHO_OH + NOA_OH + 0.5*MACRN_OH + ALKNIT_OH + 0.4*INHEB_OH + 0.19*INHED_OH + ',
+               'ISOPFDNC_OH + 0.5*ISOPFNC_OH + 0.17*ISOPN1D_O3 + 0.08*ISOPN1D_OH + 0.46*ISOPN2BO2_HO2 + ',
+               '0.15*ISOPN2B_OH + 0.13*ISOPN3B_OH + 0.17*ISOPN4D_O3 + 0.04*ISOPN4D_OH + 0.17*ISOPNOOHD_O3 + ',
+               '0.07*ISOPNOOHD_OH + 0.17*NC4CHO_O3 + 0.04*NC4CHO_OH + ISOPN1DO2_NOa + 1.73*ISOPN2BO2_NOa + ',
+               'ISOPN3BO2_NOa + ISOPN4DO2_NOa + ISOPNBNO3O2_NOa + ISOPNOOHBO2_NOa + ISOPNOOHDO2_NOa + ',
+               'NC4CHOO2_NOa + TERPFDN_OH + 0.7*TERPNPS1O2_NO + 0.7*TERPNPT1O2_NO + 0.7*TERPNS1O2_NO + ',
+               'TERPNS_OH + 0.7*TERPNT1O2_NO + TERPNT_OH',
+    'Ox_Loss = 2.0*O_O3 + O1D_H2O + HO2_O + HO2_O3 + OH_O + OH_O3 + H_O3 + 2.0*NO2_O + 2.0*jno3_b + 2.0*CLO_O + ',
+              '2.0*jcl2o2 + 2.0*CLO_CLOa + 2.0*CLO_CLOb + 2.0*BRO_CLOb + 2.0*BRO_CLOc + 2.0*BRO_BRO + 2.0*BRO_O + CLO_HO2 + BRO_HO2 + ',
+              'C2H4_O3 + C3H6_O3 + ISOP_O3 + MVK_O3 + MACR_O3 + BCARY_O3 + S_O3 + SO_O3 +',
+              'APIN_O3 + BPIN_O3 + LIMON_O3 + MYRC_O3 + ',
+              'ISOPN1D_O3 + ISOPN4D_O3 + ISOPNOOHD_O3 + NC4CHO_O3 + TERPF1_O3 + TERPF2_O3'
+</rxn_rate_sums>
+<rxn_rate_sums chem="trop_strat_mam5_t4s2">
+  'O3_Prod = NO_HO2 + CH3O2_NO + C2H5O2_NO + CH3CO3_NO + EO2_NO + C3H7O2_NO + PO2_NO + RO2_NO + ',
+           ' MACRO2_NOa + MCO3_NO + .92*ISOPO2_NO + ISOPNO3_NO + XO2_NO + jnoa + jonitr + NOA_OH ',
+           'O3_Loss = O1D_H2O + OH_O3 + HO2_O3 + C2H4_O3 + C3H6_O3 + ISOP_O3 + MVK_O3 + MACR_O3 + TERP_O3 + S_O3 + SO_O3',
+  'O3S_Loss = 2.0*O_O3 + O1D_H2O + HO2_O3 + OH_O3 + H_O3 + 2.0*NO2_O + 2.0*jno3_b + 2.0*CLO_O + 2.0*jcl2o2 + 2.0*CLO_CLOa + ',
+            ' 2.0*CLO_CLOb + 2.0*BRO_CLOb + 2.0*BRO_CLOc + 2.0*BRO_BRO + 2.0*BRO_O + CLO_HO2 + BRO_HO2 + S_O3 + SO_O3 + ',
+            ' C2H4_O3 + C3H6_O3 + ISOP_O3 + MVK_O3 + MACR_O3',
+  'O3_alkenes = C2H4_O3 + C3H6_O3 + ISOP_O3 + MVK_O3 + MACR_O3',
+  'RO2_NO_sum = CH3O2_NO + C2H5O2_NO + CH3CO3_NO + EO2_NO + C3H7O2_NO + PO2_NO + RO2_NO + MACRO2_NOa + ',
+              ' MACRO2_NOb + MCO3_NO + ISOPO2_NO + ISOPNO3_NO + XO2_NO', 'RO2_NO3_sum = MACRO2_NO3 + MCO3_NO3 + ISOPO2_NO3 + ISOPNO3_NO3 + XO2_NO3',
+  'RO2_HO2_sum = CH3O2_HO2 + C2H5O2_HO2 + CH3CO3_HO2 + EO2_HO2 + C3H7O2_HO2 + PO2_HO2 + RO2_HO2 + MACRO2_HO2 + ',
+               ' MCO3_HO2 + ISOPO2_HO2 + ISOPNO3_HO2 + XO2_HO2',
+  'RO2_RO2_sum = CH3O2_CH3O2a + CH3O2_CH3O2b + C2H5O2_CH3O2 + C2H5O2_C2H5O2 + CH3CO3_CH3O2 + CH3CO3_CH3CO3 + C3H7O2_CH3O2 + ',
+               ' RO2_CH3O2 + MACRO2_CH3O2 + MACRO2_CH3CO3 + MCO3_CH3O2 + MCO3_CH3CO3 + MCO3_MCO3 + ISOPO2_CH3O2 + ',
+               ' ISOPO2_CH3CO3 + XO2_CH3O2 + XO2_CH3CO3',
+  'RCO2_NO2_sum = CH3CO3_NO2 + MCO3_NO2',
+  'OddOx_Ox_Loss  = 2.0*O_O3 + O1D_H2O',
+  'OddOx_HOx_Loss = HO2_O + HO2_O3 + OH_O + OH_O3 + H_O3',
+  'OddOx_NOx_Loss = 2.0*NO2_O + 2.0*jno3_b',
+  'OddOx_CLOxBROx_Loss = 2.0*CLO_O + 2.0*jcl2o2 + 2.0*CLO_CLOa + 2.0*CLO_CLOb + 2.0*BRO_CLOb + 2.0*BRO_CLOc + 2.0*BRO_BRO + 2.0*BRO_O + CLO_HO2 + BRO_HO2',
+  'OddOx_Loss_Tot = 2.0*O_O3 + O1D_H2O + HO2_O + HO2_O3 + OH_O + OH_O3 + H_O3 + 2.0*NO2_O + 2.0*jno3_b + 2.0*CLO_O + 2.0*jcl2o2 + ',
+                  ' 2.0*CLO_CLOa + 2.0*CLO_CLOb + 2.0*BRO_CLOb + 2.0*BRO_CLOc + 2.0*BRO_BRO + 2.0*BRO_O + CLO_HO2 + BRO_HO2',
+  'OddOx_Prod_Tot = 2.0*jo2_a + 2.0*jo2_b',
+  'Ox_Prod = 2.0*jo2_a + 2.0*jo2_b + NO_HO2 + CH3O2_NO + C2H5O2_NO + CH3CO3_NO + EO2_NO + C3H7O2_NO + PO2_NO + ',
+           ' RO2_NO + MACRO2_NOa + MCO3_NO + .92*ISOPO2_NO + ISOPNO3_NO + XO2_NO + jnoa + jonitr + NOA_OH',
+  'Ox_Loss = 2.0*O_O3 + O1D_H2O + HO2_O + HO2_O3 + OH_O + OH_O3 + H_O3 + 2.0*NO2_O + 2.0*jno3_b + 2.0*CLO_O + 2.0*jcl2o2 + ',
+           ' 2.0*CLO_CLOa + 2.0*CLO_CLOb + 2.0*BRO_CLOb + 2.0*BRO_CLOc + 2.0*BRO_BRO + 2.0*BRO_O + CLO_HO2 + BRO_HO2 + C2H4_O3 + ',
+           ' C3H6_O3 + ISOP_O3 + MVK_O3 + MACR_O3 + TERP_O3 + S_O3 + SO_O3'
+</rxn_rate_sums>
+<rxn_rate_sums chem="waccm_t4ma_mam5">
+  'O3S_Loss = 2.0*O_O3 + O1D_H2O + HO2_O3 + OH_O3 + H_O3 + 2.0*NO2_O + 2.0*jno3_b + 2.0*CLO_O + 2.0*jcl2o2 + 2.0*CLO_CLOa + ',
+            ' 2.0*CLO_CLOb + 2.0*BRO_CLOb + 2.0*BRO_CLOc + 2.0*BRO_BRO + 2.0*BRO_O + CLO_HO2 + BRO_HO2 + S_O3 + SO_O3 + ',
+            ' C2H4_O3 + C3H6_O3 + ISOP_O3 + MVK_O3 + MACR_O3 + TERP_O3'
+</rxn_rate_sums>
+<rxn_rate_sums>
+  'O3_Prod = NO_HO2 + CH3O2_NO + HOCH2OO_NO + C2H5O2_NO + CH3CO3_NO + EO2_NO + C3H7O2_NO + PO2_NO + RO2_NO + ENEO2_NO + ',
+           ' MACRO2_NOa + MCO3_NO + MEKO2_NO + ALKO2_NO + .92*ISOPAO2_NO + .92*ISOPBO2_NO + ISOPNO3_NO + XO2_NO + ACBZO2_NO + ',
+           ' BENZO2_NO + BZOO_NO + C6H5O2_NO + DICARBO2_NO + MALO2_NO + MDIALO2_NO + PHENO2_NO + TOLO2_NO + XYLENO2_NO + XYLOLO2_NO + ',
+           ' NTERPO2_NO + .9*TERP2O2_NO + .8*TERPO2_NO + jalknit + jhonitr + jisopnooh + jnc4cho + jnoa + jnterpooh + jonitr + jterpnit + ',
+           ' ALKNIT_OH + 0.7*ISOPNITA_OH + NOA_OH + TERPNIT_OH',
+  'O3_Loss = O1D_H2O + OH_O3 + HO2_O3 + C2H4_O3 + C3H6_O3 + ISOP_O3 + MVK_O3 + MACR_O3 + MTERP_O3 + BCARY_O3 + S_O3 + SO_O3',
+  'O3S_Loss = 2.0*O_O3 + O1D_H2O + HO2_O3 + OH_O3 + H_O3 + 2.0*NO2_O + 2.0*jno3_b + 2.0*CLO_O + 2.0*jcl2o2 + 2.0*CLO_CLOa + ',
+            ' 2.0*CLO_CLOb + 2.0*BRO_CLOb + 2.0*BRO_CLOc + 2.0*BRO_BRO + 2.0*BRO_O + CLO_HO2 + BRO_HO2 + S_O3 + SO_O3 + ',
+            ' C2H4_O3 + C3H6_O3 + ISOP_O3 + MVK_O3 + MACR_O3 + MTERP_O3 + BCARY_O3'
+  'O3_alkenes = C2H4_O3 + C3H6_O3 + ISOP_O3 + MVK_O3 + MACR_O3 + MTERP_O3 + BCARY_O3',
+  'RO2_NO_sum = CH3O2_NO + HOCH2OO_NO + C2H5O2_NO + CH3CO3_NO + EO2_NO + C3H7O2_NO + PO2_NO + RO2_NO + ENEO2_NO + ENEO2_NOb + MACRO2_NOa + ',
+              ' MACRO2_NOb + MCO3_NO + MEKO2_NO + ALKO2_NO + ALKO2_NOb + ISOPAO2_NO + ISOPBO2_NO + ISOPNO3_NO + XO2_NO + ACBZO2_NO + BENZO2_NO + BZOO_NO + ',
+              ' C6H5O2_NO + DICARBO2_NO + MALO2_NO + MDIALO2_NO + PHENO2_NO + TOLO2_NO + XYLENO2_NO + XYLOLO2_NO + NTERPO2_NO + TERP2O2_NO + TERPO2_NO',
+  'RO2_NO3_sum = MACRO2_NO3 + MCO3_NO3 + ISOPAO2_NO3 + ISOPBO2_NO3 + ISOPNO3_NO3 + XO2_NO3 + NTERPO2_NO3',
+  'RO2_HO2_sum = CH3O2_HO2 + HOCH2OO_HO2 + C2H5O2_HO2 + CH3CO3_HO2 + EO2_HO2 + C3H7O2_HO2 + PO2_HO2 + RO2_HO2 +  MACRO2_HO2 + ',
+               ' MCO3_HO2 + MEKO2_HO2 + ALKO2_HO2 + ISOPAO2_HO2 + ISOPBO2_HO2 + ISOPNO3_HO2 + XO2_HO2 + ACBZO2_HO2 + BENZO2_HO2 + BZOO_HO2 + ',
+               ' C6H5O2_HO2 + DICARBO2_HO2 + MALO2_HO2 + MDIALO2_HO2 + PHENO2_HO2 + TOLO2_HO2 + XYLENO2_HO2 + XYLOLO2_HO2 + NTERPO2_HO2 + ',
+               ' TERP2O2_HO2 + TERPO2_HO2',
+  'RO2_RO2_sum = CH3O2_CH3O2a + CH3O2_CH3O2b + C2H5O2_CH3O2 + C2H5O2_C2H5O2 + CH3CO3_CH3O2 + CH3CO3_CH3CO3 + C3H7O2_CH3O2 + ',
+               ' RO2_CH3O2 + MACRO2_CH3O2 + MACRO2_CH3CO3 + MCO3_CH3O2 + MCO3_CH3CO3 + MCO3_MCO3 + ISOPAO2_CH3O2 + ISOPBO2_CH3O2 + ',
+               ' ISOPAO2_CH3CO3 + ISOPBO2_CH3CO3 + ISOPNO3_CH3O2 + XO2_CH3O2 + XO2_CH3CO3 + NTERPO2_CH3O2 + TERP2O2_CH3O2',
+  'RCO2_NO2_sum = CH3CO3_NO2 + MCO3_NO2 + ACBZO2_NO2',
+  'OddOx_Ox_Loss  = 2.0*O_O3 + O1D_H2O',
+  'OddOx_HOx_Loss = HO2_O + HO2_O3 + OH_O + OH_O3 + H_O3',
+  'OddOx_NOx_Loss = 2.0*NO2_O + 2.0*jno3_b',
+  'OddOx_CLOxBROx_Loss = 2.0*CLO_O + 2.0*jcl2o2 + 2.0*CLO_CLOa + 2.0*CLO_CLOb + 2.0*BRO_CLOb + 2.0*BRO_CLOc + 2.0*BRO_BRO + 2.0*BRO_O + CLO_HO2 + BRO_HO2',
+  'OddOx_Loss_Tot = 2.0*O_O3 + O1D_H2O + HO2_O + HO2_O3 + OH_O + OH_O3 + H_O3 + 2.0*NO2_O + 2.0*jno3_b + 2.0*CLO_O + 2.0*jcl2o2 + ',
+                  ' 2.0*CLO_CLOa + 2.0*CLO_CLOb + 2.0*BRO_CLOb + 2.0*BRO_CLOc + 2.0*BRO_BRO + 2.0*BRO_O + CLO_HO2 + BRO_HO2',
+  'OddOx_Prod_Tot = 2.0*jo2_a + 2.0*jo2_b',
+  'Ox_Prod = 2.0*jo2_a + 2.0*jo2_b + NO_HO2 + CH3O2_NO + HOCH2OO_NO + C2H5O2_NO + CH3CO3_NO + EO2_NO + C3H7O2_NO + PO2_NO + ',
+           ' RO2_NO + ENEO2_NO + MACRO2_NOa + MCO3_NO + MEKO2_NO + ALKO2_NO + .92*ISOPAO2_NO + .92*ISOPBO2_NO + ISOPNO3_NO + XO2_NO + ',
+           ' ACBZO2_NO + BENZO2_NO + BZOO_NO + C6H5O2_NO + DICARBO2_NO + MALO2_NO + MDIALO2_NO + PHENO2_NO + TOLO2_NO + XYLENO2_NO + ',
+           ' XYLOLO2_NO + NTERPO2_NO + .9*TERP2O2_NO + .8*TERPO2_NO + jalknit + jhonitr + jisopnooh + jnc4cho + jnoa + jnterpooh + ',
+           ' jonitr + jterpnit + ALKNIT_OH + 0.7*ISOPNITA_OH + NOA_OH + TERPNIT_OH',
+  'Ox_Loss = 2.0*O_O3 + O1D_H2O + HO2_O + HO2_O3 + OH_O + OH_O3 + H_O3 + 2.0*NO2_O + 2.0*jno3_b + 2.0*CLO_O + 2.0*jcl2o2 + ',
+           ' 2.0*CLO_CLOa + 2.0*CLO_CLOb + 2.0*BRO_CLOb + 2.0*BRO_CLOc + 2.0*BRO_BRO + 2.0*BRO_O + CLO_HO2 + BRO_HO2 + C2H4_O3 + ',
+           ' C3H6_O3 + ISOP_O3 + MVK_O3 + MACR_O3 + MTERP_O3 + BCARY_O3 + S_O3 + SO_O3'
+</rxn_rate_sums>
+
+<!-- HEMCO: Harmonized Emissions Component -->
+<use_hemco>.false.</use_hemco>
+<hemco_data_root>atm/cam/geoschem/ExtData/HEMCO</hemco_data_root>
+<hemco_config_file>atm/cam/hemco/HEMCO_Config.CC.CEDS_AEIC19.NEx.c241122.rc</hemco_config_file>
+<hemco_diagn_file>atm/cam/hemco/HEMCO_Diagn.3_5_0.c230307.rc</hemco_diagn_file>
+<hemco_emission_year>-1</hemco_emission_year>
+
+<!-- Default emissions grid resolution at 2x2.5 degree: coarser may result in masking artifacts -->
+<hemco_grid_xdim>144</hemco_grid_xdim>
+<hemco_grid_ydim>91</hemco_grid_ydim>
+
+<!-- if using SE refined mesh use 0.5x0.625 degree grid -->
+<hemco_grid_xdim se_refined_mesh="1">576</hemco_grid_xdim>
+<hemco_grid_ydim se_refined_mesh="1">361</hemco_grid_ydim>
+
+<!-- use 0.9x1.25 degree HEMCO grid for ne30 simulation -->
+<hemco_grid_xdim hgrid="ne30np4">288</hemco_grid_xdim>
+<hemco_grid_ydim hgrid="ne30np4">201</hemco_grid_ydim>
+
+<!-- use 0.9x1.25 degree HEMCO grid for 0.9x1.25 degree simulation -->
+<hemco_grid_xdim hgrid="0.9x1.25">288</hemco_grid_xdim>
+<hemco_grid_ydim hgrid="0.9x1.25">201</hemco_grid_ydim>
+
+<!-- use 2x2.5 degree HEMCO grid for 1.9x2.5 degree simulation -->
+<hemco_grid_xdim hgrid="1.9x2.5">144</hemco_grid_xdim>
+<hemco_grid_ydim hgrid="1.9x2.5">91</hemco_grid_ydim>
+
+<!-- GEOS-Chem chemistry -->
+<geoschem_chem_inputs chem="geoschem_mam4">atm/cam/geoschem/ExtData/CHEM_INPUTS</geoschem_chem_inputs>
+<geoschem_aeropt_inputs chem="geoschem_mam4">atm/cam/geoschem/ExtData/CHEM_INPUTS/Aerosol_Optics/v2024-08/</geoschem_aeropt_inputs>
+<geoschem_photol_inputs chem="geoschem_mam4">atm/cam/geoschem/ExtData/CHEM_INPUTS/CLOUD_J/v2024-09/</geoschem_photol_inputs>
+
+<BC_GAINS_filename >atm/cam/chem/carma/data/ETP_base_CLE_V5_BC_2010.nc</BC_GAINS_filename>
+<OC_GAINS_filename >atm/cam/chem/carma/data/ETP_base_CLE_V5_OC_2010.nc</OC_GAINS_filename>
+<BC_ship_filename  >atm/cam/chem/carma/data/IPCC_BC_ships_2010_0.5x0.5.nc</BC_ship_filename>
+<OC_ship_filename  >atm/cam/chem/carma/data/IPCC_OC_ships_2010_0.5x0.5.nc</OC_ship_filename>
+<BC_GFEDv3_filename>atm/cam/chem/carma/data/GFEDv3_BC_2010.nc</BC_GFEDv3_filename>
+<OC_GFEDv3_filename>atm/cam/chem/carma/data/GFEDv3_OC_2010.nc</OC_GFEDv3_filename>
+
+<bin_defs carma="trop_strat_soa1">
+  'MXAER01:=',  'N:NBMXAER01:N:CLDNBMXAER01:num:+',
+                'A:MXSULF01:N:CLDMXSULF01:sulfate:shell:$INPUTDATA_ROOT/atm/cam/physprops/sulfate_rrtmg_carma_c080918.nc:+',
+                'A:MXOC01:N:CLDMXOC01:p-organic:shell:$INPUTDATA_ROOT/atm/cam/physprops/ocphi_rrtmg_carma_c100508.nc:+',
+                'A:MXSOA01:N:CLDMXSOA01:s-organic:shell:$INPUTDATA_ROOT/atm/cam/physprops/soa_rrtmg_carma_c100508.nc:+',
+                'A:MXBC01:N:CLDMXBC01:black-c:core:$INPUTDATA_ROOT/atm/cam/physprops/bcpho_rrtmg_carma_c100508.nc:+',
+                'A:MXDUST01:N:CLDMXDUST01:dust:core:$INPUTDATA_ROOT/atm/cam/physprops/dust_aeronet_rrtmg_carma_c141106.nc:+',
+                'A:MXSALT01:N:CLDMXSALT01:seasalt:shell:$INPUTDATA_ROOT/atm/cam/physprops/ssam_rrtmg_carma_c100508.nc',
+   'MXAER02:=', 'N:NBMXAER02:N:CLDNBMXAER02:num:+',
+                'A:MXSULF02:N:CLDMXSULF02:sulfate:shell:$INPUTDATA_ROOT/atm/cam/physprops/sulfate_rrtmg_carma_c080918.nc:+',
+                'A:MXOC02:N:CLDMXOC02:p-organic:shell:$INPUTDATA_ROOT/atm/cam/physprops/ocphi_rrtmg_carma_c100508.nc:+',
+                'A:MXSOA02:N:CLDMXSOA02:s-organic:shell:$INPUTDATA_ROOT/atm/cam/physprops/soa_rrtmg_carma_c100508.nc:+',
+                'A:MXBC02:N:CLDMXBC02:black-c:core:$INPUTDATA_ROOT/atm/cam/physprops/bcpho_rrtmg_carma_c100508.nc:+',
+                'A:MXDUST02:N:CLDMXDUST02:dust:core:$INPUTDATA_ROOT/atm/cam/physprops/dust_aeronet_rrtmg_carma_c141106.nc:+',
+                'A:MXSALT02:N:CLDMXSALT02:seasalt:shell:$INPUTDATA_ROOT/atm/cam/physprops/ssam_rrtmg_carma_c100508.nc',
+   'MXAER03:=', 'N:NBMXAER03:N:CLDNBMXAER03:num:+',
+                'A:MXSULF03:N:CLDMXSULF03:sulfate:shell:$INPUTDATA_ROOT/atm/cam/physprops/sulfate_rrtmg_carma_c080918.nc:+',
+                'A:MXOC03:N:CLDMXOC03:p-organic:shell:$INPUTDATA_ROOT/atm/cam/physprops/ocphi_rrtmg_carma_c100508.nc:+',
+                'A:MXSOA03:N:CLDMXSOA03:s-organic:shell:$INPUTDATA_ROOT/atm/cam/physprops/soa_rrtmg_carma_c100508.nc:+',
+                'A:MXBC03:N:CLDMXBC03:black-c:core:$INPUTDATA_ROOT/atm/cam/physprops/bcpho_rrtmg_carma_c100508.nc:+',
+                'A:MXDUST03:N:CLDMXDUST03:dust:core:$INPUTDATA_ROOT/atm/cam/physprops/dust_aeronet_rrtmg_carma_c141106.nc:+',
+                'A:MXSALT03:N:CLDMXSALT03:seasalt:shell:$INPUTDATA_ROOT/atm/cam/physprops/ssam_rrtmg_carma_c100508.nc',
+   'MXAER04:=', 'N:NBMXAER04:N:CLDNBMXAER04:num:+',
+                'A:MXSULF04:N:CLDMXSULF04:sulfate:shell:$INPUTDATA_ROOT/atm/cam/physprops/sulfate_rrtmg_carma_c080918.nc:+',
+                'A:MXOC04:N:CLDMXOC04:p-organic:shell:$INPUTDATA_ROOT/atm/cam/physprops/ocphi_rrtmg_carma_c100508.nc:+',
+                'A:MXSOA04:N:CLDMXSOA04:s-organic:shell:$INPUTDATA_ROOT/atm/cam/physprops/soa_rrtmg_carma_c100508.nc:+',
+                'A:MXBC04:N:CLDMXBC04:black-c:core:$INPUTDATA_ROOT/atm/cam/physprops/bcpho_rrtmg_carma_c100508.nc:+',
+                'A:MXDUST04:N:CLDMXDUST04:dust:core:$INPUTDATA_ROOT/atm/cam/physprops/dust_aeronet_rrtmg_carma_c141106.nc:+',
+                'A:MXSALT04:N:CLDMXSALT04:seasalt:shell:$INPUTDATA_ROOT/atm/cam/physprops/ssam_rrtmg_carma_c100508.nc',
+   'MXAER05:=', 'N:NBMXAER05:N:CLDNBMXAER05:num:+',
+                'A:MXSULF05:N:CLDMXSULF05:sulfate:shell:$INPUTDATA_ROOT/atm/cam/physprops/sulfate_rrtmg_carma_c080918.nc:+',
+                'A:MXOC05:N:CLDMXOC05:p-organic:shell:$INPUTDATA_ROOT/atm/cam/physprops/ocphi_rrtmg_carma_c100508.nc:+',
+                'A:MXSOA05:N:CLDMXSOA05:s-organic:shell:$INPUTDATA_ROOT/atm/cam/physprops/soa_rrtmg_carma_c100508.nc:+',
+                'A:MXBC05:N:CLDMXBC05:black-c:core:$INPUTDATA_ROOT/atm/cam/physprops/bcpho_rrtmg_carma_c100508.nc:+',
+                'A:MXDUST05:N:CLDMXDUST05:dust:core:$INPUTDATA_ROOT/atm/cam/physprops/dust_aeronet_rrtmg_carma_c141106.nc:+',
+                'A:MXSALT05:N:CLDMXSALT05:seasalt:shell:$INPUTDATA_ROOT/atm/cam/physprops/ssam_rrtmg_carma_c100508.nc',
+   'MXAER06:=', 'N:NBMXAER06:N:CLDNBMXAER06:num:+',
+                'A:MXSULF06:N:CLDMXSULF06:sulfate:shell:$INPUTDATA_ROOT/atm/cam/physprops/sulfate_rrtmg_carma_c080918.nc:+',
+                'A:MXOC06:N:CLDMXOC06:p-organic:shell:$INPUTDATA_ROOT/atm/cam/physprops/ocphi_rrtmg_carma_c100508.nc:+',
+                'A:MXSOA06:N:CLDMXSOA06:s-organic:shell:$INPUTDATA_ROOT/atm/cam/physprops/soa_rrtmg_carma_c100508.nc:+',
+                'A:MXBC06:N:CLDMXBC06:black-c:core:$INPUTDATA_ROOT/atm/cam/physprops/bcpho_rrtmg_carma_c100508.nc:+',
+                'A:MXDUST06:N:CLDMXDUST06:dust:core:$INPUTDATA_ROOT/atm/cam/physprops/dust_aeronet_rrtmg_carma_c141106.nc:+',
+                'A:MXSALT06:N:CLDMXSALT06:seasalt:shell:$INPUTDATA_ROOT/atm/cam/physprops/ssam_rrtmg_carma_c100508.nc',
+   'MXAER07:=', 'N:NBMXAER07:N:CLDNBMXAER07:num:+',
+                'A:MXSULF07:N:CLDMXSULF07:sulfate:shell:$INPUTDATA_ROOT/atm/cam/physprops/sulfate_rrtmg_carma_c080918.nc:+',
+                'A:MXOC07:N:CLDMXOC07:p-organic:shell:$INPUTDATA_ROOT/atm/cam/physprops/ocphi_rrtmg_carma_c100508.nc:+',
+                'A:MXSOA07:N:CLDMXSOA07:s-organic:shell:$INPUTDATA_ROOT/atm/cam/physprops/soa_rrtmg_carma_c100508.nc:+',
+                'A:MXBC07:N:CLDMXBC07:black-c:core:$INPUTDATA_ROOT/atm/cam/physprops/bcpho_rrtmg_carma_c100508.nc:+',
+                'A:MXDUST07:N:CLDMXDUST07:dust:core:$INPUTDATA_ROOT/atm/cam/physprops/dust_aeronet_rrtmg_carma_c141106.nc:+',
+                'A:MXSALT07:N:CLDMXSALT07:seasalt:shell:$INPUTDATA_ROOT/atm/cam/physprops/ssam_rrtmg_carma_c100508.nc',
+   'MXAER08:=', 'N:NBMXAER08:N:CLDNBMXAER08:num:+',
+                'A:MXSULF08:N:CLDMXSULF08:sulfate:shell:$INPUTDATA_ROOT/atm/cam/physprops/sulfate_rrtmg_carma_c080918.nc:+',
+                'A:MXOC08:N:CLDMXOC08:p-organic:shell:$INPUTDATA_ROOT/atm/cam/physprops/ocphi_rrtmg_carma_c100508.nc:+',
+                'A:MXSOA08:N:CLDMXSOA08:s-organic:shell:$INPUTDATA_ROOT/atm/cam/physprops/soa_rrtmg_carma_c100508.nc:+',
+                'A:MXBC08:N:CLDMXBC08:black-c:core:$INPUTDATA_ROOT/atm/cam/physprops/bcpho_rrtmg_carma_c100508.nc:+',
+                'A:MXDUST08:N:CLDMXDUST08:dust:core:$INPUTDATA_ROOT/atm/cam/physprops/dust_aeronet_rrtmg_carma_c141106.nc:+',
+                'A:MXSALT08:N:CLDMXSALT08:seasalt:shell:$INPUTDATA_ROOT/atm/cam/physprops/ssam_rrtmg_carma_c100508.nc',
+   'MXAER09:=', 'N:NBMXAER09:N:CLDNBMXAER09:num:+',
+                'A:MXSULF09:N:CLDMXSULF09:sulfate:shell:$INPUTDATA_ROOT/atm/cam/physprops/sulfate_rrtmg_carma_c080918.nc:+',
+                'A:MXOC09:N:CLDMXOC09:p-organic:shell:$INPUTDATA_ROOT/atm/cam/physprops/ocphi_rrtmg_carma_c100508.nc:+',
+                'A:MXSOA09:N:CLDMXSOA09:s-organic:shell:$INPUTDATA_ROOT/atm/cam/physprops/soa_rrtmg_carma_c100508.nc:+',
+                'A:MXBC09:N:CLDMXBC09:black-c:core:$INPUTDATA_ROOT/atm/cam/physprops/bcpho_rrtmg_carma_c100508.nc:+',
+                'A:MXDUST09:N:CLDMXDUST09:dust:core:$INPUTDATA_ROOT/atm/cam/physprops/dust_aeronet_rrtmg_carma_c141106.nc:+',
+                'A:MXSALT09:N:CLDMXSALT09:seasalt:shell:$INPUTDATA_ROOT/atm/cam/physprops/ssam_rrtmg_carma_c100508.nc',
+   'MXAER10:=', 'N:NBMXAER10:N:CLDNBMXAER10:num:+',
+                'A:MXSULF10:N:CLDMXSULF10:sulfate:shell:$INPUTDATA_ROOT/atm/cam/physprops/sulfate_rrtmg_carma_c080918.nc:+',
+                'A:MXOC10:N:CLDMXOC10:p-organic:shell:$INPUTDATA_ROOT/atm/cam/physprops/ocphi_rrtmg_carma_c100508.nc:+',
+                'A:MXSOA10:N:CLDMXSOA10:s-organic:shell:$INPUTDATA_ROOT/atm/cam/physprops/soa_rrtmg_carma_c100508.nc:+',
+                'A:MXBC10:N:CLDMXBC10:black-c:core:$INPUTDATA_ROOT/atm/cam/physprops/bcpho_rrtmg_carma_c100508.nc:+',
+                'A:MXDUST10:N:CLDMXDUST10:dust:core:$INPUTDATA_ROOT/atm/cam/physprops/dust_aeronet_rrtmg_carma_c141106.nc:+',
+                'A:MXSALT10:N:CLDMXSALT10:seasalt:shell:$INPUTDATA_ROOT/atm/cam/physprops/ssam_rrtmg_carma_c100508.nc',
+   'MXAER11:=', 'N:NBMXAER11:N:CLDNBMXAER11:num:+',
+                'A:MXSULF11:N:CLDMXSULF11:sulfate:shell:$INPUTDATA_ROOT/atm/cam/physprops/sulfate_rrtmg_carma_c080918.nc:+',
+                'A:MXOC11:N:CLDMXOC11:p-organic:shell:$INPUTDATA_ROOT/atm/cam/physprops/ocphi_rrtmg_carma_c100508.nc:+',
+                'A:MXSOA11:N:CLDMXSOA11:s-organic:shell:$INPUTDATA_ROOT/atm/cam/physprops/soa_rrtmg_carma_c100508.nc:+',
+                'A:MXBC11:N:CLDMXBC11:black-c:core:$INPUTDATA_ROOT/atm/cam/physprops/bcpho_rrtmg_carma_c100508.nc:+',
+                'A:MXDUST11:N:CLDMXDUST11:dust:core:$INPUTDATA_ROOT/atm/cam/physprops/dust_aeronet_rrtmg_carma_c141106.nc:+',
+                'A:MXSALT11:N:CLDMXSALT11:seasalt:shell:$INPUTDATA_ROOT/atm/cam/physprops/ssam_rrtmg_carma_c100508.nc',
+   'MXAER12:=', 'N:NBMXAER12:N:CLDNBMXAER12:num:+',
+                'A:MXSULF12:N:CLDMXSULF12:sulfate:shell:$INPUTDATA_ROOT/atm/cam/physprops/sulfate_rrtmg_carma_c080918.nc:+',
+                'A:MXOC12:N:CLDMXOC12:p-organic:shell:$INPUTDATA_ROOT/atm/cam/physprops/ocphi_rrtmg_carma_c100508.nc:+',
+                'A:MXSOA12:N:CLDMXSOA12:s-organic:shell:$INPUTDATA_ROOT/atm/cam/physprops/soa_rrtmg_carma_c100508.nc:+',
+                'A:MXBC12:N:CLDMXBC12:black-c:core:$INPUTDATA_ROOT/atm/cam/physprops/bcpho_rrtmg_carma_c100508.nc:+',
+                'A:MXDUST12:N:CLDMXDUST12:dust:core:$INPUTDATA_ROOT/atm/cam/physprops/dust_aeronet_rrtmg_carma_c141106.nc:+',
+                'A:MXSALT12:N:CLDMXSALT12:seasalt:shell:$INPUTDATA_ROOT/atm/cam/physprops/ssam_rrtmg_carma_c100508.nc',
+   'MXAER13:=', 'N:NBMXAER13:N:CLDNBMXAER13:num:+',
+                'A:MXSULF13:N:CLDMXSULF13:sulfate:shell:$INPUTDATA_ROOT/atm/cam/physprops/sulfate_rrtmg_carma_c080918.nc:+',
+                'A:MXOC13:N:CLDMXOC13:p-organic:shell:$INPUTDATA_ROOT/atm/cam/physprops/ocphi_rrtmg_carma_c100508.nc:+',
+                'A:MXSOA13:N:CLDMXSOA13:s-organic:shell:$INPUTDATA_ROOT/atm/cam/physprops/soa_rrtmg_carma_c100508.nc:+',
+                'A:MXBC13:N:CLDMXBC13:black-c:core:$INPUTDATA_ROOT/atm/cam/physprops/bcpho_rrtmg_carma_c100508.nc:+',
+                'A:MXDUST13:N:CLDMXDUST13:dust:core:$INPUTDATA_ROOT/atm/cam/physprops/dust_aeronet_rrtmg_carma_c141106.nc:+',
+                'A:MXSALT13:N:CLDMXSALT13:seasalt:shell:$INPUTDATA_ROOT/atm/cam/physprops/ssam_rrtmg_carma_c100508.nc',
+   'MXAER14:=', 'N:NBMXAER14:N:CLDNBMXAER14:num:+',
+                'A:MXSULF14:N:CLDMXSULF14:sulfate:shell:$INPUTDATA_ROOT/atm/cam/physprops/sulfate_rrtmg_carma_c080918.nc:+',
+                'A:MXOC14:N:CLDMXOC14:p-organic:shell:$INPUTDATA_ROOT/atm/cam/physprops/ocphi_rrtmg_carma_c100508.nc:+',
+                'A:MXSOA14:N:CLDMXSOA14:s-organic:shell:$INPUTDATA_ROOT/atm/cam/physprops/soa_rrtmg_carma_c100508.nc:+',
+                'A:MXBC14:N:CLDMXBC14:black-c:core:$INPUTDATA_ROOT/atm/cam/physprops/bcpho_rrtmg_carma_c100508.nc:+',
+                'A:MXDUST14:N:CLDMXDUST14:dust:core:$INPUTDATA_ROOT/atm/cam/physprops/dust_aeronet_rrtmg_carma_c141106.nc:+',
+                'A:MXSALT14:N:CLDMXSALT14:seasalt:shell:$INPUTDATA_ROOT/atm/cam/physprops/ssam_rrtmg_carma_c100508.nc',
+   'MXAER15:=', 'N:NBMXAER15:N:CLDNBMXAER15:num:+',
+                'A:MXSULF15:N:CLDMXSULF15:sulfate:shell:$INPUTDATA_ROOT/atm/cam/physprops/sulfate_rrtmg_carma_c080918.nc:+',
+                'A:MXOC15:N:CLDMXOC15:p-organic:shell:$INPUTDATA_ROOT/atm/cam/physprops/ocphi_rrtmg_carma_c100508.nc:+',
+                'A:MXSOA15:N:CLDMXSOA15:s-organic:shell:$INPUTDATA_ROOT/atm/cam/physprops/soa_rrtmg_carma_c100508.nc:+',
+                'A:MXBC15:N:CLDMXBC15:black-c:core:$INPUTDATA_ROOT/atm/cam/physprops/bcpho_rrtmg_carma_c100508.nc:+',
+                'A:MXDUST15:N:CLDMXDUST15:dust:core:$INPUTDATA_ROOT/atm/cam/physprops/dust_aeronet_rrtmg_carma_c141106.nc:+',
+                'A:MXSALT15:N:CLDMXSALT15:seasalt:shell:$INPUTDATA_ROOT/atm/cam/physprops/ssam_rrtmg_carma_c100508.nc',
+   'MXAER16:=', 'N:NBMXAER16:N:CLDNBMXAER16:num:+',
+                'A:MXSULF16:N:CLDMXSULF16:sulfate:shell:$INPUTDATA_ROOT/atm/cam/physprops/sulfate_rrtmg_carma_c080918.nc:+',
+                'A:MXOC16:N:CLDMXOC16:p-organic:shell:$INPUTDATA_ROOT/atm/cam/physprops/ocphi_rrtmg_carma_c100508.nc:+',
+                'A:MXSOA16:N:CLDMXSOA16:s-organic:shell:$INPUTDATA_ROOT/atm/cam/physprops/soa_rrtmg_carma_c100508.nc:+',
+                'A:MXBC16:N:CLDMXBC16:black-c:core:$INPUTDATA_ROOT/atm/cam/physprops/bcpho_rrtmg_carma_c100508.nc:+',
+                'A:MXDUST16:N:CLDMXDUST16:dust:core:$INPUTDATA_ROOT/atm/cam/physprops/dust_aeronet_rrtmg_carma_c141106.nc:+',
+                'A:MXSALT16:N:CLDMXSALT16:seasalt:shell:$INPUTDATA_ROOT/atm/cam/physprops/ssam_rrtmg_carma_c100508.nc',
+   'MXAER17:=', 'N:NBMXAER17:N:CLDNBMXAER17:num:+',
+                'A:MXSULF17:N:CLDMXSULF17:sulfate:shell:$INPUTDATA_ROOT/atm/cam/physprops/sulfate_rrtmg_carma_c080918.nc:+',
+                'A:MXOC17:N:CLDMXOC17:p-organic:shell:$INPUTDATA_ROOT/atm/cam/physprops/ocphi_rrtmg_carma_c100508.nc:+',
+                'A:MXSOA17:N:CLDMXSOA17:s-organic:shell:$INPUTDATA_ROOT/atm/cam/physprops/soa_rrtmg_carma_c100508.nc:+',
+                'A:MXBC17:N:CLDMXBC17:black-c:core:$INPUTDATA_ROOT/atm/cam/physprops/bcpho_rrtmg_carma_c100508.nc:+',
+                'A:MXDUST17:N:CLDMXDUST17:dust:core:$INPUTDATA_ROOT/atm/cam/physprops/dust_aeronet_rrtmg_carma_c141106.nc:+',
+                'A:MXSALT17:N:CLDMXSALT17:seasalt:shell:$INPUTDATA_ROOT/atm/cam/physprops/ssam_rrtmg_carma_c100508.nc',
+   'MXAER18:=', 'N:NBMXAER18:N:CLDNBMXAER18:num:+',
+                'A:MXSULF18:N:CLDMXSULF18:sulfate:shell:$INPUTDATA_ROOT/atm/cam/physprops/sulfate_rrtmg_carma_c080918.nc:+',
+                'A:MXOC18:N:CLDMXOC18:p-organic:shell:$INPUTDATA_ROOT/atm/cam/physprops/ocphi_rrtmg_carma_c100508.nc:+',
+                'A:MXSOA18:N:CLDMXSOA18:s-organic:shell:$INPUTDATA_ROOT/atm/cam/physprops/soa_rrtmg_carma_c100508.nc:+',
+                'A:MXBC18:N:CLDMXBC18:black-c:core:$INPUTDATA_ROOT/atm/cam/physprops/bcpho_rrtmg_carma_c100508.nc:+',
+                'A:MXDUST18:N:CLDMXDUST18:dust:core:$INPUTDATA_ROOT/atm/cam/physprops/dust_aeronet_rrtmg_carma_c141106.nc:+',
+                'A:MXSALT18:N:CLDMXSALT18:seasalt:shell:$INPUTDATA_ROOT/atm/cam/physprops/ssam_rrtmg_carma_c100508.nc',
+   'MXAER19:=', 'N:NBMXAER19:N:CLDNBMXAER19:num:+',
+                'A:MXSULF19:N:CLDMXSULF19:sulfate:shell:$INPUTDATA_ROOT/atm/cam/physprops/sulfate_rrtmg_carma_c080918.nc:+',
+                'A:MXOC19:N:CLDMXOC19:p-organic:shell:$INPUTDATA_ROOT/atm/cam/physprops/ocphi_rrtmg_carma_c100508.nc:+',
+                'A:MXSOA19:N:CLDMXSOA19:s-organic:shell:$INPUTDATA_ROOT/atm/cam/physprops/soa_rrtmg_carma_c100508.nc:+',
+                'A:MXBC19:N:CLDMXBC19:black-c:core:$INPUTDATA_ROOT/atm/cam/physprops/bcpho_rrtmg_carma_c100508.nc:+',
+                'A:MXDUST19:N:CLDMXDUST19:dust:core:$INPUTDATA_ROOT/atm/cam/physprops/dust_aeronet_rrtmg_carma_c141106.nc:+',
+                'A:MXSALT19:N:CLDMXSALT19:seasalt:shell:$INPUTDATA_ROOT/atm/cam/physprops/ssam_rrtmg_carma_c100508.nc',
+   'MXAER20:=', 'N:NBMXAER20:N:CLDNBMXAER20:num:+',
+                'A:MXSULF20:N:CLDMXSULF20:sulfate:shell:$INPUTDATA_ROOT/atm/cam/physprops/sulfate_rrtmg_carma_c080918.nc:+',
+                'A:MXOC20:N:CLDMXOC20:p-organic:shell:$INPUTDATA_ROOT/atm/cam/physprops/ocphi_rrtmg_carma_c100508.nc:+',
+                'A:MXSOA20:N:CLDMXSOA20:s-organic:shell:$INPUTDATA_ROOT/atm/cam/physprops/soa_rrtmg_carma_c100508.nc:+',
+                'A:MXBC20:N:CLDMXBC20:black-c:core:$INPUTDATA_ROOT/atm/cam/physprops/bcpho_rrtmg_carma_c100508.nc:+',
+                'A:MXDUST20:N:CLDMXDUST20:dust:core:$INPUTDATA_ROOT/atm/cam/physprops/dust_aeronet_rrtmg_carma_c141106.nc:+',
+                'A:MXSALT20:N:CLDMXSALT20:seasalt:shell:$INPUTDATA_ROOT/atm/cam/physprops/ssam_rrtmg_carma_c100508.nc',
+   'PRSUL01:=', 'N:NBPRSUL01:N:CLDNBPRSUL01:num:+',
+                'A:PRSULF01:N:CLDPRSULF01:sulfate:shell:$INPUTDATA_ROOT/atm/cam/physprops/sulfate_rrtmg_carma_c080918.nc',
+   'PRSUL02:=', 'N:NBPRSUL02:N:CLDNBPRSUL02:num:+',
+                'A:PRSULF02:N:CLDPRSULF02:sulfate:shell:$INPUTDATA_ROOT/atm/cam/physprops/sulfate_rrtmg_carma_c080918.nc',
+   'PRSUL03:=', 'N:NBPRSUL03:N:CLDNBPRSUL03:num:+',
+                'A:PRSULF03:N:CLDPRSULF03:sulfate:shell:$INPUTDATA_ROOT/atm/cam/physprops/sulfate_rrtmg_carma_c080918.nc',
+   'PRSUL04:=', 'N:NBPRSUL04:N:CLDNBPRSUL04:num:+',
+                'A:PRSULF04:N:CLDPRSULF04:sulfate:shell:$INPUTDATA_ROOT/atm/cam/physprops/sulfate_rrtmg_carma_c080918.nc',
+   'PRSUL05:=', 'N:NBPRSUL05:N:CLDNBPRSUL05:num:+',
+                'A:PRSULF05:N:CLDPRSULF05:sulfate:shell:$INPUTDATA_ROOT/atm/cam/physprops/sulfate_rrtmg_carma_c080918.nc',
+   'PRSUL06:=', 'N:NBPRSUL06:N:CLDNBPRSUL06:num:+',
+                'A:PRSULF06:N:CLDPRSULF06:sulfate:shell:$INPUTDATA_ROOT/atm/cam/physprops/sulfate_rrtmg_carma_c080918.nc',
+   'PRSUL07:=', 'N:NBPRSUL07:N:CLDNBPRSUL07:num:+',
+                'A:PRSULF07:N:CLDPRSULF07:sulfate:shell:$INPUTDATA_ROOT/atm/cam/physprops/sulfate_rrtmg_carma_c080918.nc',
+   'PRSUL08:=', 'N:NBPRSUL08:N:CLDNBPRSUL08:num:+',
+                'A:PRSULF08:N:CLDPRSULF08:sulfate:shell:$INPUTDATA_ROOT/atm/cam/physprops/sulfate_rrtmg_carma_c080918.nc',
+   'PRSUL09:=', 'N:NBPRSUL09:N:CLDNBPRSUL09:num:+',
+                'A:PRSULF09:N:CLDPRSULF09:sulfate:shell:$INPUTDATA_ROOT/atm/cam/physprops/sulfate_rrtmg_carma_c080918.nc',
+   'PRSUL10:=', 'N:NBPRSUL10:N:CLDNBPRSUL10:num:+',
+                'A:PRSULF10:N:CLDPRSULF10:sulfate:shell:$INPUTDATA_ROOT/atm/cam/physprops/sulfate_rrtmg_carma_c080918.nc',
+   'PRSUL11:=', 'N:NBPRSUL11:N:CLDNBPRSUL11:num:+',
+                'A:PRSULF11:N:CLDPRSULF11:sulfate:shell:$INPUTDATA_ROOT/atm/cam/physprops/sulfate_rrtmg_carma_c080918.nc',
+   'PRSUL12:=', 'N:NBPRSUL12:N:CLDNBPRSUL12:num:+',
+                'A:PRSULF12:N:CLDPRSULF12:sulfate:shell:$INPUTDATA_ROOT/atm/cam/physprops/sulfate_rrtmg_carma_c080918.nc',
+   'PRSUL13:=', 'N:NBPRSUL13:N:CLDNBPRSUL13:num:+',
+                'A:PRSULF13:N:CLDPRSULF13:sulfate:shell:$INPUTDATA_ROOT/atm/cam/physprops/sulfate_rrtmg_carma_c080918.nc',
+   'PRSUL14:=', 'N:NBPRSUL14:N:CLDNBPRSUL14:num:+',
+                'A:PRSULF14:N:CLDPRSULF14:sulfate:shell:$INPUTDATA_ROOT/atm/cam/physprops/sulfate_rrtmg_carma_c080918.nc',
+   'PRSUL15:=', 'N:NBPRSUL15:N:CLDNBPRSUL15:num:+',
+                'A:PRSULF15:N:CLDPRSULF15:sulfate:shell:$INPUTDATA_ROOT/atm/cam/physprops/sulfate_rrtmg_carma_c080918.nc',
+   'PRSUL16:=', 'N:NBPRSUL16:N:CLDNBPRSUL16:num:+',
+                'A:PRSULF16:N:CLDPRSULF16:sulfate:shell:$INPUTDATA_ROOT/atm/cam/physprops/sulfate_rrtmg_carma_c080918.nc',
+   'PRSUL17:=', 'N:NBPRSUL17:N:CLDNBPRSUL17:num:+',
+                'A:PRSULF17:N:CLDPRSULF17:sulfate:shell:$INPUTDATA_ROOT/atm/cam/physprops/sulfate_rrtmg_carma_c080918.nc',
+   'PRSUL18:=', 'N:NBPRSUL18:N:CLDNBPRSUL18:num:+',
+                'A:PRSULF18:N:CLDPRSULF18:sulfate:shell:$INPUTDATA_ROOT/atm/cam/physprops/sulfate_rrtmg_carma_c080918.nc',
+   'PRSUL19:=', 'N:NBPRSUL19:N:CLDNBPRSUL19:num:+',
+                'A:PRSULF19:N:CLDPRSULF19:sulfate:shell:$INPUTDATA_ROOT/atm/cam/physprops/sulfate_rrtmg_carma_c080918.nc',
+   'PRSUL20:=', 'N:NBPRSUL20:N:CLDNBPRSUL20:num:+',
+                'A:PRSULF20:N:CLDPRSULF20:sulfate:shell:$INPUTDATA_ROOT/atm/cam/physprops/sulfate_rrtmg_carma_c080918.nc'
+</bin_defs>
+
+<bin_defs carma="trop_strat_soa5">
+   'MXAER01:=', 'N:NBMXAER01:N:CLDNBMXAER01:num:+',
+                'A:MXSULF01:N:CLDMXSULF01:sulfate:shell:$INPUTDATA_ROOT/atm/cam/physprops/sulfate_rrtmg_carma_c080918.nc:+',
+                'A:MXOC01:N:CLDMXOC01:p-organic:shell:$INPUTDATA_ROOT/atm/cam/physprops/ocphi_rrtmg_carma_c100508.nc:+',
+                'A:MXSOA101:N:CLDMXSOA101:s-organic:shell:$INPUTDATA_ROOT/atm/cam/physprops/soa_rrtmg_carma_c100508.nc:+',
+                'A:MXSOA201:N:CLDMXSOA201:s-organic:shell:$INPUTDATA_ROOT/atm/cam/physprops/soa_rrtmg_carma_c100508.nc:+',
+                'A:MXSOA301:N:CLDMXSOA301:s-organic:shell:$INPUTDATA_ROOT/atm/cam/physprops/soa_rrtmg_carma_c100508.nc:+',
+                'A:MXSOA401:N:CLDMXSOA401:s-organic:shell:$INPUTDATA_ROOT/atm/cam/physprops/soa_rrtmg_carma_c100508.nc:+',
+                'A:MXSOA501:N:CLDMXSOA501:s-organic:shell:$INPUTDATA_ROOT/atm/cam/physprops/soa_rrtmg_carma_c100508.nc:+',
+                'A:MXBC01:N:CLDMXBC01:black-c:core:$INPUTDATA_ROOT/atm/cam/physprops/bcpho_rrtmg_carma_c100508.nc:+',
+                'A:MXDUST01:N:CLDMXDUST01:dust:core:$INPUTDATA_ROOT/atm/cam/physprops/dust_aeronet_rrtmg_carma_c141106.nc:+',
+                'A:MXSALT01:N:CLDMXSALT01:seasalt:shell:$INPUTDATA_ROOT/atm/cam/physprops/ssam_rrtmg_carma_c100508.nc',
+   'MXAER02:=', 'N:NBMXAER02:N:CLDNBMXAER02:num:+',
+                'A:MXSULF02:N:CLDMXSULF02:sulfate:shell:$INPUTDATA_ROOT/atm/cam/physprops/sulfate_rrtmg_carma_c080918.nc:+',
+                'A:MXOC02:N:CLDMXOC02:p-organic:shell:$INPUTDATA_ROOT/atm/cam/physprops/ocphi_rrtmg_carma_c100508.nc:+',
+                'A:MXSOA102:N:CLDMXSOA102:s-organic:shell:$INPUTDATA_ROOT/atm/cam/physprops/soa_rrtmg_carma_c100508.nc:+',
+                'A:MXSOA202:N:CLDMXSOA202:s-organic:shell:$INPUTDATA_ROOT/atm/cam/physprops/soa_rrtmg_carma_c100508.nc:+',
+                'A:MXSOA302:N:CLDMXSOA302:s-organic:shell:$INPUTDATA_ROOT/atm/cam/physprops/soa_rrtmg_carma_c100508.nc:+',
+                'A:MXSOA402:N:CLDMXSOA402:s-organic:shell:$INPUTDATA_ROOT/atm/cam/physprops/soa_rrtmg_carma_c100508.nc:+',
+                'A:MXSOA502:N:CLDMXSOA502:s-organic:shell:$INPUTDATA_ROOT/atm/cam/physprops/soa_rrtmg_carma_c100508.nc:+',
+                'A:MXBC02:N:CLDMXBC02:black-c:core:$INPUTDATA_ROOT/atm/cam/physprops/bcpho_rrtmg_carma_c100508.nc:+',
+                'A:MXDUST02:N:CLDMXDUST02:dust:core:$INPUTDATA_ROOT/atm/cam/physprops/dust_aeronet_rrtmg_carma_c141106.nc:+',
+                'A:MXSALT02:N:CLDMXSALT02:seasalt:shell:$INPUTDATA_ROOT/atm/cam/physprops/ssam_rrtmg_carma_c100508.nc',
+   'MXAER03:=', 'N:NBMXAER03:N:CLDNBMXAER03:num:+',
+                'A:MXSULF03:N:CLDMXSULF03:sulfate:shell:$INPUTDATA_ROOT/atm/cam/physprops/sulfate_rrtmg_carma_c080918.nc:+',
+                'A:MXOC03:N:CLDMXOC03:p-organic:shell:$INPUTDATA_ROOT/atm/cam/physprops/ocphi_rrtmg_carma_c100508.nc:+',
+                'A:MXSOA103:N:CLDMXSOA103:s-organic:shell:$INPUTDATA_ROOT/atm/cam/physprops/soa_rrtmg_carma_c100508.nc:+',
+                'A:MXSOA203:N:CLDMXSOA203:s-organic:shell:$INPUTDATA_ROOT/atm/cam/physprops/soa_rrtmg_carma_c100508.nc:+',
+                'A:MXSOA303:N:CLDMXSOA303:s-organic:shell:$INPUTDATA_ROOT/atm/cam/physprops/soa_rrtmg_carma_c100508.nc:+',
+                'A:MXSOA403:N:CLDMXSOA403:s-organic:shell:$INPUTDATA_ROOT/atm/cam/physprops/soa_rrtmg_carma_c100508.nc:+',
+                'A:MXSOA503:N:CLDMXSOA503:s-organic:shell:$INPUTDATA_ROOT/atm/cam/physprops/soa_rrtmg_carma_c100508.nc:+',
+                'A:MXBC03:N:CLDMXBC03:black-c:core:$INPUTDATA_ROOT/atm/cam/physprops/bcpho_rrtmg_carma_c100508.nc:+',
+                'A:MXDUST03:N:CLDMXDUST03:dust:core:$INPUTDATA_ROOT/atm/cam/physprops/dust_aeronet_rrtmg_carma_c141106.nc:+',
+                'A:MXSALT03:N:CLDMXSALT03:seasalt:shell:$INPUTDATA_ROOT/atm/cam/physprops/ssam_rrtmg_carma_c100508.nc',
+   'MXAER04:=', 'N:NBMXAER04:N:CLDNBMXAER04:num:+',
+                'A:MXSULF04:N:CLDMXSULF04:sulfate:shell:$INPUTDATA_ROOT/atm/cam/physprops/sulfate_rrtmg_carma_c080918.nc:+',
+                'A:MXOC04:N:CLDMXOC04:p-organic:shell:$INPUTDATA_ROOT/atm/cam/physprops/ocphi_rrtmg_carma_c100508.nc:+',
+                'A:MXSOA104:N:CLDMXSOA104:s-organic:shell:$INPUTDATA_ROOT/atm/cam/physprops/soa_rrtmg_carma_c100508.nc:+',
+                'A:MXSOA204:N:CLDMXSOA204:s-organic:shell:$INPUTDATA_ROOT/atm/cam/physprops/soa_rrtmg_carma_c100508.nc:+',
+                'A:MXSOA304:N:CLDMXSOA304:s-organic:shell:$INPUTDATA_ROOT/atm/cam/physprops/soa_rrtmg_carma_c100508.nc:+',
+                'A:MXSOA404:N:CLDMXSOA404:s-organic:shell:$INPUTDATA_ROOT/atm/cam/physprops/soa_rrtmg_carma_c100508.nc:+',
+                'A:MXSOA504:N:CLDMXSOA504:s-organic:shell:$INPUTDATA_ROOT/atm/cam/physprops/soa_rrtmg_carma_c100508.nc:+',
+                'A:MXBC04:N:CLDMXBC04:black-c:core:$INPUTDATA_ROOT/atm/cam/physprops/bcpho_rrtmg_carma_c100508.nc:+',
+                'A:MXDUST04:N:CLDMXDUST04:dust:core:$INPUTDATA_ROOT/atm/cam/physprops/dust_aeronet_rrtmg_carma_c141106.nc:+',
+                'A:MXSALT04:N:CLDMXSALT04:seasalt:shell:$INPUTDATA_ROOT/atm/cam/physprops/ssam_rrtmg_carma_c100508.nc',
+   'MXAER05:=', 'N:NBMXAER05:N:CLDNBMXAER05:num:+',
+                'A:MXSULF05:N:CLDMXSULF05:sulfate:shell:$INPUTDATA_ROOT/atm/cam/physprops/sulfate_rrtmg_carma_c080918.nc:+',
+                'A:MXOC05:N:CLDMXOC05:p-organic:shell:$INPUTDATA_ROOT/atm/cam/physprops/ocphi_rrtmg_carma_c100508.nc:+',
+                'A:MXSOA105:N:CLDMXSOA105:s-organic:shell:$INPUTDATA_ROOT/atm/cam/physprops/soa_rrtmg_carma_c100508.nc:+',
+                'A:MXSOA205:N:CLDMXSOA205:s-organic:shell:$INPUTDATA_ROOT/atm/cam/physprops/soa_rrtmg_carma_c100508.nc:+',
+                'A:MXSOA305:N:CLDMXSOA305:s-organic:shell:$INPUTDATA_ROOT/atm/cam/physprops/soa_rrtmg_carma_c100508.nc:+',
+                'A:MXSOA405:N:CLDMXSOA405:s-organic:shell:$INPUTDATA_ROOT/atm/cam/physprops/soa_rrtmg_carma_c100508.nc:+',
+                'A:MXSOA505:N:CLDMXSOA505:s-organic:shell:$INPUTDATA_ROOT/atm/cam/physprops/soa_rrtmg_carma_c100508.nc:+',
+                'A:MXBC05:N:CLDMXBC05:black-c:core:$INPUTDATA_ROOT/atm/cam/physprops/bcpho_rrtmg_carma_c100508.nc:+',
+                'A:MXDUST05:N:CLDMXDUST05:dust:core:$INPUTDATA_ROOT/atm/cam/physprops/dust_aeronet_rrtmg_carma_c141106.nc:+',
+                'A:MXSALT05:N:CLDMXSALT05:seasalt:shell:$INPUTDATA_ROOT/atm/cam/physprops/ssam_rrtmg_carma_c100508.nc',
+   'MXAER06:=', 'N:NBMXAER06:N:CLDNBMXAER06:num:+',
+                'A:MXSULF06:N:CLDMXSULF06:sulfate:shell:$INPUTDATA_ROOT/atm/cam/physprops/sulfate_rrtmg_carma_c080918.nc:+',
+                'A:MXOC06:N:CLDMXOC06:p-organic:shell:$INPUTDATA_ROOT/atm/cam/physprops/ocphi_rrtmg_carma_c100508.nc:+',
+                'A:MXSOA106:N:CLDMXSOA106:s-organic:shell:$INPUTDATA_ROOT/atm/cam/physprops/soa_rrtmg_carma_c100508.nc:+',
+                'A:MXSOA206:N:CLDMXSOA206:s-organic:shell:$INPUTDATA_ROOT/atm/cam/physprops/soa_rrtmg_carma_c100508.nc:+',
+                'A:MXSOA306:N:CLDMXSOA306:s-organic:shell:$INPUTDATA_ROOT/atm/cam/physprops/soa_rrtmg_carma_c100508.nc:+',
+                'A:MXSOA406:N:CLDMXSOA406:s-organic:shell:$INPUTDATA_ROOT/atm/cam/physprops/soa_rrtmg_carma_c100508.nc:+',
+                'A:MXSOA506:N:CLDMXSOA506:s-organic:shell:$INPUTDATA_ROOT/atm/cam/physprops/soa_rrtmg_carma_c100508.nc:+',
+                'A:MXBC06:N:CLDMXBC06:black-c:core:$INPUTDATA_ROOT/atm/cam/physprops/bcpho_rrtmg_carma_c100508.nc:+',
+                'A:MXDUST06:N:CLDMXDUST06:dust:core:$INPUTDATA_ROOT/atm/cam/physprops/dust_aeronet_rrtmg_carma_c141106.nc:+',
+                'A:MXSALT06:N:CLDMXSALT06:seasalt:shell:$INPUTDATA_ROOT/atm/cam/physprops/ssam_rrtmg_carma_c100508.nc',
+   'MXAER07:=', 'N:NBMXAER07:N:CLDNBMXAER07:num:+',
+                'A:MXSULF07:N:CLDMXSULF07:sulfate:shell:$INPUTDATA_ROOT/atm/cam/physprops/sulfate_rrtmg_carma_c080918.nc:+',
+                'A:MXOC07:N:CLDMXOC07:p-organic:shell:$INPUTDATA_ROOT/atm/cam/physprops/ocphi_rrtmg_carma_c100508.nc:+',
+                'A:MXSOA107:N:CLDMXSOA107:s-organic:shell:$INPUTDATA_ROOT/atm/cam/physprops/soa_rrtmg_carma_c100508.nc:+',
+                'A:MXSOA207:N:CLDMXSOA207:s-organic:shell:$INPUTDATA_ROOT/atm/cam/physprops/soa_rrtmg_carma_c100508.nc:+',
+                'A:MXSOA307:N:CLDMXSOA307:s-organic:shell:$INPUTDATA_ROOT/atm/cam/physprops/soa_rrtmg_carma_c100508.nc:+',
+                'A:MXSOA407:N:CLDMXSOA407:s-organic:shell:$INPUTDATA_ROOT/atm/cam/physprops/soa_rrtmg_carma_c100508.nc:+',
+                'A:MXSOA507:N:CLDMXSOA507:s-organic:shell:$INPUTDATA_ROOT/atm/cam/physprops/soa_rrtmg_carma_c100508.nc:+',
+                'A:MXBC07:N:CLDMXBC07:black-c:core:$INPUTDATA_ROOT/atm/cam/physprops/bcpho_rrtmg_carma_c100508.nc:+',
+                'A:MXDUST07:N:CLDMXDUST07:dust:core:$INPUTDATA_ROOT/atm/cam/physprops/dust_aeronet_rrtmg_carma_c141106.nc:+',
+                'A:MXSALT07:N:CLDMXSALT07:seasalt:shell:$INPUTDATA_ROOT/atm/cam/physprops/ssam_rrtmg_carma_c100508.nc',
+   'MXAER08:=', 'N:NBMXAER08:N:CLDNBMXAER08:num:+',
+                'A:MXSULF08:N:CLDMXSULF08:sulfate:shell:$INPUTDATA_ROOT/atm/cam/physprops/sulfate_rrtmg_carma_c080918.nc:+',
+                'A:MXOC08:N:CLDMXOC08:p-organic:shell:$INPUTDATA_ROOT/atm/cam/physprops/ocphi_rrtmg_carma_c100508.nc:+',
+                'A:MXSOA108:N:CLDMXSOA108:s-organic:shell:$INPUTDATA_ROOT/atm/cam/physprops/soa_rrtmg_carma_c100508.nc:+',
+                'A:MXSOA208:N:CLDMXSOA208:s-organic:shell:$INPUTDATA_ROOT/atm/cam/physprops/soa_rrtmg_carma_c100508.nc:+',
+                'A:MXSOA308:N:CLDMXSOA308:s-organic:shell:$INPUTDATA_ROOT/atm/cam/physprops/soa_rrtmg_carma_c100508.nc:+',
+                'A:MXSOA408:N:CLDMXSOA408:s-organic:shell:$INPUTDATA_ROOT/atm/cam/physprops/soa_rrtmg_carma_c100508.nc:+',
+                'A:MXSOA508:N:CLDMXSOA508:s-organic:shell:$INPUTDATA_ROOT/atm/cam/physprops/soa_rrtmg_carma_c100508.nc:+',
+                'A:MXBC08:N:CLDMXBC08:black-c:core:$INPUTDATA_ROOT/atm/cam/physprops/bcpho_rrtmg_carma_c100508.nc:+',
+                'A:MXDUST08:N:CLDMXDUST08:dust:core:$INPUTDATA_ROOT/atm/cam/physprops/dust_aeronet_rrtmg_carma_c141106.nc:+',
+                'A:MXSALT08:N:CLDMXSALT08:seasalt:shell:$INPUTDATA_ROOT/atm/cam/physprops/ssam_rrtmg_carma_c100508.nc',
+   'MXAER09:=', 'N:NBMXAER09:N:CLDNBMXAER09:num:+',
+                'A:MXSULF09:N:CLDMXSULF09:sulfate:shell:$INPUTDATA_ROOT/atm/cam/physprops/sulfate_rrtmg_carma_c080918.nc:+',
+                'A:MXOC09:N:CLDMXOC09:p-organic:shell:$INPUTDATA_ROOT/atm/cam/physprops/ocphi_rrtmg_carma_c100508.nc:+',
+                'A:MXSOA109:N:CLDMXSOA109:s-organic:shell:$INPUTDATA_ROOT/atm/cam/physprops/soa_rrtmg_carma_c100508.nc:+',
+                'A:MXSOA209:N:CLDMXSOA209:s-organic:shell:$INPUTDATA_ROOT/atm/cam/physprops/soa_rrtmg_carma_c100508.nc:+',
+                'A:MXSOA309:N:CLDMXSOA309:s-organic:shell:$INPUTDATA_ROOT/atm/cam/physprops/soa_rrtmg_carma_c100508.nc:+',
+                'A:MXSOA409:N:CLDMXSOA409:s-organic:shell:$INPUTDATA_ROOT/atm/cam/physprops/soa_rrtmg_carma_c100508.nc:+',
+                'A:MXSOA509:N:CLDMXSOA509:s-organic:shell:$INPUTDATA_ROOT/atm/cam/physprops/soa_rrtmg_carma_c100508.nc:+',
+                'A:MXBC09:N:CLDMXBC09:black-c:core:$INPUTDATA_ROOT/atm/cam/physprops/bcpho_rrtmg_carma_c100508.nc:+',
+                'A:MXDUST09:N:CLDMXDUST09:dust:core:$INPUTDATA_ROOT/atm/cam/physprops/dust_aeronet_rrtmg_carma_c141106.nc:+',
+                'A:MXSALT09:N:CLDMXSALT09:seasalt:shell:$INPUTDATA_ROOT/atm/cam/physprops/ssam_rrtmg_carma_c100508.nc',
+   'MXAER10:=', 'N:NBMXAER10:N:CLDNBMXAER10:num:+',
+                'A:MXSULF10:N:CLDMXSULF10:sulfate:shell:$INPUTDATA_ROOT/atm/cam/physprops/sulfate_rrtmg_carma_c080918.nc:+',
+                'A:MXOC10:N:CLDMXOC10:p-organic:shell:$INPUTDATA_ROOT/atm/cam/physprops/ocphi_rrtmg_carma_c100508.nc:+',
+                'A:MXSOA110:N:CLDMXSOA110:s-organic:shell:$INPUTDATA_ROOT/atm/cam/physprops/soa_rrtmg_carma_c100508.nc:+',
+                'A:MXSOA210:N:CLDMXSOA210:s-organic:shell:$INPUTDATA_ROOT/atm/cam/physprops/soa_rrtmg_carma_c100508.nc:+',
+                'A:MXSOA310:N:CLDMXSOA310:s-organic:shell:$INPUTDATA_ROOT/atm/cam/physprops/soa_rrtmg_carma_c100508.nc:+',
+                'A:MXSOA410:N:CLDMXSOA410:s-organic:shell:$INPUTDATA_ROOT/atm/cam/physprops/soa_rrtmg_carma_c100508.nc:+',
+                'A:MXSOA510:N:CLDMXSOA510:s-organic:shell:$INPUTDATA_ROOT/atm/cam/physprops/soa_rrtmg_carma_c100508.nc:+',
+                'A:MXBC10:N:CLDMXBC10:black-c:core:$INPUTDATA_ROOT/atm/cam/physprops/bcpho_rrtmg_carma_c100508.nc:+',
+                'A:MXDUST10:N:CLDMXDUST10:dust:core:$INPUTDATA_ROOT/atm/cam/physprops/dust_aeronet_rrtmg_carma_c141106.nc:+',
+                'A:MXSALT10:N:CLDMXSALT10:seasalt:shell:$INPUTDATA_ROOT/atm/cam/physprops/ssam_rrtmg_carma_c100508.nc',
+   'MXAER11:=', 'N:NBMXAER11:N:CLDNBMXAER11:num:+',
+                'A:MXSULF11:N:CLDMXSULF11:sulfate:shell:$INPUTDATA_ROOT/atm/cam/physprops/sulfate_rrtmg_carma_c080918.nc:+',
+                'A:MXOC11:N:CLDMXOC11:p-organic:shell:$INPUTDATA_ROOT/atm/cam/physprops/ocphi_rrtmg_carma_c100508.nc:+',
+                'A:MXSOA111:N:CLDMXSOA111:s-organic:shell:$INPUTDATA_ROOT/atm/cam/physprops/soa_rrtmg_carma_c100508.nc:+',
+                'A:MXSOA211:N:CLDMXSOA211:s-organic:shell:$INPUTDATA_ROOT/atm/cam/physprops/soa_rrtmg_carma_c100508.nc:+',
+                'A:MXSOA311:N:CLDMXSOA311:s-organic:shell:$INPUTDATA_ROOT/atm/cam/physprops/soa_rrtmg_carma_c100508.nc:+',
+                'A:MXSOA411:N:CLDMXSOA411:s-organic:shell:$INPUTDATA_ROOT/atm/cam/physprops/soa_rrtmg_carma_c100508.nc:+',
+                'A:MXSOA511:N:CLDMXSOA511:s-organic:shell:$INPUTDATA_ROOT/atm/cam/physprops/soa_rrtmg_carma_c100508.nc:+',
+                'A:MXBC11:N:CLDMXBC11:black-c:core:$INPUTDATA_ROOT/atm/cam/physprops/bcpho_rrtmg_carma_c100508.nc:+',
+                'A:MXDUST11:N:CLDMXDUST11:dust:core:$INPUTDATA_ROOT/atm/cam/physprops/dust_aeronet_rrtmg_carma_c141106.nc:+',
+                'A:MXSALT11:N:CLDMXSALT11:seasalt:shell:$INPUTDATA_ROOT/atm/cam/physprops/ssam_rrtmg_carma_c100508.nc',
+   'MXAER12:=', 'N:NBMXAER12:N:CLDNBMXAER12:num:+',
+                'A:MXSULF12:N:CLDMXSULF12:sulfate:shell:$INPUTDATA_ROOT/atm/cam/physprops/sulfate_rrtmg_carma_c080918.nc:+',
+                'A:MXOC12:N:CLDMXOC12:p-organic:shell:$INPUTDATA_ROOT/atm/cam/physprops/ocphi_rrtmg_carma_c100508.nc:+',
+                'A:MXSOA112:N:CLDMXSOA112:s-organic:shell:$INPUTDATA_ROOT/atm/cam/physprops/soa_rrtmg_carma_c100508.nc:+',
+                'A:MXSOA212:N:CLDMXSOA212:s-organic:shell:$INPUTDATA_ROOT/atm/cam/physprops/soa_rrtmg_carma_c100508.nc:+',
+                'A:MXSOA312:N:CLDMXSOA312:s-organic:shell:$INPUTDATA_ROOT/atm/cam/physprops/soa_rrtmg_carma_c100508.nc:+',
+                'A:MXSOA412:N:CLDMXSOA412:s-organic:shell:$INPUTDATA_ROOT/atm/cam/physprops/soa_rrtmg_carma_c100508.nc:+',
+                'A:MXSOA512:N:CLDMXSOA512:s-organic:shell:$INPUTDATA_ROOT/atm/cam/physprops/soa_rrtmg_carma_c100508.nc:+',
+                'A:MXBC12:N:CLDMXBC12:black-c:core:$INPUTDATA_ROOT/atm/cam/physprops/bcpho_rrtmg_carma_c100508.nc:+',
+                'A:MXDUST12:N:CLDMXDUST12:dust:core:$INPUTDATA_ROOT/atm/cam/physprops/dust_aeronet_rrtmg_carma_c141106.nc:+',
+                'A:MXSALT12:N:CLDMXSALT12:seasalt:shell:$INPUTDATA_ROOT/atm/cam/physprops/ssam_rrtmg_carma_c100508.nc',
+   'MXAER13:=', 'N:NBMXAER13:N:CLDNBMXAER13:num:+',
+                'A:MXSULF13:N:CLDMXSULF13:sulfate:shell:$INPUTDATA_ROOT/atm/cam/physprops/sulfate_rrtmg_carma_c080918.nc:+',
+                'A:MXOC13:N:CLDMXOC13:p-organic:shell:$INPUTDATA_ROOT/atm/cam/physprops/ocphi_rrtmg_carma_c100508.nc:+',
+                'A:MXSOA113:N:CLDMXSOA113:s-organic:shell:$INPUTDATA_ROOT/atm/cam/physprops/soa_rrtmg_carma_c100508.nc:+',
+                'A:MXSOA213:N:CLDMXSOA213:s-organic:shell:$INPUTDATA_ROOT/atm/cam/physprops/soa_rrtmg_carma_c100508.nc:+',
+                'A:MXSOA313:N:CLDMXSOA313:s-organic:shell:$INPUTDATA_ROOT/atm/cam/physprops/soa_rrtmg_carma_c100508.nc:+',
+                'A:MXSOA413:N:CLDMXSOA413:s-organic:shell:$INPUTDATA_ROOT/atm/cam/physprops/soa_rrtmg_carma_c100508.nc:+',
+                'A:MXSOA513:N:CLDMXSOA513:s-organic:shell:$INPUTDATA_ROOT/atm/cam/physprops/soa_rrtmg_carma_c100508.nc:+',
+                'A:MXBC13:N:CLDMXBC13:black-c:core:$INPUTDATA_ROOT/atm/cam/physprops/bcpho_rrtmg_carma_c100508.nc:+',
+                'A:MXDUST13:N:CLDMXDUST13:dust:core:$INPUTDATA_ROOT/atm/cam/physprops/dust_aeronet_rrtmg_carma_c141106.nc:+',
+                'A:MXSALT13:N:CLDMXSALT13:seasalt:shell:$INPUTDATA_ROOT/atm/cam/physprops/ssam_rrtmg_carma_c100508.nc',
+   'MXAER14:=', 'N:NBMXAER14:N:CLDNBMXAER14:num:+',
+                'A:MXSULF14:N:CLDMXSULF14:sulfate:shell:$INPUTDATA_ROOT/atm/cam/physprops/sulfate_rrtmg_carma_c080918.nc:+',
+                'A:MXOC14:N:CLDMXOC14:p-organic:shell:$INPUTDATA_ROOT/atm/cam/physprops/ocphi_rrtmg_carma_c100508.nc:+',
+                'A:MXSOA114:N:CLDMXSOA114:s-organic:shell:$INPUTDATA_ROOT/atm/cam/physprops/soa_rrtmg_carma_c100508.nc:+',
+                'A:MXSOA214:N:CLDMXSOA214:s-organic:shell:$INPUTDATA_ROOT/atm/cam/physprops/soa_rrtmg_carma_c100508.nc:+',
+                'A:MXSOA314:N:CLDMXSOA314:s-organic:shell:$INPUTDATA_ROOT/atm/cam/physprops/soa_rrtmg_carma_c100508.nc:+',
+                'A:MXSOA414:N:CLDMXSOA414:s-organic:shell:$INPUTDATA_ROOT/atm/cam/physprops/soa_rrtmg_carma_c100508.nc:+',
+                'A:MXSOA514:N:CLDMXSOA514:s-organic:shell:$INPUTDATA_ROOT/atm/cam/physprops/soa_rrtmg_carma_c100508.nc:+',
+                'A:MXBC14:N:CLDMXBC14:black-c:core:$INPUTDATA_ROOT/atm/cam/physprops/bcpho_rrtmg_carma_c100508.nc:+',
+                'A:MXDUST14:N:CLDMXDUST14:dust:core:$INPUTDATA_ROOT/atm/cam/physprops/dust_aeronet_rrtmg_carma_c141106.nc:+',
+                'A:MXSALT14:N:CLDMXSALT14:seasalt:shell:$INPUTDATA_ROOT/atm/cam/physprops/ssam_rrtmg_carma_c100508.nc',
+   'MXAER15:=', 'N:NBMXAER15:N:CLDNBMXAER15:num:+',
+                'A:MXSULF15:N:CLDMXSULF15:sulfate:shell:$INPUTDATA_ROOT/atm/cam/physprops/sulfate_rrtmg_carma_c080918.nc:+',
+                'A:MXOC15:N:CLDMXOC15:p-organic:shell:$INPUTDATA_ROOT/atm/cam/physprops/ocphi_rrtmg_carma_c100508.nc:+',
+                'A:MXSOA115:N:CLDMXSOA115:s-organic:shell:$INPUTDATA_ROOT/atm/cam/physprops/soa_rrtmg_carma_c100508.nc:+',
+                'A:MXSOA215:N:CLDMXSOA215:s-organic:shell:$INPUTDATA_ROOT/atm/cam/physprops/soa_rrtmg_carma_c100508.nc:+',
+                'A:MXSOA315:N:CLDMXSOA315:s-organic:shell:$INPUTDATA_ROOT/atm/cam/physprops/soa_rrtmg_carma_c100508.nc:+',
+                'A:MXSOA415:N:CLDMXSOA415:s-organic:shell:$INPUTDATA_ROOT/atm/cam/physprops/soa_rrtmg_carma_c100508.nc:+',
+                'A:MXSOA515:N:CLDMXSOA515:s-organic:shell:$INPUTDATA_ROOT/atm/cam/physprops/soa_rrtmg_carma_c100508.nc:+',
+                'A:MXBC15:N:CLDMXBC15:black-c:core:$INPUTDATA_ROOT/atm/cam/physprops/bcpho_rrtmg_carma_c100508.nc:+',
+                'A:MXDUST15:N:CLDMXDUST15:dust:core:$INPUTDATA_ROOT/atm/cam/physprops/dust_aeronet_rrtmg_carma_c141106.nc:+',
+                'A:MXSALT15:N:CLDMXSALT15:seasalt:shell:$INPUTDATA_ROOT/atm/cam/physprops/ssam_rrtmg_carma_c100508.nc',
+   'MXAER16:=', 'N:NBMXAER16:N:CLDNBMXAER16:num:+',
+                'A:MXSULF16:N:CLDMXSULF16:sulfate:shell:$INPUTDATA_ROOT/atm/cam/physprops/sulfate_rrtmg_carma_c080918.nc:+',
+                'A:MXOC16:N:CLDMXOC16:p-organic:shell:$INPUTDATA_ROOT/atm/cam/physprops/ocphi_rrtmg_carma_c100508.nc:+',
+                'A:MXSOA116:N:CLDMXSOA116:s-organic:shell:$INPUTDATA_ROOT/atm/cam/physprops/soa_rrtmg_carma_c100508.nc:+',
+                'A:MXSOA216:N:CLDMXSOA216:s-organic:shell:$INPUTDATA_ROOT/atm/cam/physprops/soa_rrtmg_carma_c100508.nc:+',
+                'A:MXSOA316:N:CLDMXSOA316:s-organic:shell:$INPUTDATA_ROOT/atm/cam/physprops/soa_rrtmg_carma_c100508.nc:+',
+                'A:MXSOA416:N:CLDMXSOA416:s-organic:shell:$INPUTDATA_ROOT/atm/cam/physprops/soa_rrtmg_carma_c100508.nc:+',
+                'A:MXSOA516:N:CLDMXSOA516:s-organic:shell:$INPUTDATA_ROOT/atm/cam/physprops/soa_rrtmg_carma_c100508.nc:+',
+                'A:MXBC16:N:CLDMXBC16:black-c:core:$INPUTDATA_ROOT/atm/cam/physprops/bcpho_rrtmg_carma_c100508.nc:+',
+                'A:MXDUST16:N:CLDMXDUST16:dust:core:$INPUTDATA_ROOT/atm/cam/physprops/dust_aeronet_rrtmg_carma_c141106.nc:+',
+                'A:MXSALT16:N:CLDMXSALT16:seasalt:shell:$INPUTDATA_ROOT/atm/cam/physprops/ssam_rrtmg_carma_c100508.nc',
+   'MXAER17:=', 'N:NBMXAER17:N:CLDNBMXAER17:num:+',
+                'A:MXSULF17:N:CLDMXSULF17:sulfate:shell:$INPUTDATA_ROOT/atm/cam/physprops/sulfate_rrtmg_carma_c080918.nc:+',
+                'A:MXOC17:N:CLDMXOC17:p-organic:shell:$INPUTDATA_ROOT/atm/cam/physprops/ocphi_rrtmg_carma_c100508.nc:+',
+                'A:MXSOA117:N:CLDMXSOA117:s-organic:shell:$INPUTDATA_ROOT/atm/cam/physprops/soa_rrtmg_carma_c100508.nc:+',
+                'A:MXSOA217:N:CLDMXSOA217:s-organic:shell:$INPUTDATA_ROOT/atm/cam/physprops/soa_rrtmg_carma_c100508.nc:+',
+                'A:MXSOA317:N:CLDMXSOA317:s-organic:shell:$INPUTDATA_ROOT/atm/cam/physprops/soa_rrtmg_carma_c100508.nc:+',
+                'A:MXSOA417:N:CLDMXSOA417:s-organic:shell:$INPUTDATA_ROOT/atm/cam/physprops/soa_rrtmg_carma_c100508.nc:+',
+                'A:MXSOA517:N:CLDMXSOA517:s-organic:shell:$INPUTDATA_ROOT/atm/cam/physprops/soa_rrtmg_carma_c100508.nc:+',
+                'A:MXBC17:N:CLDMXBC17:black-c:core:$INPUTDATA_ROOT/atm/cam/physprops/bcpho_rrtmg_carma_c100508.nc:+',
+                'A:MXDUST17:N:CLDMXDUST17:dust:core:$INPUTDATA_ROOT/atm/cam/physprops/dust_aeronet_rrtmg_carma_c141106.nc:+',
+                'A:MXSALT17:N:CLDMXSALT17:seasalt:shell:$INPUTDATA_ROOT/atm/cam/physprops/ssam_rrtmg_carma_c100508.nc',
+   'MXAER18:=', 'N:NBMXAER18:N:CLDNBMXAER18:num:+',
+                'A:MXSULF18:N:CLDMXSULF18:sulfate:shell:$INPUTDATA_ROOT/atm/cam/physprops/sulfate_rrtmg_carma_c080918.nc:+',
+                'A:MXOC18:N:CLDMXOC18:p-organic:shell:$INPUTDATA_ROOT/atm/cam/physprops/ocphi_rrtmg_carma_c100508.nc:+',
+                'A:MXSOA118:N:CLDMXSOA118:s-organic:shell:$INPUTDATA_ROOT/atm/cam/physprops/soa_rrtmg_carma_c100508.nc:+',
+                'A:MXSOA218:N:CLDMXSOA218:s-organic:shell:$INPUTDATA_ROOT/atm/cam/physprops/soa_rrtmg_carma_c100508.nc:+',
+                'A:MXSOA318:N:CLDMXSOA318:s-organic:shell:$INPUTDATA_ROOT/atm/cam/physprops/soa_rrtmg_carma_c100508.nc:+',
+                'A:MXSOA418:N:CLDMXSOA418:s-organic:shell:$INPUTDATA_ROOT/atm/cam/physprops/soa_rrtmg_carma_c100508.nc:+',
+                'A:MXSOA518:N:CLDMXSOA518:s-organic:shell:$INPUTDATA_ROOT/atm/cam/physprops/soa_rrtmg_carma_c100508.nc:+',
+                'A:MXBC18:N:CLDMXBC18:black-c:core:$INPUTDATA_ROOT/atm/cam/physprops/bcpho_rrtmg_carma_c100508.nc:+',
+                'A:MXDUST18:N:CLDMXDUST18:dust:core:$INPUTDATA_ROOT/atm/cam/physprops/dust_aeronet_rrtmg_carma_c141106.nc:+',
+                'A:MXSALT18:N:CLDMXSALT18:seasalt:shell:$INPUTDATA_ROOT/atm/cam/physprops/ssam_rrtmg_carma_c100508.nc',
+   'MXAER19:=', 'N:NBMXAER19:N:CLDNBMXAER19:num:+',
+                'A:MXSULF19:N:CLDMXSULF19:sulfate:shell:$INPUTDATA_ROOT/atm/cam/physprops/sulfate_rrtmg_carma_c080918.nc:+',
+                'A:MXOC19:N:CLDMXOC19:p-organic:shell:$INPUTDATA_ROOT/atm/cam/physprops/ocphi_rrtmg_carma_c100508.nc:+',
+                'A:MXSOA119:N:CLDMXSOA119:s-organic:shell:$INPUTDATA_ROOT/atm/cam/physprops/soa_rrtmg_carma_c100508.nc:+',
+                'A:MXSOA219:N:CLDMXSOA219:s-organic:shell:$INPUTDATA_ROOT/atm/cam/physprops/soa_rrtmg_carma_c100508.nc:+',
+                'A:MXSOA319:N:CLDMXSOA319:s-organic:shell:$INPUTDATA_ROOT/atm/cam/physprops/soa_rrtmg_carma_c100508.nc:+',
+                'A:MXSOA419:N:CLDMXSOA419:s-organic:shell:$INPUTDATA_ROOT/atm/cam/physprops/soa_rrtmg_carma_c100508.nc:+',
+                'A:MXSOA519:N:CLDMXSOA519:s-organic:shell:$INPUTDATA_ROOT/atm/cam/physprops/soa_rrtmg_carma_c100508.nc:+',
+                'A:MXBC19:N:CLDMXBC19:black-c:core:$INPUTDATA_ROOT/atm/cam/physprops/bcpho_rrtmg_carma_c100508.nc:+',
+                'A:MXDUST19:N:CLDMXDUST19:dust:core:$INPUTDATA_ROOT/atm/cam/physprops/dust_aeronet_rrtmg_carma_c141106.nc:+',
+                'A:MXSALT19:N:CLDMXSALT19:seasalt:shell:$INPUTDATA_ROOT/atm/cam/physprops/ssam_rrtmg_carma_c100508.nc',
+   'MXAER20:=', 'N:NBMXAER20:N:CLDNBMXAER20:num:+',
+                'A:MXSULF20:N:CLDMXSULF20:sulfate:shell:$INPUTDATA_ROOT/atm/cam/physprops/sulfate_rrtmg_carma_c080918.nc:+',
+                'A:MXOC20:N:CLDMXOC20:p-organic:shell:$INPUTDATA_ROOT/atm/cam/physprops/ocphi_rrtmg_carma_c100508.nc:+',
+                'A:MXSOA120:N:CLDMXSOA120:s-organic:shell:$INPUTDATA_ROOT/atm/cam/physprops/soa_rrtmg_carma_c100508.nc:+',
+                'A:MXSOA220:N:CLDMXSOA220:s-organic:shell:$INPUTDATA_ROOT/atm/cam/physprops/soa_rrtmg_carma_c100508.nc:+',
+                'A:MXSOA320:N:CLDMXSOA320:s-organic:shell:$INPUTDATA_ROOT/atm/cam/physprops/soa_rrtmg_carma_c100508.nc:+',
+                'A:MXSOA420:N:CLDMXSOA420:s-organic:shell:$INPUTDATA_ROOT/atm/cam/physprops/soa_rrtmg_carma_c100508.nc:+',
+                'A:MXSOA520:N:CLDMXSOA520:s-organic:shell:$INPUTDATA_ROOT/atm/cam/physprops/soa_rrtmg_carma_c100508.nc:+',
+                'A:MXBC20:N:CLDMXBC20:black-c:core:$INPUTDATA_ROOT/atm/cam/physprops/bcpho_rrtmg_carma_c100508.nc:+',
+                'A:MXDUST20:N:CLDMXDUST20:dust:core:$INPUTDATA_ROOT/atm/cam/physprops/dust_aeronet_rrtmg_carma_c141106.nc:+',
+                'A:MXSALT20:N:CLDMXSALT20:seasalt:shell:$INPUTDATA_ROOT/atm/cam/physprops/ssam_rrtmg_carma_c100508.nc',
+   'PRSUL01:=', 'N:NBPRSUL01:N:CLDNBPRSUL01:num:+',
+                'A:PRSULF01:N:CLDPRSULF01:sulfate:shell:$INPUTDATA_ROOT/atm/cam/physprops/sulfate_rrtmg_carma_c080918.nc',
+   'PRSUL02:=', 'N:NBPRSUL02:N:CLDNBPRSUL02:num:+',
+                'A:PRSULF02:N:CLDPRSULF02:sulfate:shell:$INPUTDATA_ROOT/atm/cam/physprops/sulfate_rrtmg_carma_c080918.nc',
+   'PRSUL03:=', 'N:NBPRSUL03:N:CLDNBPRSUL03:num:+',
+                'A:PRSULF03:N:CLDPRSULF03:sulfate:shell:$INPUTDATA_ROOT/atm/cam/physprops/sulfate_rrtmg_carma_c080918.nc',
+   'PRSUL04:=', 'N:NBPRSUL04:N:CLDNBPRSUL04:num:+',
+                'A:PRSULF04:N:CLDPRSULF04:sulfate:shell:$INPUTDATA_ROOT/atm/cam/physprops/sulfate_rrtmg_carma_c080918.nc',
+   'PRSUL05:=', 'N:NBPRSUL05:N:CLDNBPRSUL05:num:+',
+                'A:PRSULF05:N:CLDPRSULF05:sulfate:shell:$INPUTDATA_ROOT/atm/cam/physprops/sulfate_rrtmg_carma_c080918.nc',
+   'PRSUL06:=', 'N:NBPRSUL06:N:CLDNBPRSUL06:num:+',
+                'A:PRSULF06:N:CLDPRSULF06:sulfate:shell:$INPUTDATA_ROOT/atm/cam/physprops/sulfate_rrtmg_carma_c080918.nc',
+   'PRSUL07:=', 'N:NBPRSUL07:N:CLDNBPRSUL07:num:+',
+                'A:PRSULF07:N:CLDPRSULF07:sulfate:shell:$INPUTDATA_ROOT/atm/cam/physprops/sulfate_rrtmg_carma_c080918.nc',
+   'PRSUL08:=', 'N:NBPRSUL08:N:CLDNBPRSUL08:num:+',
+                'A:PRSULF08:N:CLDPRSULF08:sulfate:shell:$INPUTDATA_ROOT/atm/cam/physprops/sulfate_rrtmg_carma_c080918.nc',
+   'PRSUL09:=', 'N:NBPRSUL09:N:CLDNBPRSUL09:num:+',
+                'A:PRSULF09:N:CLDPRSULF09:sulfate:shell:$INPUTDATA_ROOT/atm/cam/physprops/sulfate_rrtmg_carma_c080918.nc',
+   'PRSUL10:=', 'N:NBPRSUL10:N:CLDNBPRSUL10:num:+',
+                'A:PRSULF10:N:CLDPRSULF10:sulfate:shell:$INPUTDATA_ROOT/atm/cam/physprops/sulfate_rrtmg_carma_c080918.nc',
+   'PRSUL11:=', 'N:NBPRSUL11:N:CLDNBPRSUL11:num:+',
+                'A:PRSULF11:N:CLDPRSULF11:sulfate:shell:$INPUTDATA_ROOT/atm/cam/physprops/sulfate_rrtmg_carma_c080918.nc',
+   'PRSUL12:=', 'N:NBPRSUL12:N:CLDNBPRSUL12:num:+',
+                'A:PRSULF12:N:CLDPRSULF12:sulfate:shell:$INPUTDATA_ROOT/atm/cam/physprops/sulfate_rrtmg_carma_c080918.nc',
+   'PRSUL13:=', 'N:NBPRSUL13:N:CLDNBPRSUL13:num:+',
+                'A:PRSULF13:N:CLDPRSULF13:sulfate:shell:$INPUTDATA_ROOT/atm/cam/physprops/sulfate_rrtmg_carma_c080918.nc',
+   'PRSUL14:=', 'N:NBPRSUL14:N:CLDNBPRSUL14:num:+',
+                'A:PRSULF14:N:CLDPRSULF14:sulfate:shell:$INPUTDATA_ROOT/atm/cam/physprops/sulfate_rrtmg_carma_c080918.nc',
+   'PRSUL15:=', 'N:NBPRSUL15:N:CLDNBPRSUL15:num:+',
+                'A:PRSULF15:N:CLDPRSULF15:sulfate:shell:$INPUTDATA_ROOT/atm/cam/physprops/sulfate_rrtmg_carma_c080918.nc',
+   'PRSUL16:=', 'N:NBPRSUL16:N:CLDNBPRSUL16:num:+',
+                'A:PRSULF16:N:CLDPRSULF16:sulfate:shell:$INPUTDATA_ROOT/atm/cam/physprops/sulfate_rrtmg_carma_c080918.nc',
+   'PRSUL17:=', 'N:NBPRSUL17:N:CLDNBPRSUL17:num:+',
+                'A:PRSULF17:N:CLDPRSULF17:sulfate:shell:$INPUTDATA_ROOT/atm/cam/physprops/sulfate_rrtmg_carma_c080918.nc',
+   'PRSUL18:=', 'N:NBPRSUL18:N:CLDNBPRSUL18:num:+',
+                'A:PRSULF18:N:CLDPRSULF18:sulfate:shell:$INPUTDATA_ROOT/atm/cam/physprops/sulfate_rrtmg_carma_c080918.nc',
+   'PRSUL19:=', 'N:NBPRSUL19:N:CLDNBPRSUL19:num:+',
+                'A:PRSULF19:N:CLDPRSULF19:sulfate:shell:$INPUTDATA_ROOT/atm/cam/physprops/sulfate_rrtmg_carma_c080918.nc',
+   'PRSUL20:=', 'N:NBPRSUL20:N:CLDNBPRSUL20:num:+',
+                'A:PRSULF20:N:CLDPRSULF20:sulfate:shell:$INPUTDATA_ROOT/atm/cam/physprops/sulfate_rrtmg_carma_c080918.nc'
+</bin_defs>
+
+<rad_climate carma="trop_strat_soa1">
+    'A:Q:H2O', 'N:O2:O2', 'A:CO2:CO2', 'A:O3:O3', 'A:N2O:N2O', 'A:CH4:CH4','N:CFC11:CFC11', 'N:CFC12:CFC12',
+    'B:MXAER01:$INPUTDATA_ROOT/atm/cam/chem/carma/rrtmg/aerosol_cld_CRMIX01_rrtmg.nc',
+    'B:MXAER02:$INPUTDATA_ROOT/atm/cam/chem/carma/rrtmg/aerosol_cld_CRMIX02_rrtmg.nc',
+    'B:MXAER03:$INPUTDATA_ROOT/atm/cam/chem/carma/rrtmg/aerosol_cld_CRMIX03_rrtmg.nc',
+    'B:MXAER04:$INPUTDATA_ROOT/atm/cam/chem/carma/rrtmg/aerosol_cld_CRMIX04_rrtmg.nc',
+    'B:MXAER05:$INPUTDATA_ROOT/atm/cam/chem/carma/rrtmg/aerosol_cld_CRMIX05_rrtmg.nc',
+    'B:MXAER06:$INPUTDATA_ROOT/atm/cam/chem/carma/rrtmg/aerosol_cld_CRMIX06_rrtmg.nc',
+    'B:MXAER07:$INPUTDATA_ROOT/atm/cam/chem/carma/rrtmg/aerosol_cld_CRMIX07_rrtmg.nc',
+    'B:MXAER08:$INPUTDATA_ROOT/atm/cam/chem/carma/rrtmg/aerosol_cld_CRMIX08_rrtmg.nc',
+    'B:MXAER09:$INPUTDATA_ROOT/atm/cam/chem/carma/rrtmg/aerosol_cld_CRMIX09_rrtmg.nc',
+    'B:MXAER10:$INPUTDATA_ROOT/atm/cam/chem/carma/rrtmg/aerosol_cld_CRMIX10_rrtmg.nc',
+    'B:MXAER11:$INPUTDATA_ROOT/atm/cam/chem/carma/rrtmg/aerosol_cld_CRMIX11_rrtmg.nc',
+    'B:MXAER12:$INPUTDATA_ROOT/atm/cam/chem/carma/rrtmg/aerosol_cld_CRMIX12_rrtmg.nc',
+    'B:MXAER13:$INPUTDATA_ROOT/atm/cam/chem/carma/rrtmg/aerosol_cld_CRMIX13_rrtmg.nc',
+    'B:MXAER14:$INPUTDATA_ROOT/atm/cam/chem/carma/rrtmg/aerosol_cld_CRMIX14_rrtmg.nc',
+    'B:MXAER15:$INPUTDATA_ROOT/atm/cam/chem/carma/rrtmg/aerosol_cld_CRMIX15_rrtmg.nc',
+    'B:MXAER16:$INPUTDATA_ROOT/atm/cam/chem/carma/rrtmg/aerosol_cld_CRMIX16_rrtmg.nc',
+    'B:MXAER17:$INPUTDATA_ROOT/atm/cam/chem/carma/rrtmg/aerosol_cld_CRMIX17_rrtmg.nc',
+    'B:MXAER18:$INPUTDATA_ROOT/atm/cam/chem/carma/rrtmg/aerosol_cld_CRMIX18_rrtmg.nc',
+    'B:MXAER19:$INPUTDATA_ROOT/atm/cam/chem/carma/rrtmg/aerosol_cld_CRMIX19_rrtmg.nc',
+    'B:MXAER20:$INPUTDATA_ROOT/atm/cam/chem/carma/rrtmg/aerosol_cld_CRMIX20_rrtmg.nc',
+    'B:PRSUL01:$INPUTDATA_ROOT/atm/cam/chem/carma/rrtmg/aerosol_cld_SULF01_rrtmg.nc',
+    'B:PRSUL02:$INPUTDATA_ROOT/atm/cam/chem/carma/rrtmg/aerosol_cld_SULF02_rrtmg.nc',
+    'B:PRSUL03:$INPUTDATA_ROOT/atm/cam/chem/carma/rrtmg/aerosol_cld_SULF03_rrtmg.nc',
+    'B:PRSUL04:$INPUTDATA_ROOT/atm/cam/chem/carma/rrtmg/aerosol_cld_SULF04_rrtmg.nc',
+    'B:PRSUL05:$INPUTDATA_ROOT/atm/cam/chem/carma/rrtmg/aerosol_cld_SULF05_rrtmg.nc',
+    'B:PRSUL06:$INPUTDATA_ROOT/atm/cam/chem/carma/rrtmg/aerosol_cld_SULF06_rrtmg.nc',
+    'B:PRSUL07:$INPUTDATA_ROOT/atm/cam/chem/carma/rrtmg/aerosol_cld_SULF07_rrtmg.nc',
+    'B:PRSUL08:$INPUTDATA_ROOT/atm/cam/chem/carma/rrtmg/aerosol_cld_SULF08_rrtmg.nc',
+    'B:PRSUL09:$INPUTDATA_ROOT/atm/cam/chem/carma/rrtmg/aerosol_cld_SULF09_rrtmg.nc',
+    'B:PRSUL10:$INPUTDATA_ROOT/atm/cam/chem/carma/rrtmg/aerosol_cld_SULF10_rrtmg.nc',
+    'B:PRSUL11:$INPUTDATA_ROOT/atm/cam/chem/carma/rrtmg/aerosol_cld_SULF11_rrtmg.nc',
+    'B:PRSUL12:$INPUTDATA_ROOT/atm/cam/chem/carma/rrtmg/aerosol_cld_SULF12_rrtmg.nc',
+    'B:PRSUL13:$INPUTDATA_ROOT/atm/cam/chem/carma/rrtmg/aerosol_cld_SULF13_rrtmg.nc',
+    'B:PRSUL14:$INPUTDATA_ROOT/atm/cam/chem/carma/rrtmg/aerosol_cld_SULF14_rrtmg.nc',
+    'B:PRSUL15:$INPUTDATA_ROOT/atm/cam/chem/carma/rrtmg/aerosol_cld_SULF15_rrtmg.nc',
+    'B:PRSUL16:$INPUTDATA_ROOT/atm/cam/chem/carma/rrtmg/aerosol_cld_SULF16_rrtmg.nc',
+    'B:PRSUL17:$INPUTDATA_ROOT/atm/cam/chem/carma/rrtmg/aerosol_cld_SULF17_rrtmg.nc',
+    'B:PRSUL18:$INPUTDATA_ROOT/atm/cam/chem/carma/rrtmg/aerosol_cld_SULF18_rrtmg.nc',
+    'B:PRSUL19:$INPUTDATA_ROOT/atm/cam/chem/carma/rrtmg/aerosol_cld_SULF19_rrtmg.nc',
+    'B:PRSUL20:$INPUTDATA_ROOT/atm/cam/chem/carma/rrtmg/aerosol_cld_SULF20_rrtmg.nc'
+</rad_climate>
+
+<rad_climate carma="trop_strat_soa5">
+    'A:Q:H2O', 'N:O2:O2', 'A:CO2:CO2', 'A:O3:O3', 'A:N2O:N2O', 'A:CH4:CH4','N:CFC11:CFC11', 'N:CFC12:CFC12',
+    'B:MXAER01:$INPUTDATA_ROOT/atm/cam/chem/carma/rrtmg/aerosol_cld_CRMIX01_rrtmg.nc',
+    'B:MXAER02:$INPUTDATA_ROOT/atm/cam/chem/carma/rrtmg/aerosol_cld_CRMIX02_rrtmg.nc',
+    'B:MXAER03:$INPUTDATA_ROOT/atm/cam/chem/carma/rrtmg/aerosol_cld_CRMIX03_rrtmg.nc',
+    'B:MXAER04:$INPUTDATA_ROOT/atm/cam/chem/carma/rrtmg/aerosol_cld_CRMIX04_rrtmg.nc',
+    'B:MXAER05:$INPUTDATA_ROOT/atm/cam/chem/carma/rrtmg/aerosol_cld_CRMIX05_rrtmg.nc',
+    'B:MXAER06:$INPUTDATA_ROOT/atm/cam/chem/carma/rrtmg/aerosol_cld_CRMIX06_rrtmg.nc',
+    'B:MXAER07:$INPUTDATA_ROOT/atm/cam/chem/carma/rrtmg/aerosol_cld_CRMIX07_rrtmg.nc',
+    'B:MXAER08:$INPUTDATA_ROOT/atm/cam/chem/carma/rrtmg/aerosol_cld_CRMIX08_rrtmg.nc',
+    'B:MXAER09:$INPUTDATA_ROOT/atm/cam/chem/carma/rrtmg/aerosol_cld_CRMIX09_rrtmg.nc',
+    'B:MXAER10:$INPUTDATA_ROOT/atm/cam/chem/carma/rrtmg/aerosol_cld_CRMIX10_rrtmg.nc',
+    'B:MXAER11:$INPUTDATA_ROOT/atm/cam/chem/carma/rrtmg/aerosol_cld_CRMIX11_rrtmg.nc',
+    'B:MXAER12:$INPUTDATA_ROOT/atm/cam/chem/carma/rrtmg/aerosol_cld_CRMIX12_rrtmg.nc',
+    'B:MXAER13:$INPUTDATA_ROOT/atm/cam/chem/carma/rrtmg/aerosol_cld_CRMIX13_rrtmg.nc',
+    'B:MXAER14:$INPUTDATA_ROOT/atm/cam/chem/carma/rrtmg/aerosol_cld_CRMIX14_rrtmg.nc',
+    'B:MXAER15:$INPUTDATA_ROOT/atm/cam/chem/carma/rrtmg/aerosol_cld_CRMIX15_rrtmg.nc',
+    'B:MXAER16:$INPUTDATA_ROOT/atm/cam/chem/carma/rrtmg/aerosol_cld_CRMIX16_rrtmg.nc',
+    'B:MXAER17:$INPUTDATA_ROOT/atm/cam/chem/carma/rrtmg/aerosol_cld_CRMIX17_rrtmg.nc',
+    'B:MXAER18:$INPUTDATA_ROOT/atm/cam/chem/carma/rrtmg/aerosol_cld_CRMIX18_rrtmg.nc',
+    'B:MXAER19:$INPUTDATA_ROOT/atm/cam/chem/carma/rrtmg/aerosol_cld_CRMIX19_rrtmg.nc',
+    'B:MXAER20:$INPUTDATA_ROOT/atm/cam/chem/carma/rrtmg/aerosol_cld_CRMIX20_rrtmg.nc',
+    'B:PRSUL01:$INPUTDATA_ROOT/atm/cam/chem/carma/rrtmg/aerosol_cld_SULF01_rrtmg.nc',
+    'B:PRSUL02:$INPUTDATA_ROOT/atm/cam/chem/carma/rrtmg/aerosol_cld_SULF02_rrtmg.nc',
+    'B:PRSUL03:$INPUTDATA_ROOT/atm/cam/chem/carma/rrtmg/aerosol_cld_SULF03_rrtmg.nc',
+    'B:PRSUL04:$INPUTDATA_ROOT/atm/cam/chem/carma/rrtmg/aerosol_cld_SULF04_rrtmg.nc',
+    'B:PRSUL05:$INPUTDATA_ROOT/atm/cam/chem/carma/rrtmg/aerosol_cld_SULF05_rrtmg.nc',
+    'B:PRSUL06:$INPUTDATA_ROOT/atm/cam/chem/carma/rrtmg/aerosol_cld_SULF06_rrtmg.nc',
+    'B:PRSUL07:$INPUTDATA_ROOT/atm/cam/chem/carma/rrtmg/aerosol_cld_SULF07_rrtmg.nc',
+    'B:PRSUL08:$INPUTDATA_ROOT/atm/cam/chem/carma/rrtmg/aerosol_cld_SULF08_rrtmg.nc',
+    'B:PRSUL09:$INPUTDATA_ROOT/atm/cam/chem/carma/rrtmg/aerosol_cld_SULF09_rrtmg.nc',
+    'B:PRSUL10:$INPUTDATA_ROOT/atm/cam/chem/carma/rrtmg/aerosol_cld_SULF10_rrtmg.nc',
+    'B:PRSUL11:$INPUTDATA_ROOT/atm/cam/chem/carma/rrtmg/aerosol_cld_SULF11_rrtmg.nc',
+    'B:PRSUL12:$INPUTDATA_ROOT/atm/cam/chem/carma/rrtmg/aerosol_cld_SULF12_rrtmg.nc',
+    'B:PRSUL13:$INPUTDATA_ROOT/atm/cam/chem/carma/rrtmg/aerosol_cld_SULF13_rrtmg.nc',
+    'B:PRSUL14:$INPUTDATA_ROOT/atm/cam/chem/carma/rrtmg/aerosol_cld_SULF14_rrtmg.nc',
+    'B:PRSUL15:$INPUTDATA_ROOT/atm/cam/chem/carma/rrtmg/aerosol_cld_SULF15_rrtmg.nc',
+    'B:PRSUL16:$INPUTDATA_ROOT/atm/cam/chem/carma/rrtmg/aerosol_cld_SULF16_rrtmg.nc',
+    'B:PRSUL17:$INPUTDATA_ROOT/atm/cam/chem/carma/rrtmg/aerosol_cld_SULF17_rrtmg.nc',
+    'B:PRSUL18:$INPUTDATA_ROOT/atm/cam/chem/carma/rrtmg/aerosol_cld_SULF18_rrtmg.nc',
+    'B:PRSUL19:$INPUTDATA_ROOT/atm/cam/chem/carma/rrtmg/aerosol_cld_SULF19_rrtmg.nc',
+    'B:PRSUL20:$INPUTDATA_ROOT/atm/cam/chem/carma/rrtmg/aerosol_cld_SULF20_rrtmg.nc'
+</rad_climate>
+
+</namelist_defaults>

--- a/TAU_ML_microphysics/bld/namelist_files/namelist_definition.xml
+++ b/TAU_ML_microphysics/bld/namelist_files/namelist_definition.xml
@@ -1,0 +1,10086 @@
+<?xml version="1.0"?>
+
+<?xml-stylesheet type="text/xsl" href="http://www.cgd.ucar.edu/~cam/namelist/namelist_definition_CAM.xsl"?>
+
+<namelist_definition>
+
+<!-- Each namelist variable is defined in an <entry> element.  The
+     content of the element is the documentation of how the variable is
+     used.  Other aspects of the variable's definition are expressed as
+     attributes of the <entry> element.  Note that it is an XML requirement
+     that the attribute values are enclosed in quotes.  The attributes are:
+
+     id
+          The variable's name.  *** N.B. *** The name must be lower case.
+          The module convert all namelist variable names to lower case
+          since Fortran is case insensitive.
+
+     type
+          An abbreviation of the fortran declaration for the variable.
+	  Valid declarations are:
+
+          char*n
+	  integer
+	  logical
+	  real
+
+	  Any of these types may be followed by a comma separated list of
+	  integers enclosed in parenthesis to indicate an array.
+
+	  The current namelist validation code only distinquishes between
+	  string and non-string types.
+
+     input_pathname
+          Only include this attribute to indicate that the variable
+          contains the pathname of an input dataset that resides in the
+          CCSM inputdata directory tree.  Note that the variables
+          containing the names of restart files that are used in branch
+          runs don't reside in the inputdata tree and should not be given
+          this attribute.
+
+	  The recognized values are "abs" to indicate that an absolute
+          pathname is required, or "rel:var_name" to indicate that the
+          pathname is relative and that the namelist variable "var_name"
+          contains the absolute root directory.
+
+     category
+          A category assigned for organizing the documentation.
+
+     group
+          The namelist group that the variable is declared in.
+
+     valid_values
+          This is an optional attribute that is mainly useful for variables
+          that have only a small number of allowed values.
+                                                                        -->
+
+<!-- Frierson Simple Physics Parameters -->
+
+<entry id="frierson_Wind_min" type="real" category="frierson"
+       group="frierson_nl" valid_values="" >
+       Minimum Wind Threshold for surface flux calculations which is
+       added to avoid possible cases that would result in a division by zero.
+       Default: 1.0d-5
+       </entry>
+
+<entry id="frierson_Z0" type="real" category="frierson"
+       group="frierson_nl" valid_values="" >
+       Surface Roughness Length for surface drag calculation.
+       Default: 3.21d-5
+       </entry>
+
+<entry id="frierson_Ri_c" type="real" category="frierson"
+       group="frierson_nl" valid_values="" >
+       Critical Richardson Number for stable mixing cutoff.
+       Default: 1.0
+       </entry>
+
+<entry id="frierson_Fb" type="real" category="frierson"
+       group="frierson_nl" valid_values="" >
+       Surface Layer Fraction of boundary layer depth.
+       The prescribed fraction of the boundary layer depth
+       for surface interactions.
+       Default: 0.1
+       </entry>
+
+<entry id="frierson_Albedo" type="real" category="frierson"
+       group="frierson_nl" valid_values="" >
+       Frierson Albedo: Frierson's Net Solar Flux=>  938.4 = 1360*(1.-0.31)
+       The Frierson model prescribes a net solar flux which incorporated the
+       effects of albedo. Rather than adhering to this formulation, the net
+       solar flux is obtained by a more common practice of specifying an albedo
+       value. For the approximate (simple) solar flux of 1360 W m-2, the albedo
+       value of 0.31 yields the value used by Frierson.
+       Default: 0.31
+       </entry>
+
+<entry id="frierson_DeltaS" type="real" category="frierson"
+       group="frierson_nl" valid_values="" >
+       Latitudinal Variation of Shortwave Radiation.
+       Shortwave radiation contains no seasonal/diurnal variations and has a
+       Latitudinal variation specified by DeltaS according to:
+               R_solar = (R_net/4)*[1 + DeltaS*P_2(Lat)]
+       where P_2 is the second Legendre polynomial.
+       Default: 1.4
+       </entry>
+
+<entry id="frierson_Tau_eqtr" type="real" category="frierson"
+       group="frierson_nl" valid_values="" >
+       Longwave Optical Depth at Equator.
+       The optical depths are specified as a function of Latitude to approximate
+       the effects of water vapor according to:
+        Tau_0 = Tau_eqtr + (Tau_pole - Tau_eqtr)*sin^2(Lat)
+       Default: 6.0
+       </entry>
+
+<entry id="frierson_Tau_pole" type="real" category="frierson"
+       group="frierson_nl" valid_values="" >
+       Longwave Optical Depth at Poles.
+       The optical depths are specified as a function of Latitude to approximate
+       the effects of water vapor according to:
+        Tau_0 = Tau_eqtr + (Tau_pole - Tau_eqtr)*sin^2(Lat)
+       Default: 1.5
+       </entry>
+
+<entry id="frierson_LinFrac" type="real" category="frierson"
+       group="frierson_nl" valid_values="" >
+       Linear Optical Depth Parameter for stratosphere.
+       The pressure dependence of optical depths that approximate the effects of
+       water vapor varies according to:
+          Tau = Tau_0*[ LinFrac*(P/P_s) + (1-LinFrac)*(P/P_s)^4 ]
+       Default: 0.1
+       </entry>
+
+<entry id="frierson_C0" type="real" category="frierson"
+       group="frierson_nl" valid_values="" >
+       Ocean Mixed-Layer Heat Capacity.
+       The ocean surface is a slab mixed layer with a specified heat capacity in units of J K-1 m-2
+       Default: 1.e7
+       </entry>
+
+<entry id="frierson_WetDryCoef" type="real" category="frierson"
+       group="frierson_nl" valid_values="" >
+       Scale Factor for E0 (saturation vapor pressure) to contol wet/dry experiments.
+       WetDryCoef=0  corresponds to the atmosphere in the dry limit.
+       Friersons wet limit corresponds to WetDryCoef=10.
+       Default: 1.
+       </entry>
+
+<entry id="frierson_Tmin" type="real" category="frierson"
+       group="frierson_nl" valid_values="" >
+       Tsrf Initial Condition: Minimum SST (K).
+       The ocean temperatures are initailized with the values:
+        T_s = Tmin + Tdlt*exp[-0.5*(Lat/Twidth)^2]
+       Default: 271.
+       </entry>
+
+<entry id="frierson_Tdlt" type="real" category="frierson"
+       group="frierson_nl" valid_values="" >
+       Tsrf Initial Condition: Equator-Pole SST difference (K).
+       The ocean temperatures are initailized with the values:
+        T_s = Tmin + Tdlt*exp[-0.5*(Lat/Twidth)^2]
+       Default: 39.
+       </entry>
+
+<entry id="frierson_Twidth" type="real" category="frierson"
+       group="frierson_nl" valid_values="" >
+       Tsrf Initial Condition: Latitudinal width parameter for sst (degrees latitude)
+       The ocean temperatures are initailized with the values:
+        T_s = Tmin + Tdlt*exp[-0.5*(Lat/Twidth)^2]
+       Default: 26.
+       </entry>
+
+<!-- Nudging Parameters -->
+
+<entry id="Nudge_Model" type="logical" category="nudging"
+       group="nudging_nl" valid_values="" >
+       Toggle Model Nudging ON/OFF.
+
+        FORCING:
+        --------
+        Nudging tendencies are applied as a relaxation force between the current
+        model state values and target state values derived from the avalilable
+        analyses. The form of the target values is selected by the 'Nudge_Force_Opt'
+        option, the timescale of the forcing is determined from the given
+        'Nudge_TimeScale_Opt', and the nudging strength Alpha=[0.,1.] for each
+        variable is specified by the 'Nudge_Xcoef' values. Where X={U,V,T,Q,PS}
+
+               F_nudge = Alpha*((Target-Model(t_curr))/TimeScale
+
+        WINDOWING:
+        ----------
+        The region of applied nudging can be limited using Horizontal/Vertical
+        window functions that are constructed using a parameterization of the
+        Heaviside step function.
+
+        The Heaviside window function is the product of separate horizonal and vertical
+        windows that are controled via 12 parameters:
+
+            Nudge_Hwin_lat0:     Specify the horizontal center of the window in degrees.
+            Nudge_Hwin_lon0:     The longitude must be in the range [0,360] and the
+                                 latitude should be [-90,+90].
+            Nudge_Hwin_latWidth: Specify the lat and lon widths of the window as positive
+            Nudge_Hwin_lonWidth: values in degrees.Setting a width to a large value (e.g. 999)
+                                 renders the window a constant in that direction.
+            Nudge_Hwin_latDelta: Controls the sharpness of the window transition with a
+            Nudge_Hwin_lonDelta: length in degrees. Small non-zero values yeild a step
+                                 function while a large value yeilds a smoother transition.
+            Nudge_Hwin_Invert  : A logical flag used to invert the horizontal window function
+                                 to get its compliment.(e.g. to nudge outside a given window).
+
+            Nudge_Vwin_Lindex:   In the vertical, the window is specified in terms of model
+            Nudge_Vwin_Ldelta:   level indcies. The High and Low transition levels should
+            Nudge_Vwin_Hindex:   range from [0,(NLEV+1)]. The transition lengths are also
+            Nudge_Vwin_Hdelta:   specified in terms of model indices. For a window function
+                                 constant in the vertical, the Low index should be set to 0,
+                                 the High index should be set to (NLEV+1), and the transition
+                                 lengths should be set to 0.001
+            Nudge_Vwin_Invert  : A logical flag used to invert the vertical window function
+                                 to get its compliment.
+       Default: FALSE
+       </entry>
+
+<entry id="Nudge_Path" type="char*256" input_pathname="abs" category="nudging"
+       group="nudging_nl" valid_values="" >
+       Full pathname of analyses data to use for nudging.
+        (e.g. '/$DIN_LOC_ROOT/atm/cam/nudging/')
+       Default: none
+       </entry>
+
+<entry id="Nudge_File_Template" type="char*80" category="nudging"
+       group="nudging_nl" valid_values="" >
+       Template for Nudging analyses file names.
+        (e.g. '%y/ERAI_ne30np4_L30.cam2.i.%y-%m-%d-%s.nc')
+       Default: none
+       </entry>
+
+<entry id="Nudge_Times_Per_Day" type="integer" category="nudging"
+       group="nudging_nl" valid_values="" >
+       Number of analyses files per day.
+        (e.g. 4 --> 6 hourly analyses)
+       Default: none
+       </entry>
+
+<entry id="Model_Times_Per_Day" type="integer" category="nudging"
+       group="nudging_nl" valid_values="" >
+       Number of time to update model data per day.
+        (e.g. 48 --> 1800 Second timestep)
+       Default: none
+       </entry>
+
+<entry id="Nudge_Beg_Year" type="integer" category="nudging"
+       group="nudging_nl" valid_values="" >
+       Year at which Nudging Begins.
+       Default: none
+       </entry>
+
+<entry id="Nudge_Beg_Month" type="integer" category="nudging"
+       group="nudging_nl" valid_values="" >
+       Month at which Nudging Begins.
+       Default: none
+       </entry>
+
+<entry id="Nudge_Beg_Day" type="integer" category="nudging"
+       group="nudging_nl" valid_values="" >
+       Day at which Nudging Begins.
+       Default: none
+       </entry>
+
+<entry id="Nudge_End_Year" type="integer" category="nudging"
+       group="nudging_nl" valid_values="" >
+       Year at which Nudging Ends.
+       Default: none
+       </entry>
+
+<entry id="Nudge_End_Month" type="integer" category="nudging"
+       group="nudging_nl" valid_values="" >
+       Month at which Nudging Ends.
+       Default: none
+       </entry>
+
+<entry id="Nudge_End_Day" type="integer" category="nudging"
+       group="nudging_nl" valid_values="" >
+       Day at which Nudging Ends.
+       Default: none
+       </entry>
+
+<entry id="Nudge_Force_Opt" type="integer" category="nudging"
+       group="nudging_nl" valid_values="" >
+       Select the form of nudging forcing, where (t'==Analysis times ; t==Model Times)
+         0 -> NEXT-OBS: Target=Anal(t'_next)
+         1 -> LINEAR:   Target=(F*Anal(t'_curr) +(1-F)*Anal(t'_next))
+                            F =(t'_next - t_curr )/Tdlt_Anal
+       Default: 0
+       </entry>
+
+<entry id="Nudge_TimeScale_Opt" type="integer" category="nudging"
+       group="nudging_nl" valid_values="" >
+       Select the timescale of nudging force, where (t'==Analysis times ; t==Model Times)
+         0 -->  TimeScale = 1/Tdlt_Anal
+         1 -->  TimeScale = 1/(t'_next - t_curr )
+       Default: 0
+       </entry>
+
+<entry id="Nudge_Uprof" type="integer" category="nudging"
+       group="nudging_nl" valid_values="" >
+       Profile index for U nudging.
+         0 == OFF      (No Nudging of this variable)
+         1 == CONSTANT (Spatially Uniform Nudging)
+         2 == HEAVISIDE WINDOW FUNCTION
+       Default: 0
+       </entry>
+
+<entry id="Nudge_Ucoef" type="real" category="nudging"
+       group="nudging_nl" valid_values="" >
+       Normalized Coeffcient for U nudging.
+         [0.,1.] fraction of nudging tendency applied.
+       Default: 0.
+       </entry>
+
+<entry id="Nudge_Vprof" type="integer" category="nudging"
+       group="nudging_nl" valid_values="" >
+       Profile index for V nudging.
+         0 == OFF      (No Nudging of this variable)
+         1 == CONSTANT (Spatially Uniform Nudging)
+         2 == HEAVISIDE WINDOW FUNCTION
+       Default: 0
+       </entry>
+
+<entry id="Nudge_Vcoef" type="real" category="nudging"
+       group="nudging_nl" valid_values="" >
+       Normalized Coeffcient for V nudging.
+         [0.,1.] fraction of nudging tendency applied.
+       Default: 0.
+       </entry>
+
+<entry id="Nudge_Tprof" type="integer" category="nudging"
+       group="nudging_nl" valid_values="" >
+       Profile index for T nudging.
+         0 == OFF      (No Nudging of this variable)
+         1 == CONSTANT (Spatially Uniform Nudging)
+         2 == HEAVISIDE WINDOW FUNCTION
+       Default: 0
+       </entry>
+
+<entry id="Nudge_Tcoef" type="real" category="nudging"
+       group="nudging_nl" valid_values="" >
+       Normalized Coeffcient for T nudging.
+         [0.,1.] fraction of nudging tendency applied.
+       Default: 0.
+       </entry>
+
+<entry id="Nudge_Qprof" type="integer" category="nudging"
+       group="nudging_nl" valid_values="" >
+       Profile index for Q nudging.
+         0 == OFF      (No Nudging of this variable)
+         1 == CONSTANT (Spatially Uniform Nudging)
+         2 == HEAVISIDE WINDOW FUNCTION
+       Default: 0
+       </entry>
+
+<entry id="Nudge_Qcoef" type="real" category="nudging"
+       group="nudging_nl" valid_values="" >
+       Normalized Coeffcient for Q nudging.
+         [0.,1.] fraction of nudging tendency applied.
+       Default: 0.
+       </entry>
+
+<entry id="Nudge_PSprof" type="integer" category="nudging"
+       group="nudging_nl" valid_values="" >
+       Profile index for PS nudging.
+         0 == OFF      (No Nudging of this variable)
+         1 == CONSTANT (Spatially Uniform Nudging)
+         2 == HEAVISIDE WINDOW FUNCTION
+       Default: 0
+       </entry>
+
+<entry id="Nudge_PScoef" type="real" category="nudging"
+       group="nudging_nl" valid_values="" >
+       Normalized Coeffcient for PS nudging.
+         [0.,1.] fraction of nudging tendency applied.
+       Default: 0.
+       </entry>
+
+<entry id="Nudge_Hwin_lat0" type="real" category="nudging"
+       group="nudging_nl" valid_values="" >
+       LAT0 center of Horizontal Window in degrees [-90.,90.].
+       Default: none
+       </entry>
+
+<entry id="Nudge_Hwin_latWidth" type="real" category="nudging"
+       group="nudging_nl" valid_values="" >
+       Width of LAT Window in degrees.
+       Default: none
+       </entry>
+
+<entry id="Nudge_Hwin_latDelta" type="real" category="nudging"
+       group="nudging_nl" valid_values="" >
+       Width of transition which controls the steepness of window transition in latitude.
+        0. --> Step function
+       Default: none
+       </entry>
+
+<entry id="Nudge_Hwin_lon0" type="real" category="nudging"
+       group="nudging_nl" valid_values="" >
+       LON0 center of Horizontal Window in degrees [0.,360.].
+       Default: none
+       </entry>
+
+<entry id="Nudge_Hwin_lonWidth" type="real" category="nudging"
+       group="nudging_nl" valid_values="" >
+       Width of LON Window in degrees.
+       Default: none
+       </entry>
+
+<entry id="Nudge_Hwin_lonDelta" type="real" category="nudging"
+       group="nudging_nl" valid_values="" >
+       Width of transition which controls the steepness of window transition in longitude.
+        0. --> Step function
+       Default: none
+       </entry>
+
+<entry id="Nudge_Hwin_Invert" type="logical" category="nudging"
+       group="nudging_nl" valid_values="" >
+       Invert Horizontal Window Function to its Compliment.
+         TRUE  = value=0 inside the specified window, 1 outside
+         FALSE = value=1 inside the specified window, 0 outside
+       Default: FALSE
+       </entry>
+
+<entry id="Nudge_Vwin_Hindex" type="real" category="nudging"
+       group="nudging_nl" valid_values="" >
+       HIGH Level Index for Verical Window specified in terms of model level indices.
+         (e.g. For a 30 level model, Nudge_Vwin_Hindex ~ 30 )
+       Default: none
+       </entry>
+
+<entry id="Nudge_Vwin_Hdelta" type="real" category="nudging"
+       group="nudging_nl" valid_values="" >
+       Width of transition for HIGH end of Vertical Window.
+       Default: none
+       </entry>
+
+<entry id="Nudge_Vwin_Lindex" type="real" category="nudging"
+       group="nudging_nl" valid_values="" >
+       LOW Level Index for Verical Window specified in terms of model level indices.
+         (e.g. Nudge_Vwin_Lindex ~ 0 )
+       Default: none
+       </entry>
+
+<entry id="Nudge_Vwin_Ldelta" type="real" category="nudging"
+       group="nudging_nl" valid_values="" >
+       Width of transition for LOW end of Vertical Window.
+       Default: none
+       </entry>
+
+<entry id="Nudge_Vwin_Invert" type="logical" category="nudging"
+       group="nudging_nl" valid_values="" >
+       Invert Vertical Window Function to its Compliment.
+         TRUE  = value=0 inside the specified window, 1 outside
+         FALSE = value=1 inside the specified window, 0 outside
+       Default: FALSE
+       </entry>
+
+<entry id="Nudge_ZonalFilter" type="logical" category="nudging"
+       group="nudging_nl" valid_values="" >
+       Switch to turn on zonal mean filtering nudging.  If TRUE, the nudging scheme
+       filters 3D model and the 3D input target data to zonal mean values, and then
+       applies nudging to the differences.
+       Default: FALSE
+       </entry>
+
+<entry id="Nudge_ZonalNbasis" type="integer" category="nudging"
+       group="nudging_nl" valid_values="" >
+       Number of zonal mean basis functions (number of m=0 spherical harmonics) used in
+       zonal mean filtering nudging.
+       Default: none
+       </entry>
+
+<!-- Physics grid decomp including physics dynamics coupling methods -->
+
+<entry id="phys_alltoall" type="integer"  category="perf_dp_coup"
+       group="phys_grid_nl" valid_values="-1,0,1,2,11,12,13">
+Dynamics/physics transpose method for nonlocal load-balance.
+0: use mpi_alltoallv.
+1: use point-to-point MPI-1 two-sided implementation.
+2: use point-to-point MPI-2 one-sided implementation if supported, otherwise use
+   MPI-1 implementation.
+3: use Co-Array Fortran implementation if supported, otherwise use MPI-1 implementation.
+11-13: use mod_comm, choosing any of several methods internal to mod_comm.  The method
+   within mod_comm (denoted mod_method) has possible values 0,1,2 and is set according
+   to mod_method = phys_alltoall - modmin_alltoall, where modmin_alltoall is 11.
+-1: use option 1 when each process communicates with less than half of the other
+   processes, otherwise use option 0 (if max_nproc_smpx and nproc_busy_d are both &gt; npes/2).
+Default: -1
+</entry>
+
+<entry id="phys_chnk_per_thd" type="integer"  category="perf_dp_coup"
+       group="phys_grid_nl" valid_values="">
+Select target number of chunks per thread.  Must be positive.
+Default: 1
+</entry>
+
+<entry id="phys_loadbalance" type="integer"  category="perf_dp_coup"
+       group="phys_grid_nl" valid_values="">
+Physics grid decomposition options.
+-1: each chunk is a dynamics block.
+ 0: chunk definitions and assignments do not require interprocess comm.
+ 1: chunk definitions and assignments do not require internode comm.
+ 2: optimal diurnal, seasonal, and latitude load-balanced chunk definition and assignments.
+ 3: chunk definitions and assignments only require communication with one other process.
+ 4: concatenated blocks, no load balancing, no interprocess communication.
+Default: 2
+</entry>
+
+<entry id="phys_twin_algorithm" type="integer"  category="perf_dp_coup"
+       group="phys_grid_nl" valid_values="">
+Physics grid decomposition options.
+ 0: assign columns to chunks as single columns, wrap mapped across chunks
+ 1: use (day/night; north/south) twin algorithm to determine load-balanced pairs of
+      columns and assign columns to chunks in pairs, wrap mapped
+Default: 0 for unstructured grid dycores, 1 for lat/lon grid dycores
+</entry>
+
+<!-- Diagnostics -->
+
+<entry id="diag_cnst_conv_tend" type="char*8"  category="diagnostics"
+       group="cam_diag_opts" valid_values="none,q_only,all" >
+Output constituent tendencies due to convection.  Set to
+'none', 'q_only' or 'all'.
+Default: 'q_only'
+</entry>
+
+<entry id="do_circulation_diags" type="logical"  category="diagnostics"
+       group="circ_diag_nl" valid_values="" >
+Turns on TEM circulation diagnostics history output.  Only valid for FV dycore.
+
+Default: .false.,  unless it is overridden (WACCM with interactive chemistry and a few other specific
+          configurations do this)
+</entry>
+
+<entry id="ctem_diags_numlats" type="integer"  category="diagnostics"
+       group="ctem_diags_nl" valid_values="" >
+Number of latitude grid points for zonal average Transformed Eulerian Mean (TEM)
+diagnostics history fields.  Values greater than zero turn on the TEM diagostics.
+Default: 0
+</entry>
+
+<entry id="phys_grid_ctem_zm_nbas" type="integer"  category="diagnostics"
+       group="phys_grid_ctem_opts" valid_values="" >
+Number of zonal mean basis functions (number of m=0 spherical harmonics) used in
+Transformed Eulerian Mean (TEM) diagnostics
+</entry>
+
+<entry id="phys_grid_ctem_za_nlat" type="integer"  category="diagnostics"
+       group="phys_grid_ctem_opts" valid_values="" >
+Number of latitude grid points for zonal average TEM diagnostics history fields
+</entry>
+
+<entry id="phys_grid_ctem_nfreq" type="integer"  category="diagnostics"
+       group="phys_grid_ctem_opts" valid_values="" >
+  Frequency of TEM diagnostics calucation.
+  If &gt; 0, frequency is specified as number of timesteps.
+  If &lt; 0, frequency is specified as number of hours.
+</entry>
+
+<entry id="print_energy_errors" type="logical"  category="diagnostics"
+       group="check_energy_nl" valid_values="" >
+Turn on verbose output identifying columns that fail energy/water
+conservation checks.
+Default: FALSE
+</entry>
+
+<entry id="print_qneg_warn" type="char*8"  category="diagnostics"
+       group="qneg_nl" valid_values="summary,timestep,off" >
+Control the writing of qneg3 and qneg4 warning messages.
+'summary' causes a summary of QNEG3 and QNEG4 errors to be
+    printed at the end of the run
+'timestep' causes a summary of QNEG3 and QNEG4 errors to be printed at the
+    end of each timestep. The total is reset at the end of each timestep.
+'off' causes the qneg3 and qneg4 warnings to be supressed.
+Note that these settings do not affect the availability of qneg
+    history variables.
+Default: 'summary'
+</entry>
+
+<!-- Dry Convective Adjustment -->
+
+<entry id="dadadj_nlvdry" type="integer"  category="dry_conv_adj"
+       group="dadadj_nl" valid_values="" >
+Number of layers from the top of the model over which to do dry convective
+adjustment. Must be less than plev (the number of vertical levels).
+Default: 3
+</entry>
+
+<entry id="dadadj_niter" type="integer"  category="dry_conv_adj"
+       group="dadadj_nl" valid_values="" >
+The maximum number of iterations to achieve convergence in dry adiabatic adjustment.
+For WACCM-X it can be advantageous to use a number which is much higher than the CAM
+default.
+Default: 15
+</entry>
+
+<!-- Dynamics: Finite Volume -->
+
+<entry id="fv_nsplit" type="integer"  category="dyn_fv"
+       group="dyn_fv_inparm" valid_values="" >
+Number of dynamics timesteps per physics timestep. If zero, a best-estimate
+will be automatically calculated.
+Default: 0
+</entry>
+
+<entry id="fv_nspltrac" type="integer"  category="dyn_fv"
+       group="dyn_fv_inparm" valid_values="" >
+Number of tracer advection timesteps per physics timestep.
+Nsplit is partitioned into nspltrac and nsplit/nspltrac,
+with the latter being the number of dynamics timesteps per
+tracer timestep, possibly rounded upward; after initialization,
+the code quantity nsplit is redefined to be the number of
+dynamics timesteps per tracer timestep.
+Default: 0
+</entry>
+
+<entry id="fv_nspltvrm" type="integer"  category="dyn_fv"
+       group="dyn_fv_inparm" valid_values="" >
+Number of vertical re-mapping timesteps per physics timestep.
+Nspltrac is partitioned into nspltvrm and nspltrac/nspltvrm,
+with the latter being the number of tracer timesteps per
+re-mapping timestep, possibly rounded upward; after initialization,
+the code quantity nspltrac is redefined to be the number of
+tracer timesteps per re-mapping timestep.
+Default: 0
+</entry>
+
+<entry id="fv_iord" type="integer"  category="dyn_fv"
+       group="dyn_fv_inparm" valid_values="" >
+Order (mode) of X interpolation (1,..,6).
+East-West transport scheme.
+   = 1: first order upwind
+   = 2: 2nd order van Leer (Lin et al 1994)
+   = 3: standard PPM
+   = 4: enhanced PPM (default)
+Default: 4
+</entry>
+
+<entry id="fv_jord" type="integer"  category="dyn_fv"
+       group="dyn_fv_inparm" valid_values="" >
+Order (mode) of Y interpolation (1,..,6).
+North-South transport scheme.
+   = 1: first order upwind
+   = 2: 2nd order van Leer (Lin et al 1994)
+   = 3: standard PPM
+   = 4: enhanced PPM (default)
+Default: 4
+</entry>
+
+<entry id="fv_kord" type="integer"  category="dyn_fv"
+       group="dyn_fv_inparm" valid_values="" >
+Scheme to be used for vertical mapping.
+   = 1: first order upwind
+   = 2: 2nd order van Leer (Lin et al 1994)
+   = 3: standard PPM
+   = 4: enhanced PPM (default)
+Default: 4
+</entry>
+
+<entry id="fv_conserve" type="logical"  category="dyn_fv"
+       group="dyn_fv_inparm" valid_values="" >
+Flag indicating whether the dynamics uses internal algorithm for energy
+conservation.
+Default: .false.
+</entry>
+
+<entry id="fv_filtcw" type="integer"  category="dyn_fv"
+       group="dyn_fv_inparm" valid_values="0,1" >
+Enables optional filter for intermediate c-grid winds, (courtesy of Bill Putman).
+Default: 0
+</entry>
+
+<entry id="fv_fft_flt" type="integer"  category="dyn_fv"
+       group="dyn_fv_inparm" valid_values="0,1" >
+1 for FFT filter always, 0 for combined algebraic/FFT filter.
+Default: set by build-namelist
+</entry>
+
+<entry id="fv_div24del2flag" type="integer"  category="dyn_fv"
+       group="dyn_fv_inparm" valid_values="2,4,42" >
+Chooses type of divergence damping and velocity diffusion.
+div24del2flag = 2 for ldiv2 (default),
+              = 4 for ldiv4,
+              = 42 for ldiv4 + ldel2
+where
+ldiv2: 2nd-order divergence damping everywhere and increasing in top layers
+ldiv4: 4th-order divergence damping
+ldel2: 2nd-order velocity-component damping targetted to top layers,
+       with coefficient del2coef
+
+Default: set by build-namelist
+</entry>
+
+<entry id="fv_del2coef" type="real"  category="dyn_fv"
+       group="dyn_fv_inparm" valid_values="" >
+Chooses level of velocity diffusion.
+Default: 3.0e5
+</entry>
+
+<entry id="fv_high_order_top" type="logical"  category="dyn_fv"
+       group="dyn_fv_inparm" valid_values="" >
+Flag to extend standard 4th-order PPM scheme to model top.
+Default: .false.
+</entry>
+
+<entry id="fv_am_geom_crrct" type="logical"  category="dyn_fv"
+       group="dyn_fv_inparm" valid_values="" >
+Flag to turn on corrections in FV geometry and/or pressure terms.
+Default: .false.
+</entry>
+
+<entry id="fv_am_correction" type="logical"  category="dyn_fv"
+       group="dyn_fv_inparm" valid_values="" >
+Flag to turn on corrections that improve angular momentum conservation.
+Default: .false.
+</entry>
+
+<entry id="fv_am_fixer" type="logical"  category="dyn_fv"
+       group="dyn_fv_inparm" valid_values="" >
+Flag to apply an arbitrary fix based on solid-body rotation to the zonal
+velocity fields to improve conservation of angular momentum.
+Default: .false.
+</entry>
+
+<entry id="fv_am_fix_lbl" type="logical"  category="dyn_fv"
+       group="dyn_fv_inparm" valid_values="" >
+Flag to apply the fixer turned on by fv_am_fixer level by level.  The
+intent is to not contaminate the stratospheric circulation with
+tropospheric AM loss, where it is most likely greatest (due to the larger
+divergence fields).  This option is experimental.
+Default: .false.
+</entry>
+
+<entry id="fv_am_diag" type="logical"  category="dyn_fv"
+       group="dyn_fv_inparm" valid_values="" >
+Flag to turn on a diagnostic calculation of angular momentum which is
+written to the log file at each time step.  Also enables calculation of
+fields written to history file which are used in conjuction with those
+enabled by do_circulation_diags for detailed analysis.
+Default: .false.
+</entry>
+
+<entry id="fv_high_altitude" type="logical"  category="dyn_fv"
+       group="dyn_fv_inparm" valid_values="" >
+Switch to apply variable physics appropriate for the thermosphere and ionosphere
+Default: set by build-namelist
+</entry>
+
+<entry id="fv_print_dpcoup_warn" type="char*8"  category="dyn_fv"
+       group="dyn_fv_inparm" valid_values="off,full" >
+Flag to determine how to handle dpcoup warning messages
+Default: off
+</entry>
+
+<!-- MPI configuration for FV dycore -->
+
+<entry id="force_2d" type="integer"  category="dyn_fv"
+       group="spmd_fv_inparm" valid_values="" >
+Set to 1 to force the 2D transpose computation when a 1D decomposition is
+used.  This is intended for debugging purposes only.
+Default: 0
+</entry>
+
+<entry id="geopktrans" type="integer"  category="dyn_fv"
+       group="spmd_fv_inparm" valid_values="0,1,2" >
+Geopotential method (routines geopk, geopk16, or geopk_d).
+  =0 for transpose method;
+  =1 for method using semi-global z communication with optional 16-byte arithmetic;
+  =2 for method using local z communication;
+method 0, method 1 with 16-byte arithmetic and method 2 are all bit-for-bit across decompositions;
+method 0 scales better than method 1 with npr_z, and method 1 is superior to method 0 for small npr_z;
+The optimum speed is attained using either method 1 with 8-byte
+arithmetic (standard for geopk16) or method 2 when utilizing the
+optimal value for the associated parameter geopkblocks; for the last
+two subcycles of a timestep, method 0 is automatically used; see
+geopk.F90 and cd_core.F90.
+
+Default: 0
+</entry>
+
+<entry id="geopkblocks" type="integer"  category="dyn_fv"
+       group="spmd_fv_inparm" valid_values="" >
+Geopotential method 2 pipeline parameter (routine geopk_d).
+geopk_d implements a pipeline algorithm by dividing the
+information that must be moved between processes into blocks. geopkblocks
+specifies the number of blocks to use. The larger the number of blocks,
+the greater the opportunity for overlapping communication with computation
+and for decreasing instantaneous bandwidth requirements. The smaller the
+number of blocks, the fewer MPI messages sent, decreasing MPI total latency.
+See geopk_d within geopk.F90.
+Default: 1
+</entry>
+
+<entry id="modc_sw_dynrun" type="integer"  category="dyn_fv"
+       group="spmd_fv_inparm" valid_values="0,1,2" >
+Mod_comm irregular underlying communication method for dyn_run/misc.
+0 for original mp_sendirr/mp_recvirr
+1 for mp_swapirr and a point-to-point implementation of communication pattern
+2 for mp_swapirr and a collective (MPI_Alltoallv) implementation of communication pattern
+Default: 0
+</entry>
+
+<entry id="modc_hs_dynrun" type="logical"  category="dyn_fv"
+       group="spmd_fv_inparm" valid_values="" >
+True for mod_comm irregular communication handshaking for dyn_run/misc
+Default: .true.
+</entry>
+
+<entry id="modc_send_dynrun" type="logical"  category="dyn_fv"
+       group="spmd_fv_inparm" valid_values="" >
+True for mod_comm irregular communication blocking send for dyn_run/misc,
+false for nonblocking send
+Default: .true.
+</entry>
+
+<entry id="modc_mxreq_dynrun" type="integer"  category="dyn_fv"
+       group="spmd_fv_inparm" valid_values="" >
+Maximum number of outstanding nonblocking MPI requests to allow when
+using mp_swapirr and point-to-point communications for dyn_run/misc.
+Setting this less than the maximum can improve robustness for large process
+count runs. If set to less than zero, then do not limit the number of
+outstanding send/receive requests.
+Default: -1 (so no limit)
+</entry>
+
+<entry id="modc_sw_cdcore" type="integer"  category="dyn_fv"
+       group="spmd_fv_inparm" valid_values="0,1,2" >
+Mod_comm irregular underlying communication method for cd_core/geopk
+0 for original mp_sendirr/mp_recvirr
+1 for mp_swapirr and a point-to-point implementation of communication pattern
+2 for mp_swapirr and a collective (MPI_Alltoallv) implementation of communication pattern
+Default: 0
+</entry>
+
+<entry id="modc_hs_cdcore" type="logical"  category="dyn_fv"
+       group="spmd_fv_inparm" valid_values="" >
+True for mod_comm irregular communication handshaking for cd_core/geopk
+Default: .true.
+</entry>
+
+<entry id="modc_send_cdcore" type="logical"  category="dyn_fv"
+       group="spmd_fv_inparm" valid_values="" >
+True for geopk_d and mod_comm irregular communication blocking send for
+cd_core/geopk; false for nonblocking send.
+Default: .true.
+</entry>
+
+<entry id="modc_mxreq_cdcore" type="integer"  category="dyn_fv"
+       group="spmd_fv_inparm" valid_values="" >
+Maximum number of outstanding nonblocking MPI requests to allow when
+using mp_swapirr and point-to-point communications for cd_core/geopk.
+Setting this less than the maximum can improve robustness for large process
+count runs. If set to less than zero, then do not limit the number of
+outstanding send/receive requests.
+Default: -1 (so no limit)
+</entry>
+
+<entry id="modc_sw_gather" type="integer"  category="dyn_fv"
+       group="spmd_fv_inparm" valid_values="0,1,2" >
+Mod_comm irregular underlying communication method for gather
+0 for original mp_sendirr/mp_recvirr
+1 for mp_swapirr and a point-to-point implementation of communication pattern
+2 for mp_swapirr and a collective (MPI_Alltoallv) implementation of communication pattern
+Default: 1
+</entry>
+
+<entry id="modc_hs_gather" type="logical"  category="dyn_fv"
+       group="spmd_fv_inparm" valid_values="" >
+True for mod_comm irregular communication handshaking for gather
+Default: .true.
+</entry>
+
+<entry id="modc_send_gather" type="logical"  category="dyn_fv"
+       group="spmd_fv_inparm" valid_values="" >
+True for mod_comm irregular communication blocking send for gather,
+false for nonblocking send
+Default: .true.
+</entry>
+
+<entry id="modc_mxreq_gather" type="integer"  category="dyn_fv"
+       group="spmd_fv_inparm" valid_values="" >
+Maximum number of outstanding nonblocking MPI requests to allow when
+using mp_swapirr and point-to-point communications for gather.
+Setting this less than the maximum can improve robustness for large process
+count runs. If set to less than zero, then do not limit the number of
+outstanding send/receive requests.
+Default: 64
+</entry>
+
+<entry id="modc_sw_scatter" type="integer"  category="dyn_fv"
+       group="spmd_fv_inparm" valid_values="0,1,2" >
+Mod_comm irregular underlying communication method for scatter
+0 for original mp_sendirr/mp_recvirr
+1 for mp_swapirr and a point-to-point implementation of communication pattern
+2 for mp_swapirr and a collective (MPI_Alltoallv) implementation of communication pattern
+Default: 0
+</entry>
+
+<entry id="modc_hs_scatter" type="logical"  category="dyn_fv"
+       group="spmd_fv_inparm" valid_values="" >
+True for mod_comm irregular communication handshaking for scatter
+Default: .false.
+</entry>
+
+<entry id="modc_send_scatter" type="logical"  category="dyn_fv"
+       group="spmd_fv_inparm" valid_values="" >
+True for mod_comm irregular communication blocking send for scatter,
+false for nonblocking send
+Default: .true.
+</entry>
+
+<entry id="modc_mxreq_scatter" type="integer"  category="dyn_fv"
+       group="spmd_fv_inparm" valid_values="" >
+Maximum number of outstanding nonblocking MPI requests to allow when
+using mp_swapirr and point-to-point communications for scatter.
+Setting this less than the maximum can improve robustness for large process
+count runs. If set to less than zero, then do not limit the number of
+outstanding send/receive requests.
+Default: -1 (so no limit)
+</entry>
+
+<entry id="modc_sw_tracer" type="integer"  category="dyn_fv"
+       group="spmd_fv_inparm" valid_values="" >
+Mod_comm irregular underlying communication method for multiple tracers
+0 for original mp_sendtrirr/mp_recvtrirr
+1 for mp_swaptrirr and point-to-point communications
+2 for mp_swaptrirr and all-to-all communications
+Default: 0
+</entry>
+
+<entry id="modc_hs_tracer" type="logical"  category="dyn_fv"
+       group="spmd_fv_inparm" valid_values="" >
+True for mod_comm irregular communication handshaking for multiple tracers
+Default: .true.
+</entry>
+
+<entry id="modc_send_tracer" type="logical"  category="dyn_fv"
+       group="spmd_fv_inparm" valid_values="" >
+True for mod_comm irregular communication blocking send for multiple
+tracers, false for nonblocking send
+Default: .true.
+</entry>
+
+<entry id="modc_mxreq_tracer" type="integer"  category="dyn_fv"
+       group="spmd_fv_inparm" valid_values="" >
+Maximum number of outstanding nonblocking MPI requests to allow when
+using mp_swaptrirr and point-to-point communications for multiple tracers.
+Setting this less than the maximum can improve robustness for large process
+count runs. If set to less than zero, then do not limit the number of
+outstanding send/receive requests.
+Default: -1 (so no limit)
+</entry>
+
+<entry id="modc_onetwo" type="integer"  category="dyn_fv"
+       group="spmd_fv_inparm" valid_values="1,2" >
+One or two simultaneous mod_comm irregular communications (excl. tracers)
+Default: 2
+</entry>
+
+<entry id="modc_tracers" type="integer"  category="dyn_fv"
+       group="spmd_fv_inparm" valid_values="" >
+Max number of tracers for simultaneous mod_comm irregular communications
+Default: 3
+</entry>
+
+<entry id="modcomm_gatscat" type="integer"  category="dyn_fv"
+       group="spmd_fv_inparm" valid_values="0,1" >
+For mod_comm gather/scatters, 0 for temporary contiguous buffers; 1 for mpi derived
+types.
+Default: 0
+</entry>
+
+<entry id="modcomm_geopk" type="integer"  category="dyn_fv"
+       group="spmd_fv_inparm" valid_values="0,1" >
+For geopk (geopktrans=1) messages, 0 for temporary contiguous buffers; 1 for mpi derived
+types.
+Default: 0
+</entry>
+
+<entry id="modcomm_transpose" type="integer"  category="dyn_fv"
+       group="spmd_fv_inparm" valid_values="0,1" >
+For mod_comm transposes, 0 for temporary contiguous buffers; 1 for mpi derived
+types.
+Default: 0
+</entry>
+
+<entry id="npr_yz" type="integer(4)"  category="dyn_fv"
+       group="spmd_fv_inparm" valid_values="" >
+A four element integer array which specifies the YZ and XY decompositions.
+The first two elements are the number of Y subdomains and number of Z
+subdomains in the YZ decomposition.  The second two elements are the number
+of X subdomains and the number of Y subdomains in the XY decomposition.
+Note that both the X and Y subdomains must contain at least 3 grid points.
+For example, a grid with 96 latitudes can contain no more than 32 Y
+subdomains.  There is no restriction on the number of grid points (levels)
+in a Z subdomain, but note that the threading parallelism in the FV dycore
+is over levels, so for parallel efficiency it is best to have at least the
+number of levels in each Z subdomain as there are threads available.
+
+There are a couple of rough rules of thumb to follow when setting the 2D
+decompositions.  The first is that the number of Y subdomains in the YZ
+decomposition should be the same as the number of Y subdomains in the XY
+decomposition (npr_yz(1) == npr_yz(4)).  The second is that the total
+number of YZ subdomains (npr_yz(1)*npr_yz(2)) should equal the total number
+of XY subdomains (npr_yz(3)*npr_yz(4)).
+
+Default: ntask,1,1,ntask where ntask is the number of MPI tasks.  This is a
+1D decomposition in latitude.
+</entry>
+
+<entry id="fv_ct_overlap" type="integer"  category="dyn_fv"
+       group="spmd_fv_inparm" valid_values="" >
+Overlapping of trac2d and cd_core subcycles.
+Default: 0
+</entry>
+
+<entry id="fv_trac_decomp" type="integer"  category="dyn_fv"
+       group="spmd_fv_inparm" valid_values="" >
+Size of tracer domain decomposition for trac2d.
+Default: 1
+</entry>
+
+<entry id="print_filew_warn" type="char*8"  category="dyn_fv"
+       group="fill_nl" valid_values="off,full" >
+Control the writing of filew warning messages.
+Default: 'off'
+</entry>
+
+<!-- Dynamics: Finite Volume: Offline -->
+
+<entry id="met_cell_wall_winds" type="logical"  category="dyn_fv_off"
+       group="metdata_nl" valid_values="" >
+TRUE =&gt; the offline meteorology winds are defined on the model grid cell walls.
+Default: FALSE
+</entry>
+
+<entry id="met_data_file" type="char*256" input_pathname="rel:met_data_path" category="dyn_fv_off"
+       group="metdata_nl" valid_values="" >
+Name of file that contains the offline meteorology data.
+Default: none
+</entry>
+
+<entry id="met_data_path" type="char*256" input_pathname="abs" category="dyn_fv_off"
+       group="metdata_nl" valid_values="" >
+Name of directory that contains the offline meteorology data.
+Default: none
+</entry>
+
+<entry id="met_filenames_list" type="char*256" input_pathname="abs" category="dyn_fv_off"
+       group="metdata_nl" valid_values="" >
+Name of file that contains names of the offline meteorology data files.
+Default: none
+</entry>
+
+<entry id="met_remove_file" type="logical"  category="dyn_fv_off"
+       group="metdata_nl" valid_values="" >
+TRUE =&gt; the offline meteorology file will be removed from local disk when no longer needed.
+Default: FALSE
+</entry>
+
+<entry id="met_rlx_top" type="real"  category="dyn_fv_off"
+       group="metdata_nl" valid_values="" >
+(km) top of relaxation region of winds for offline waccm
+Default: 60.
+</entry>
+
+<entry id="met_rlx_bot" type="real"  category="dyn_fv_off"
+       group="metdata_nl" valid_values="" >
+(km) bottom of relaxation region of winds for offline waccm
+Default: 50.
+</entry>
+
+<entry id="met_rlx_bot_top" type="real"  category="dyn_fv_off"
+       group="metdata_nl" valid_values="" >
+(km) top of ramping relaxation region for metdata at model bottom
+Default: 0.
+</entry>
+
+<entry id="met_rlx_bot_bot" type="real"  category="dyn_fv_off"
+       group="metdata_nl" valid_values="" >
+(km) bottom of ramping relaxation region for metdata at model bottom
+Default: 0.
+</entry>
+
+<entry id="met_rlx_time" type="real"  category="dyn_fv_off"
+       group="metdata_nl" valid_values="" >
+Relaxation time (hours) applied to specified meteorology.
+ - positive values less then time step size gives 100% nudging
+ - negative values gives 0.0% nudging (infinite relaxation time)
+Default: 0.0
+</entry>
+
+<entry id="met_fix_mass" type="logical"  category="dyn_fv_off"
+       group="metdata_nl" valid_values="" >
+switch to turn on/off mass fixer for offline driver
+Default: true
+</entry>
+
+<entry id="met_shflx_name" type="char*16"  category="dyn_fv_off"
+       group="metdata_nl" valid_values="" >
+srf heat flux field name in met data file
+Default: 'SHFLX'
+</entry>
+
+<entry id="met_qflx_name" type="char*16"  category="dyn_fv_off"
+       group="metdata_nl" valid_values="" >
+water vapor flux field name in met data file
+Default: 'QFLX'
+</entry>
+
+<entry id="met_shflx_factor" type="real"  category="dyn_fv_off"
+       group="metdata_nl" valid_values="" >
+multiplication factor for srf heat flux
+Default: 1.0
+</entry>
+
+<entry id="met_qflx_factor" type="real"  category="dyn_fv_off"
+       group="metdata_nl" valid_values="" >
+multiplication factor for water vapor flux
+Default: 1.0
+</entry>
+
+<entry id="met_snowh_factor" type="real"  category="dyn_fv_off"
+       group="metdata_nl" valid_values="" >
+multiplication factor for snow hieght
+Default: 1.0
+</entry>
+
+<entry id="met_srf_feedback" type="logical"  category="dyn_fv_off"
+       group="metdata_nl" valid_values="" >
+If false then do not allow surface models feedbacks influence climate
+Default: true
+</entry>
+
+<entry id="met_srf_nudge_flux" type="logical"  category="dyn_fv_off"
+       group="metdata_nl" valid_values="" >
+If true nudge meteorology surface fields TAUX, TAUY, SHFLX, QFLX rather than force
+Default: true
+</entry>
+
+<entry id="met_srf_land" type="logical"  category="dyn_fv_off"
+       group="metdata_nl" valid_values="" >
+If true nudge meteorology surface fields over the land. If false, then fields are
+still nudged over the ocean.
+Default: true
+</entry>
+
+<entry id="met_srf_land_scale" type="logical"  category="dyn_fv_off"
+       group="metdata_nl" valid_values="" >
+If met_srf_land is false, then determines whether to nudge proportional to the non-land
+fraction (i.e. 1 - land fraction) (true), or to nudge everywhere except where land
+fraction is 1 (false).
+Default: false
+</entry>
+
+<entry id="met_srf_rad" type="logical"  category="dyn_fv_off"
+       group="metdata_nl" valid_values="" >
+If true nudge meteorology surface fields from radiation. These include ASDIR, ASDIF,
+ALDIR, ALDIF, and LWUP.
+Default: false
+</entry>
+
+<entry id="met_srf_refs" type="logical"  category="dyn_fv_off"
+       group="metdata_nl" valid_values="" >
+If true nudge meteorology reference surface fields. These include TSREF, QREF, and U10.
+Default: false
+</entry>
+
+<entry id="met_srf_sst" type="logical"  category="dyn_fv_off"
+       group="metdata_nl" valid_values="" >
+If true nudge meteorology reference for sea surface temperature and sea ice fraction
+(SST and SEAICEFRAC).
+Default: false
+</entry>
+
+<entry id="met_srf_tau" type="logical"  category="dyn_fv_off"
+       group="metdata_nl" valid_values="" >
+If true nudge surface sheer stress (TAUX, TAUY) from the meteorology.
+Default: true
+</entry>
+
+<entry id="met_nudge_temp" type="logical"  category="dyn_fv_off"
+       group="metdata_nl" valid_values="" >
+If true nudge atmospheric temperature (T) from the meteorology.
+Default: true
+</entry>
+
+<!-- Gravity Wave Drag -->
+
+<entry id="use_gw_oro" type="logical" category="gw_drag"
+       group="phys_ctl_nl" valid_values="" >
+Whether or not to enable gravity waves produced by orography.
+Default: set by build-namelist.
+</entry>
+
+<entry id="use_gw_front" type="logical" category="gw_drag"
+       group="phys_ctl_nl" valid_values="" >
+Whether or not to enable gravity waves produced by frontogenesis.
+Default: set by build-namelist.
+</entry>
+
+<entry id="use_gw_front_igw" type="logical" category="gw_drag"
+       group="phys_ctl_nl" valid_values="" >
+Whether or not to enable inertial gravity waves produced by frontogenesis.
+Default: set by build-namelist.
+</entry>
+
+<entry id="use_gw_convect_dp" type="logical" category="gw_drag"
+       group="phys_ctl_nl" valid_values="" >
+Whether or not to enable gravity waves produced by deep convection.
+Default: set by build-namelist.
+</entry>
+
+<entry id="use_gw_convect_sh" type="logical" category="gw_drag"
+       group="phys_ctl_nl" valid_values="" >
+Whether or not to enable gravity waves produced by shallow convection.
+Default: .false.
+</entry>
+
+<entry id="use_gw_movmtn_pbl" type="logical" category="gw_drag"
+       group="phys_ctl_nl" valid_values="" >
+Whether or not to enable gravity waves from PBL moving mountains source.
+Default: .false.
+</entry>
+
+<entry id="use_gw_rdg_resid" type="logical" category="gw_drag"
+       group="gw_drag_nl" valid_values="" >
+Whether or not to enable gravity waves from residual (non-ridge)
+orography
+Default: set by build-namelist.
+</entry>
+
+<entry id="pgwv" type="integer" category="gw_drag"
+       group="gw_drag_nl" valid_values="" >
+Gravity wave spectrum dimension (wave numbers are from -pgwv to pgwv).
+Default: set by build-namelist.
+</entry>
+
+<entry id="gw_dc" type="real" category="gw_drag"
+       group="gw_drag_nl" valid_values="" >
+Width of speed bins (delta c) for gravity wave spectrum (reference wave
+speeds are from -pgwv*dc to pgwv*dc).
+Default: set by build-namelist.
+</entry>
+
+<entry id="pgwv_long" type="integer" category="gw_drag"
+       group="gw_drag_nl" valid_values="" >
+Dimension for long wavelength gravity wave spectrum (wave numbers are from
+-pgwv_long to pgwv_long).
+Default: set by build-namelist.
+</entry>
+
+<entry id="gw_dc_long" type="real" category="gw_drag"
+       group="gw_drag_nl" valid_values="" >
+Width of speed bins (delta c) for long wavelength gravity wave spectrum
+(reference wave speeds are from -pgwv_long*dc_long to pgwv_long*dc_long).
+Default: set by build-namelist.
+</entry>
+
+<entry id="tau_0_ubc" type="logical" category="gw_drag"
+       group="gw_drag_nl" valid_values="" >
+Force the stress due to gravity waves to be zero at the top of the model.
+In the low-top model, this helps to conserve momentum and produce a QBO.
+Default: set by build-namelist.
+</entry>
+
+<entry id="gw_apply_tndmax" type="logical" category="gw_drag"
+       group="gw_drag_nl" valid_values="" >
+Apply limiter on maximum wind tendency from stress divergence in gravity wave drag scheme.
+Default: set by build-namelist
+</entry>
+
+<entry id="effgw_beres_dp" type="real" category="gw_drag"
+       group="gw_drag_nl" valid_values="" >
+Efficiency associated with convective gravity waves from the Beres
+scheme (deep convection).
+Default: set by build-namelist.
+</entry>
+
+<entry id="effgw_beres_sh" type="real" category="gw_drag"
+       group="gw_drag_nl" valid_values="" >
+Efficiency associated with convective gravity waves from the Beres
+scheme (shallow convection).
+Default: set by build-namelist.
+</entry>
+
+<entry id="effgw_cm" type="real" category="gw_drag"
+       group="gw_drag_nl" valid_values="" >
+Efficiency associated with gravity waves from frontogenesis.
+Default: set by build-namelist.
+</entry>
+
+<entry id="effgw_cm_igw" type="real" category="gw_drag"
+       group="gw_drag_nl" valid_values="" >
+Efficiency associated with inertial gravity waves from frontogenesis.
+Default: set by build-namelist.
+</entry>
+
+<entry id="effgw_oro" type="real" category="gw_drag"
+       group="gw_drag_nl" valid_values="" >
+Efficiency associated with orographic gravity waves.
+Default: set by build-namelist.
+</entry>
+
+<entry id="use_gw_rdg_beta" type="logical" category="gw_drag"
+       group="gw_drag_nl" valid_values="" >
+Whether or not to enable gravity waves produced by meso-Beta Ridges.
+Default: set by build-namelist
+</entry>
+
+<entry id="n_rdg_beta" type="integer" category="gw_drag"
+       group="gw_drag_nl" valid_values="" >
+Number of meso-Beta ridges (per gridbox) to invoke.
+Default: 10 (set by build-namelist)
+</entry>
+
+<entry id="effgw_rdg_beta" type="real" category="gw_drag"
+       group="gw_drag_nl" valid_values="" >
+Efficiency scaling factor associated with anisotropic OGW.
+Default: set by build-namelist.
+</entry>
+
+<entry id="effgw_rdg_beta_max" type="real" category="gw_drag"
+       group="gw_drag_nl" valid_values="" >
+Max efficiency associated with anisotropic OGW.
+Default: 1.0
+</entry>
+
+<entry id="effgw_rdg_resid" type="real" category="gw_drag"
+       group="gw_drag_nl" valid_values="" >
+Efficiency scaling factor associated with residual non-ridge topo
+Default: set by build-namelist.
+</entry>
+
+<entry id="effgw_movmtn_pbl" type="real" category="gw_drag"
+       group="gw_drag_nl" valid_values="" >
+Efficiency scaling factor for moving mountain source
+Default: set by build-namelist.
+</entry>
+
+<entry id="movmtn_psteer" type="real" category="gw_drag"
+       group="gw_drag_nl" valid_values="" >
+Global steering level (Pa) for moving mtns. If negative steering level, it will be provided by future code
+Default: set by build-namelist.
+</entry>
+
+<entry id="movmtn_plaunch" type="real" category="gw_drag"
+       group="gw_drag_nl" valid_values="" >
+Global launch level (Pa) for moving mtns. If negative launch level, it will be provided by future code
+Default: set by build-namelist.
+</entry>
+
+<entry id="movmtn_source" type="integer" category="gw_drag"
+       group="gw_drag_nl" valid_values="" >
+Integer code for movmtn source: 1=vorticity, 2=upwp
+Default: set by build-namelist.
+</entry>
+
+<entry id="rdg_beta_cd_llb" type="real" category="gw_drag"
+       group="gw_drag_nl" valid_values="" >
+Drag coefficient for obstacles in low-level flow.
+Default: 1.0
+</entry>
+
+<entry id="trpd_leewv_rdg_beta" type="logical" category="gw_drag"
+       group="gw_drag_nl" valid_values="" >
+Whether or not to allow trapping for meso-Beta Ridges.
+Default: FALSE (set by build-namelist)
+</entry>
+
+<entry id="use_gw_rdg_gamma" type="logical" category="gw_drag"
+       group="gw_drag_nl" valid_values="" >
+Whether or not to enable gravity waves produced by meso-gamma Ridges.
+Default: FALSE (set by build-namelist)
+</entry>
+
+<entry id="n_rdg_gamma" type="integer" category="gw_drag"
+       group="gw_drag_nl" valid_values="" >
+Number of meso-gamma ridges (per gridbox) to invoke.
+Default: -1 (set by build-namelist)
+</entry>
+
+<entry id="effgw_rdg_gamma" type="real" category="gw_drag"
+       group="gw_drag_nl" valid_values="" >
+Efficiency scaling factor associated with anisotropic OGW.
+Default: set by build-namelist.
+</entry>
+
+<entry id="effgw_rdg_gamma_max" type="real" category="gw_drag"
+       group="gw_drag_nl" valid_values="" >
+Max efficiency associated with anisotropic OGW.
+Default: 1.0
+</entry>
+
+<entry id="rdg_gamma_cd_llb" type="real" category="gw_drag"
+       group="gw_drag_nl" valid_values="" >
+Drag coefficient for obstacles in low-level flow.
+Default: 1.0
+</entry>
+
+<entry id="trpd_leewv_rdg_gamma" type="logical" category="gw_drag"
+       group="gw_drag_nl" valid_values="" >
+Whether or not to allow trapping for meso-gamma Ridges.
+Default: set by build-namelist
+</entry>
+
+<entry id="bnd_rdggm" type="char*256" input_pathname="abs" category="gw_drag"
+       group="gw_drag_nl" valid_values="" >
+Full pathname of boundary dataset for meso-gamma ridges.
+Default: set by build-namelist.
+</entry>
+
+<entry id="gw_oro_south_fac" type="real" category="gw_drag"
+       group="gw_drag_nl" valid_values="" >
+Factor to multiply tau by, for orographic waves in the southern hemisphere.
+Default: 1._r8
+</entry>
+
+<entry id="gw_prndl" type="real" category="gw_drag"
+       group="gw_drag_nl" valid_values="" >
+Inverse Prandtl number used in gravity wave diffusion
+Default: set by build-namelist
+</entry>
+
+<entry id="gw_qbo_hdepth_scaling" type="real" category="gw_drag"
+       group="gw_drag_nl" valid_values="" >
+Scaling factor for heating depth in gravity waves from convection.  If less than 1.0
+this acts as an effective reduction of the gravity wave phase speeds needed to drive
+the QBO.
+Default: set by build-namelist
+</entry>
+
+<entry id="gw_lndscl_sgh" type="logical" category="gw_drag"
+       group="gw_drag_nl" valid_values="" >
+Scale SGH by land fraction in gravity wave drag
+Default: set by build-namelist
+</entry>
+
+<entry id="frontgfc" type="real" category="gw_drag"
+       group="gw_drag_nl" valid_values="" >
+Frontogenesis function critical threshold.
+Default: set by build-namelist.
+</entry>
+
+<entry id="front_gaussian_width" type="real" category="gw_drag"
+       group="gw_drag_nl" valid_values="" >
+Width of gaussian used to create frontogenesis tau profile [m/s].
+Default: set by build-namelist.
+</entry>
+
+<entry id="alpha_gw_movmtn" type="real" category="gw_drag"
+       group="gw_drag_nl" valid_values="" >
+Tunable parameter controlling proportion of boundary layer momentum flux escaping as GW momentum flux
+Default: set by build-namelist.
+</entry>
+
+
+<entry id="gw_drag_file" type="char*256" input_pathname="abs" category="gw_drag"
+       group="gw_drag_nl" valid_values="" >
+Full pathname of Beres lookup table data file for gravity waves sourced
+from deep convection.
+Default: set by build-namelist.
+</entry>
+
+<entry id="gw_drag_file_sh" type="char*256" input_pathname="abs" category="gw_drag"
+       group="gw_drag_nl" valid_values="" >
+Full pathname of Beres lookup table data file for gravity waves sourced
+from shallow convection.
+Default: set by build-namelist.
+</entry>
+
+<entry id="gw_drag_file_mm" type="char*256" input_pathname="abs" category="gw_drag"
+       group="gw_drag_nl" valid_values="" >
+Relative pathname of lookup table for deep convective moving mountain GW source
+Default: set by build-namelist.
+</entry>
+
+<entry id="taubgnd" type="real" category="gw_drag"
+       group="gw_drag_nl" valid_values="" >
+Background source strength (used for waves from frontogenesis).
+Default: set by build-namelist.
+</entry>
+
+<entry id="taubgnd_igw" type="real" category="gw_drag"
+       group="gw_drag_nl" valid_values="" >
+Background source strength (used for inertial waves from frontogenesis).
+Default: set by build-namelist.
+</entry>
+
+<entry id="gw_polar_taper" type="logical" category="gw_drag"
+       group="gw_drag_nl" valid_values="" >
+Whether or not to use tapering at the poles to reduce the effects of
+mid-scale gravity waves from frontogenesis.
+Default: set by build-namelist.
+</entry>
+
+<entry id="gw_top_taper" type="logical" category="gw_drag"
+       group="gw_drag_nl" valid_values="" >
+Whether or not to apply tapering at the top of the model (above 0.6E-02 Pa)
+to reduce undesired effects of gravity waves in the thermosphere/ionosphere.
+Default: set by build-namelist
+</entry>
+
+<!-- Gravity Wave Ridge -->
+
+<entry id="gw_rdg_do_divstream" type="logical" category="gw_rdg"
+       group="gw_rdg_nl" valid_values="" >
+If .true. use separate dividing streamlines for downslope wind and flow
+splitting regimes ("DS" configuration).
+If .false. use single dividing streamline as in Scinocca &amp; McFarlane
+2000 ("SM" configuration).
+Default: set by build-namelist.
+</entry>
+
+<entry id="gw_rdg_do_smooth_regimes" type="logical" category="gw_rdg"
+       group="gw_rdg_nl" valid_values="" >
+If true, then use smooth regimes
+Default: set by build-namelist.
+</entry>
+
+<entry id="gw_rdg_do_adjust_tauoro" type="logical" category="gw_rdg"
+       group="gw_rdg_nl" valid_values="" >
+If true, then adjust tauoro
+Default: set by build-namelist.
+</entry>
+
+<entry id="gw_rdg_do_backward_compat" type="logical" category="gw_rdg"
+       group="gw_rdg_nl" valid_values="" >
+If true, then adjust for bit-for-bit answers with the ("N5") configuration
+Default: set by build-namelist.
+</entry>
+
+<entry id="gw_rdg_C_BetaMax_DS" type="real"  category="gw_rdg"
+       group="gw_rdg_nl" valid_values="" >
+Enhancement factor for downslope wind stress in DS configuration.
+Default: set by build-namelist.
+</entry>
+
+<entry id="gw_rdg_C_GammaMax" type="real"  category="gw_rdg"
+       group="gw_rdg_nl" valid_values="" >
+Enhancement factor for depth of downslope wind regime in DS configuration
+Default: set by build-namelist.
+</entry>
+
+<entry id="gw_rdg_Frx0" type="real"  category="gw_rdg"
+       group="gw_rdg_nl" valid_values="" >
+Lower inverse Froude number limits on linear ramp terminating downslope wind regime for high mountains in DS configuration
+Default: set by build-namelist.
+</entry>
+
+<entry id="gw_rdg_Frx1" type="real"  category="gw_rdg"
+       group="gw_rdg_nl" valid_values="" >
+Upper inverse Froude number limits on linear ramp terminating downslope wind regime for high mountains in DS configuration
+Default: set by build-namelist.
+</entry>
+
+<entry id="gw_rdg_C_BetaMax_SM" type="real"  category="gw_rdg"
+       group="gw_rdg_nl" valid_values="" >
+Enhancement factor for downslope wind stress in SM configuration.
+Default: set by build-namelist.
+</entry>
+
+<entry id="gw_rdg_Fr_c" type="real"  category="gw_rdg"
+       group="gw_rdg_nl" valid_values="" >
+Critical inverse Froude number
+Default: set by build-namelist.
+</entry>
+
+<entry id="gw_rdg_orohmin" type="real"  category="gw_rdg"
+       group="gw_rdg_nl" valid_values="" >
+minimum surface displacement height for orographic waves (m)
+Default: set by build-namelist.
+</entry>
+
+<entry id="gw_rdg_orovmin" type="real"  category="gw_rdg"
+       group="gw_rdg_nl" valid_values="" >
+Minimum wind speed for orographic waves
+Default: set by build-namelist.
+</entry>
+
+<entry id="gw_rdg_orostratmin" type="real"  category="gw_rdg"
+       group="gw_rdg_nl" valid_values="" >
+Minimum stratification allowing wave behavior
+Default: set by build-namelist.
+</entry>
+
+<entry id="gw_rdg_orom2min" type="real"  category="gw_rdg"
+       group="gw_rdg_nl" valid_values="" >
+Minimum stratification allowing wave behavior
+Default: set by build-namelist.
+</entry>
+
+<entry id="gw_rdg_do_vdiff" type="logical"  category="gw_rdg"
+       group="gw_rdg_nl" valid_values="" >
+If TRUE gravity wave ridge scheme will contribute to vertical diffusion tendencies.
+Default: TRUE
+</entry>
+
+<!-- Greenhouse Gases: CO2, CH4, N2O, CFC11, CFC12 (original CAM versions) -->
+
+<entry id="bndtvghg" type="char*256" input_pathname="abs" category="ghg_cam"
+       group="chem_surfvals_nl" valid_values="" >
+Full pathname of time-variant boundary dataset for greenhouse gas surface
+values.
+Default: set by build-namelist.
+</entry>
+
+<entry id="ch4vmr" type="real"  category="ghg_cam"
+       group="chem_surfvals_nl" valid_values="" >
+CH4 volume mixing ratio.  This is used as the time invariant surface value
+of CH4 if no time varying values are specified.
+Default: set by build-namelist.
+</entry>
+
+<entry id="co2vmr" type="real"  category="ghg_cam"
+       group="chem_surfvals_nl" valid_values="" >
+CO2 volume mixing ratio.  This is used as the time invariant surface value
+of CO2 if no time varying values are specified.
+Default: set by build-namelist.
+</entry>
+
+<entry id="co2vmr_rad" type="real"  category="ghg_cam"
+       group="chem_surfvals_nl" valid_values="" >
+User override for the prescribed CO2 volume mixing ratio used by the radiation
+calculation.  Note however that the prescribed value of CO2 which is sent
+to the surface models is still the one that is set using either the
+{{ hilight }}co2vmr{{ closehilight }} or the {{ hilight }}scenario_ghg{{ closehilight }} variables.
+Default: not used
+</entry>
+
+<entry id="f11vmr" type="real"  category="ghg_cam"
+       group="chem_surfvals_nl" valid_values="" >
+CFC11 volume mixing ratio adjusted to reflect contributions from many GHG
+species.  This is used as the time invariant surface value of F11 if no
+time varying values are specified.
+Default: set by build-namelist.
+</entry>
+
+<entry id="f12vmr" type="real"  category="ghg_cam"
+       group="chem_surfvals_nl" valid_values="" >
+CFC12 volume mixing ratio.  This is used as the time invariant surface value
+of CFC12 if no time varying values are specified.
+Default: set by build-namelist.
+</entry>
+
+<entry id="n2ovmr" type="real"  category="ghg_cam"
+       group="chem_surfvals_nl" valid_values="" >
+N2O volume mixing ratio.  This is used as the time invariant surface value
+of N2O if no time varying values are specified.
+Default: set by build-namelist
+</entry>
+
+<entry id="ghg_yearstart_data" type="integer"  category="ghg_cam"
+       group="chem_surfvals_nl" valid_values="" >
+Data start year.  Use in conjunction
+with {{ hilight }}ghg_yearstart_model{{ closehilight }}.
+Default: 0
+</entry>
+
+<entry id="ghg_yearstart_model" type="integer"  category="ghg_cam"
+       group="chem_surfvals_nl" valid_values="" >
+Model start year.  Use in conjunction
+with {{ hilight }}ghg_yearstart_data{{ closehilight }}.
+Default: 0
+</entry>
+
+<entry id="ramp_co2_annual_rate" type="real"  category="ghg_cam"
+       group="chem_surfvals_nl" valid_values="" >
+Amount of co2 ramping per year (percent).  Only used
+if {{ hilight }}scenario_ghg{{ closehilight }} = 'RAMP_CO2_ONLY'
+Default: 1.0
+</entry>
+
+<entry id="ramp_co2_cap" type="real"  category="ghg_cam"
+       group="chem_surfvals_nl" valid_values="" >
+CO2 cap if &gt; 0, floor otherwise.  Specified as multiple or fraction of
+inital value; e.g., setting to 4.0 will cap at 4x initial CO2 setting.
+Only used if {{ hilight }}scenario_ghg{{ closehilight }} = 'RAMP_CO2_ONLY'
+Default: boundless if {{ hilight }}ramp_co2_annual_rate{{ closehilight }} &gt; 0, zero otherwise.
+</entry>
+
+<entry id="ramp_co2_start_ymd" type="integer"  category="ghg_cam"
+       group="chem_surfvals_nl" valid_values="" >
+Date on which ramping of co2 begins.  The date is encoded as an integer in
+the form YYYYMMDD.  Only used if {{ hilight }}scenario_ghg{{ closehilight }} = 'RAMP_CO2_ONLY'
+Default: 0
+</entry>
+
+<entry id="rampyear_ghg" type="integer"  category="ghg_cam"
+       group="chem_surfvals_nl" valid_values="" >
+If {{ hilight }}scenario_ghg{{ closehilight }} is set to "RAMPED" then the greenhouse
+gas surface values are interpolated between the annual average values
+read from the file specified by {{ hilight }}bndtvghg{{ closehilight }}.
+In that case, the value of this variable (&gt; 0) fixes the year of the
+lower bounding value (i.e., the value for calendar day 1.0) used in the
+interpolation.  For example, if rampyear_ghg = 1950, then the GHG surface
+values will be the result of interpolating between the values for 1950 and
+1951 from the dataset.
+Default: 0
+</entry>
+
+<entry id="scenario_ghg" type="char*16"  category="ghg_cam"
+       group="chem_surfvals_nl" valid_values="FIXED,RAMPED,RAMP_CO2_ONLY,CHEM_LBC_FILE" >
+Controls treatment of prescribed co2, ch4, n2o, cfc11, cfc12 volume mixing
+ratios.  May be set to 'FIXED', 'RAMPED', 'RAMP_CO2_ONLY', or 'CHEM_LBC_FILE'.
+FIXED =&gt; volume mixing ratios are fixed and have either default or namelist
+         input values.
+RAMPED =&gt; volume mixing ratios are time interpolated from the dataset
+          specified by {{ hilight }}bndtvghg{{ closehilight }}.
+RAMP_CO2_ONLY =&gt; only co2 mixing ratios are ramped at a rate determined by
+                    the variables {{ hilight }}ramp_co2_annual_rate{{ closehilight }}, {{ hilight }}ramp_co2_cap{{ closehilight }},
+                    and {{ hilight }}ramp_co2_start_ymd{{ closehilight }}.
+CHEM_LBC_FILE =&gt; volume mixing ratios are set from the chemistry lower boundary
+                    conditions dataset specified by {{ hilight }}flbc_file{{ closehilight }}.
+Default: FIXED
+</entry>
+
+<!-- Greenhouse Gases: prognostic CH4, N2O, CFC11, CFC12 (original CAM versions) -->
+
+<entry id="bndtvg" type="char*256" input_pathname="abs" category="ghg_chem"
+       group="chem_inparm" valid_values="" >
+Full pathname of time-variant boundary dataset for greenhouse gas production/loss
+rates.  Only used by the simple prognostic GHG chemistry scheme that is
+enabled via the argument "-prog_species GHG" to configure.
+Default: set by build-namelist.
+</entry>
+
+<entry id="ghg_chem" type="logical"  category="ghg_chem"
+       group="chem_inparm" valid_values="" >
+This variable should not be set by the user.  It is set by build-namelist
+when the user specifies the argument "-prog_species GHG" to configure which
+turns on a simple prognostic chemistry scheme for CH4, N2O, CFC11 and
+CFC12.
+Default: set by build-namelist
+</entry>
+
+
+<!-- CO2 cycle for BGC -->
+
+<entry id="co2_cycle_rad_passive" type="logical" category="co2_cycle"
+       group="camexp" valid_values="" >
+Flag to set rad_climate variable so that the prognostic CO2 controlled by
+the co2_cycle module is radiatively passive.
+Default: FALSE
+</entry>
+
+<entry id="co2_flag" type="logical"  category="co2_cycle"
+       group="co2_cycle_nl" valid_values="" >
+If TRUE turn on CO2 code.
+Default: set by build-namelist
+</entry>
+
+<entry id="co2_readflux_fuel" type="logical"  category="co2_cycle"
+       group="co2_cycle_nl" valid_values="" >
+If TRUE read co2 fuel flux from file.
+Default: set by build-namelist
+</entry>
+
+<entry id="co2_readflux_ocn" type="logical"  category="co2_cycle"
+       group="co2_cycle_nl" valid_values="" >
+If TRUE read co2 ocn flux from file.
+Default: FALSE
+</entry>
+
+<entry id="co2_readflux_aircraft" type="logical"  category="co2_cycle"
+       group="co2_cycle_nl" valid_values="" >
+If TRUE read co2 aircraft flux from file.
+Default: set by build-namelist
+</entry>
+
+<entry id="co2flux_ocn_file" type="char*256" input_pathname="abs" category="co2_cycle"
+       group="co2_cycle_nl" valid_values="" >
+Filepath for dataset containing CO2 flux from ocn.
+Default: none
+</entry>
+
+<entry id="co2flux_fuel_file" type="char*256" input_pathname="abs" category="co2_cycle"
+       group="co2_cycle_nl" valid_values="" >
+Filepath for dataset containing CO2 flux from fossil fuel.
+Default: none
+</entry>
+
+<!-- History and Initial Conditions Output -->
+
+<entry id="avgflag_pertape" type="char*1(10)"  category="history"
+       group="cam_history_nl" valid_values="A,B,I,X,M,N,L,S" >
+Sets the averaging flag for all variables on a particular history file
+series. Valid values are:
+
+ A ==&gt; Average
+ B ==&gt; GMT 00:00:00 average
+ I ==&gt; Instantaneous
+ M ==&gt; Minimum
+ N ==&gt; average over nsteps
+ X ==&gt; Maximum
+ L ==&gt; Local-time
+ S ==&gt; Standard deviation
+
+The default is to use the averaging flags for each variable that are set in
+the code via calls to subroutine addfld.
+
+Defaults: set in code via the addfld and add_default subroutine calls.
+</entry>
+
+<entry id="empty_htapes" type="logical"  category="history"
+       group="cam_history_nl" valid_values="" >
+If true don't put any of the variables on the history tapes by
+default. Only output the variables that the user explicitly lists in
+the {{ hilight }}fincl#{{ closehilight }} namelist items.
+Default: FALSE
+</entry>
+
+<entry id="write_nstep0" type="logical"  category="history"
+       group="cam_history_nl" valid_values="" >
+If true then write the nstep==0 time sample to all history files except
+the monthly average file.  This output is primarily useful for development
+and debugging as it captures changes to the model state made during the
+initialization phase of the run.
+Default: FALSE
+</entry>
+
+<entry id="fexcl1" type="char*24(1000)"  category="history"
+       group="cam_history_nl" valid_values="" >
+List of fields to exclude from the 1st history file (by default the name
+of this file contains the string "h0").
+Default: none
+</entry>
+<entry id="fexcl2" type="char*24(1000)"  category="history"
+       group="cam_history_nl" valid_values="" >
+List of fields to exclude from the 2nd history file (by default the name
+of this file contains the string "h1").
+Default: none
+</entry>
+<entry id="fexcl3" type="char*24(1000)"  category="history"
+       group="cam_history_nl" valid_values="" >
+List of fields to exclude from the 3rd history file (by default the name
+of this file contains the string "h2").
+Default: none
+</entry>
+<entry id="fexcl4" type="char*24(1000)"  category="history"
+       group="cam_history_nl" valid_values="" >
+List of fields to exclude from the 4th history file (by default the name
+of this file contains the string "h3").
+Default: none
+</entry>
+<entry id="fexcl5" type="char*24(1000)"  category="history"
+       group="cam_history_nl" valid_values="" >
+List of fields to exclude from the 5th history file (by default the name
+of this file contains the string "h4").
+Default: none
+</entry>
+<entry id="fexcl6" type="char*24(1000)"  category="history"
+       group="cam_history_nl" valid_values="" >
+List of fields to exclude from the 6th history file (by default the name
+of this file contains the string "h5").
+Default: none
+</entry>
+<entry id="fexcl7" type="char*24(1000)"  category="history"
+       group="cam_history_nl" valid_values="" >
+List of fields to exclude from the 7th history file (by default the name
+of this file contains the string "h6").
+Default: none
+</entry>
+<entry id="fexcl8" type="char*24(1000)"  category="history"
+       group="cam_history_nl" valid_values="" >
+List of fields to exclude from the 8th history file (by default the name
+of this file contains the string "h7").
+Default: none
+</entry>
+<entry id="fexcl9" type="char*24(1000)"  category="history"
+       group="cam_history_nl" valid_values="" >
+List of fields to exclude from the 9th history file (by default the name
+of this file contains the string "h8").
+Default: none
+</entry>
+<entry id="fexcl10" type="char*24(1000)"  category="history"
+       group="cam_history_nl" valid_values="" >
+List of fields to exclude from the 10th history file (by default the name
+of this file contains the string "h9").
+Default: none
+</entry>
+
+<entry id="fincl1" type="char*26(1000)"  category="history"
+       group="cam_history_nl" valid_values="" >
+List of fields to include on the first history file (by default the name of
+this file contains the string "h0").  The added fields must be in Master
+Field List.  The averaging flag for the output field can be specified by
+appending a ":" and a valid averaging flag to the field name.  Valid flags
+are:
+
+ A ==&gt; Average
+ B ==&gt; GMT 00:00:00 average
+ I ==&gt; Instantaneous
+ M ==&gt; Minimum
+ N ==&gt; average over nsteps
+ X ==&gt; Maximum
+ L ==&gt; Local-time
+ S ==&gt; Standard deviation
+
+Default:  set in code via the addfld and add_default subroutine calls.
+</entry>
+<entry id="fincl2" type="char*26(1000)"  category="history"
+       group="cam_history_nl" valid_values="" >
+Same as {{ hilight }}fincl1{{ closehilight }}, but for the 2nd history file (by default
+the name of this file contains the string "h1").
+Default: none.
+</entry>
+<entry id="fincl3" type="char*26(1000)"  category="history"
+       group="cam_history_nl" valid_values="" >
+Same as {{ hilight }}fincl1{{ closehilight }}, but for the 3rd history file (by default
+the name of this file contains the string "h2").
+Default: none.
+</entry>
+<entry id="fincl4" type="char*26(1000)"  category="history"
+       group="cam_history_nl" valid_values="" >
+Same as {{ hilight }}fincl1{{ closehilight }}, but for the 4th history file (by default
+the name of this file contains the string "h3").
+Default: none.
+</entry>
+<entry id="fincl5" type="char*26(1000)"  category="history"
+       group="cam_history_nl" valid_values="" >
+Same as {{ hilight }}fincl1{{ closehilight }}, but for the 5th history file (by default
+the name of this file contains the string "h4").
+Default: none.
+</entry>
+<entry id="fincl6" type="char*26(1000)"  category="history"
+       group="cam_history_nl" valid_values="" >
+Same as {{ hilight }}fincl1{{ closehilight }}, but for the 6th history file (by default
+the name of this file contains the string "h5").
+Default: none.
+</entry>
+
+<entry id="fincl7" type="char*26(1000)"  category="history"
+       group="cam_history_nl" valid_values="" >
+Same as {{ hilight }}fincl1{{ closehilight }}, but for the 7th history file (by default
+the name of this file contains the string "h6").
+Default: none.
+</entry>
+<entry id="fincl8" type="char*26(1000)"  category="history"
+       group="cam_history_nl" valid_values="" >
+Same as {{ hilight }}fincl1{{ closehilight }}, but for the 8th history file (by default
+the name of this file contains the string "h7").
+Default: none.
+</entry>
+<entry id="fincl9" type="char*26(1000)"  category="history"
+       group="cam_history_nl" valid_values="" >
+Same as {{ hilight }}fincl1{{ closehilight }}, but for the 9th history file (by default
+the name of this file contains the string "h8").
+Default: none.
+</entry>
+<entry id="fincl10" type="char*26(1000)"  category="history"
+       group="cam_history_nl" valid_values="" >
+Same as {{ hilight }}fincl1{{ closehilight }}, but for the 10th history file (by default
+the name of this file contains the string "h9").
+Default: none.
+</entry>
+
+<entry id="clubb_history" type="logical"  category="history"
+       group="clubb_his_nl" valid_values="" >
+if .true. then output CLUBBs history statistics
+Default: false
+</entry>
+
+<entry id="clubb_rad_history" type="logical"  category="history"
+       group="clubb_his_nl" valid_values="" >
+if .true. then output CLUBBs radiative history statistics
+Default: false
+</entry>
+
+<entry id="clubb_vars_zt" type="char*35(10000)"  category="history"
+       group="clubb_stats_nl" valid_values="" >
+Same as {{ hilight }}fincl1{{ closehilight }}, but for CLUBB statistics on zt grid.
+</entry>
+
+<entry id="clubb_vars_zm" type="char*35(10000)"  category="history"
+       group="clubb_stats_nl" valid_values="" >
+Same as {{ hilight }}fincl1{{ closehilight }}, but for CLUBB statistics on zm grid.
+</entry>
+
+<entry id="clubb_vars_rad_zt" type="char*35(10000)"  category="history"
+       group="clubb_stats_nl" valid_values="" >
+Same as {{ hilight }}fincl1{{ closehilight }}, but for CLUBB statistics on radiation zt grid.
+</entry>
+
+<entry id="clubb_vars_rad_zm" type="char*35(10000)"  category="history"
+       group="clubb_stats_nl" valid_values="" >
+Same as {{ hilight }}fincl1{{ closehilight }}, but for CLUBB statistics on radiation zm grid.
+</entry>
+
+<entry id="clubb_vars_sfc" type="char*35(10000)"  category="history"
+       group="clubb_stats_nl" valid_values="" >
+Same as {{ hilight }}fincl1{{ closehilight }}, but for CLUBB statistics on surface.
+</entry>
+
+<entry id="collect_column_output" type="logical(10)" category="history"
+   group="cam_history_nl" valid_values="">
+Collect all column data into a single field and output in ncol format,
+much faster than default when you have a lot of columns.
+</entry>
+
+<entry id="fincl1lonlat" type="char*128(1000)"  category="history"
+       group="cam_history_nl" valid_values="" >
+List of columns or contiguous columns at which the fincl1 fields will be
+output. Individual columns are specified as a string using a longitude
+degree (greater or equal to 0.) followed by a single character
+(e)ast/(w)est identifer, an underscore '_' , and a latitude degree followed
+by a single character (n)orth/(s)outh identifier.  For example, '10e_20n'
+would pick the model column closest to 10 degrees east longitude by 20
+degrees north latitude.  A group of contiguous columns can be specified
+using bounding latitudes and longitudes separated by a colon.  For example,
+'10e:20e_15n:20n' would select the model columns which fall with in the
+longitude range from 10 east to 20 east and the latitude range from 15
+north to 20 north.
+</entry>
+<entry id="fincl2lonlat" type="char*128(1000)"  category="history"
+       group="cam_history_nl" valid_values="" >
+Same as {{ hilight }}fincl1lonlat{{ closehilight }}, but for 2nd history file.
+</entry>
+<entry id="fincl3lonlat" type="char*128(1000)"  category="history"
+       group="cam_history_nl" valid_values="" >
+Same as {{ hilight }}fincl1lonlat{{ closehilight }}, but for 3rd history file.
+</entry>
+<entry id="fincl4lonlat" type="char*128(1000)"  category="history"
+       group="cam_history_nl" valid_values="" >
+Same as {{ hilight }}fincl1lonlat{{ closehilight }}, but for 4th history file.
+</entry>
+<entry id="fincl5lonlat" type="char*128(1000)"  category="history"
+       group="cam_history_nl" valid_values="" >
+Same as {{ hilight }}fincl1lonlat{{ closehilight }}, but for 5th history file.
+</entry>
+<entry id="fincl6lonlat" type="char*128(1000)"  category="history"
+       group="cam_history_nl" valid_values="" >
+Same as {{ hilight }}fincl1lonlat{{ closehilight }}, but for 6th history file.
+</entry>
+<entry id="fincl7lonlat" type="char*128(1000)"  category="history"
+       group="cam_history_nl" valid_values="" >
+Same as {{ hilight }}fincl1lonlat{{ closehilight }}, but for 7th history file.
+</entry>
+<entry id="fincl8lonlat" type="char*128(1000)"  category="history"
+       group="cam_history_nl" valid_values="" >
+Same as {{ hilight }}fincl1lonlat{{ closehilight }}, but for 8th history file.
+</entry>
+<entry id="fincl9lonlat" type="char*128(1000)"  category="history"
+       group="cam_history_nl" valid_values="" >
+Same as {{ hilight }}fincl1lonlat{{ closehilight }}, but for 9th history file.
+</entry>
+<entry id="fincl10lonlat" type="char*128(1000)"  category="history"
+       group="cam_history_nl" valid_values="" >
+Same as {{ hilight }}fincl1lonlat{{ closehilight }}, but for 10th history file.
+</entry>
+
+<entry id="fwrtpr1" type="char*26(1000)"  category="history"
+       group="cam_history_nl" valid_values="" >
+Specific fields which will be written using the non-default precision on
+the 1st history file.
+Default: none
+</entry>
+<entry id="fwrtpr2" type="char*26(1000)"  category="history"
+       group="cam_history_nl" valid_values="" >
+Specific fields which will be written using the non-default precision on
+the 2nd history file.
+Default: none
+</entry>
+<entry id="fwrtpr3" type="char*26(1000)"  category="history"
+       group="cam_history_nl" valid_values="" >
+Specific fields which will be written using the non-default precision on
+the 3rd history file.
+Default: none
+</entry>
+<entry id="fwrtpr4" type="char*26(1000)"  category="history"
+       group="cam_history_nl" valid_values="" >
+Specific fields which will be written using the non-default precision on
+the 4th history file.
+Default: none
+</entry>
+<entry id="fwrtpr5" type="char*26(1000)"  category="history"
+       group="cam_history_nl" valid_values="" >
+Specific fields which will be written using the non-default precision on
+the 5th history file.
+Default: none
+</entry>
+<entry id="fwrtpr6" type="char*26(1000)"  category="history"
+       group="cam_history_nl" valid_values="" >
+Specific fields which will be written using the non-default precision on
+the 6th history file.
+Default: none
+</entry>
+<entry id="fwrtpr7" type="char*26(1000)"  category="history"
+       group="cam_history_nl" valid_values="" >
+Specific fields which will be written using the non-default precision on
+the 7th history file.
+Default: none
+</entry>
+<entry id="fwrtpr8" type="char*26(1000)"  category="history"
+       group="cam_history_nl" valid_values="" >
+Specific fields which will be written using the non-default precision on
+the 8th history file.
+Default: none
+</entry>
+<entry id="fwrtpr9" type="char*26(1000)"  category="history"
+       group="cam_history_nl" valid_values="" >
+Specific fields which will be written using the non-default precision on
+the 9th history file.
+Default: none
+</entry>
+<entry id="fwrtpr10" type="char*26(1000)"  category="history"
+       group="cam_history_nl" valid_values="" >
+Specific fields which will be written using the non-default precision on
+the 10th history file.
+Default: none
+</entry>
+
+<entry id="hfilename_spec" type="char*256(10)"  category="history"
+       group="cam_history_nl" valid_values="" >
+
+Array of history filename specifiers.  The filenames of up to six history
+output files can be controlled via this variable.  Filename specifiers give
+generic formats for the filenames with specific date and time components,
+file series number (0-5), and caseid, filled in when the files are
+created. The following strings are expanded when the filename is created:
+%c=caseid; %t=file series number (0-5); %y=year (normally 4 digits, more
+digits if needed); %m=month; %d=day; %s=seconds into current day; %%=%
+symbol.  Note that the caseid may be set using the namelist
+variable {{ hilight }}case_name{{ closehilight }}.
+
+For example, for a simulation with caseid="test" and current date and time
+of 0000-12-31 0:00UT, a filename specifier of "%c.cam2.h%t.%y-%m.nc" would
+expand into "test.cam2.h0.0000-12.nc" for the first history file.  The
+filename specifier "%c.cam2.h%t.%y-%m-%d-%s.nc" would expand to
+"test.cam2.h1.0000-12-31-00000.nc" for the second history file. Spaces are
+not allowed in filename specifiers. Although the character "/" is allowed
+in the specifier, it will be interpreted as a directory name and the
+corresponding directories will have to be created in the model execution
+directory (directory given to configure with -cam_exedir option) before
+model execution.  The first element is for the primary history file which
+is output by default as a monthly history file.  Entries 2 through 6 are
+user specified auxilliary output files.
+
+Defaults: "%c.cam2.h0.%y-%m.nc", "%c.cam2.h1.%y-%m-%d-%s.nc", ...,
+          "%c.cam2.h5.%y-%m-%d-%s.nc"
+</entry>
+
+<entry id="sathist_track_infile" type="char*256" input_pathname="abs" category="history"
+       group="satellite_options_nl" valid_values="" >
+Full pathname of the satellite track data used by the satellite track history
+output feature.
+Default: none
+</entry>
+<entry id="sathist_hfilename_spec" type="char*256"  category="history"
+       group="satellite_options_nl" valid_values="" >
+Satellite track history filename specifier.  See {{ hilight }}hfilename_spec{{ closehilight }}
+Default:  "%c.cam2.sat.%y-%m-%d-%s.nc"
+</entry>
+<entry id="sathist_fincl" type="char*26(1000)"  category="history"
+       group="satellite_options_nl" valid_values="" >
+List of history fields to output along the satellite track specified by  {{ hilight }}sathist_track_infile{{ closehilight }}
+Default: none
+</entry>
+<entry id="sathist_mfilt" type="integer"  category="history"
+       group="satellite_options_nl" valid_values="" >
+Sets the maximum number of observation columns written to the satellite track history file
+series.
+Default: 100000
+</entry>
+
+<entry id="sathist_nclosest" type="integer"  category="history"
+       group="satellite_options_nl" valid_values="" >
+Sets the number of columns closest to the observation that should be output. Setting
+this to a number greater than 1 allows for spatial interpolation in the post processing.
+Default: 1
+</entry>
+
+<entry id="sathist_ntimestep" type="integer"  category="history"
+       group="satellite_options_nl" valid_values="" >
+Sets the number of timesteps closest to the observation that should be output. Setting
+this to a number greater than 1 allows for temporal interpolation in the post processing.
+Default: 1
+</entry>
+
+<entry id="inithist" type="char*8"  category="history"
+       group="cam_history_nl" valid_values="NONE,6-HOURLY,DAILY,MONTHLY,YEARLY,CAMIOP,ENDOFRUN" >
+Frequency that initial files will be output: 6-hourly, daily, monthly,
+yearly, or never.  Valid values: 'NONE', '6-HOURLY', 'DAILY', 'MONTHLY',
+'YEARLY', 'CAMIOP', 'ENDOFRUN'.
+Default: 'YEARLY'
+</entry>
+
+<entry id="inithist_all" type="logical"  category="history"
+       group="cam_history_nl" valid_values="" >
+If false then include only REQUIRED fields on IC file.  If true then
+include required AND optional fields on IC file.
+Default: FALSE
+</entry>
+
+<entry id="mfilt" type="integer(10)"  category="history"
+       group="cam_history_nl" valid_values="" >
+Array containing the maximum number of time samples written to a history
+file.  The first value applies to the primary history file, the second
+through tenth to the auxillary history files.
+Default: 1,30,30,30,30,30,30,30,30,30
+</entry>
+
+<entry id="lcltod_start" type="integer(10)"  category="history"
+       group="cam_history_nl" valid_values="" >
+Array containing the starting time of day for local time history averaging.
+Used in conjuction with lcltod_stop. If lcltod_stop is less than lcltod_start,
+then the time range wraps around 24 hours. The start time is included in the
+interval. Time is in seconds and defaults to 39600 (11:00 AM).  The first value
+applies to the primary hist. file, the second to the first aux. hist. file, etc.
+Default: none
+</entry>
+
+<entry id="lcltod_stop" type="integer(10)"  category="history"
+       group="cam_history_nl" valid_values="" >
+Array containing the stopping time of day for local time history averaging.
+Used in conjuction with lcltod_start. If lcltod_stop is less than lcltod_start,
+then the time range wraps around 24 hours. The stop time is not included in the
+interval. Time is in seconds and defaults to 0 (midnight).  The first value
+applies to the primary hist. file, the second to the first aux. hist. file, etc.
+Default: none
+</entry>
+
+<entry id="ndens" type="integer(10)"  category="history"
+       group="cam_history_nl" valid_values="1,2" >
+
+Array specifying the precision of real data written to each history file
+series. Valid values are 1 or 2. '1' implies output real values are 8-byte
+and '2' implies output real values are 4-byte.
+
+Default: 2,2,2,2,2,2,2,2,2,2
+</entry>
+
+
+<entry id="nhtfrq" type="integer(10)"  category="history"
+       group="cam_history_nl" valid_values="" >
+
+Array of write frequencies for each history file series.
+If {{ hilight }}nhtfrq(i){{ closehilight }} = 0, the file will be a monthly average.
+If {{ hilight }}nhtfrq(i){{ closehilight }} &gt; 0, frequency is specified as number of
+timesteps.  If {{ hilight }}nhtfrq(i){{ closehilight }} &lt; 0, frequency is specified
+as number of hours.
+
+Default: 0,-24,-24,-24,-24,-24,-24,-24,-24,-24
+</entry>
+
+<entry id="interpolate_output" type="logical(10)" category="history"
+    group="cam_history_nl" valid_values="">
+If interpolate_output(k) = .true., then the k'th history file will be
+interpolated to a lat/lon grid before output.
+Default: .false.
+</entry>
+
+<entry id="interpolate_nlat" type="integer(10)" category="history"
+    group="cam_history_nl" valid_values="">
+Size of latitude dimension of grid for interpolated output.
+If interpolate_nlat and interpolate_nlon are zero, reasonable values
+will be chosen by the dycore based on the run resolution.
+Default: 0
+</entry>
+
+<entry id="interpolate_nlon" type="integer(10)" category="history"
+    group="cam_history_nl" valid_values="">
+Size of longitude dimension of grid for interpolated output.
+If interpolate_nlat and interpolate_nlon are zero, reasonable values
+will be chosen by the dycore based on the run resolution.
+Default: 0
+</entry>
+
+<entry id="interpolate_type" type="integer(10)" category="history"
+    group="cam_history_nl" valid_values="0,1">
+Selects interpolation method for output on lat/lon grid.
+0: Use SE's native high-order method.
+1: Use a bilinear method.
+Default: 1 (bilinear)
+</entry>
+
+<entry id="interpolate_gridtype" type="integer(10)" category="history"
+    group="cam_history_nl" valid_values="1,2,3">
+Selects output grid type for lat/lon interpolated output.
+1: Equally spaced, including poles (FV scalars output grid).
+2: Gauss grid (CAM Eulerian).
+3: Equally spaced, no poles (FV staggered velocity).
+Default: 1
+</entry>
+
+<!-- Initial Conditions -->
+
+<entry id="ncdata" type="char*256" input_pathname="abs" category="initial_conditions"
+       group="cam_initfiles_nl" valid_values="" >
+Full pathname of initial atmospheric state dataset (NetCDF format).
+Default: set by build-namelist.
+</entry>
+
+<entry id="pertlim" type="real"  category="initial_conditions"
+       group="cam_initfiles_nl" valid_values="" >
+Perturb the initial conditions for temperature randomly by up to the given
+amount. Only applied for initial simulations.
+Default: 0.0
+</entry>
+
+<entry id="cam_branch_file" type="char*256" category="initial_conditions"
+       group="cam_initfiles_nl" valid_values="">
+Full pathname of master restart file from which to branch. Setting is
+Required for branch run.
+Default: none
+</entry>
+
+<entry id="scale_dry_air_mass" type="real" category="initial_conditions"
+       group="cam_initfiles_nl" valid_values="">
+Specify whether and how to perform dry surface pressure scaling. If less than or equal to 0.0,
+do not perform scaling. If greater than 0.0, perform scaling to scale_dry_air_mass
+value (in Pa) as the average dry surface pressure target.
+Default: set by build-namelist.
+</entry>
+
+<entry id="readtrace" type="logical"  category="initial_conditions"
+       group="constituents_nl" valid_values="" >
+If TRUE, try to initialize data for all consituents by reading from the
+initial conditions dataset. If variable not found then data will be
+initialized using internally-specified default values.  If FALSE then don't
+try reading constituent data from the IC file; just use the
+internally-specified defaults.
+Default: TRUE
+</entry>
+
+<!-- COSP Cloud Simulator control LOGICALS -->
+
+<entry id="docosp" type="logical"  category="cosp"
+       group="cospsimulator_nl" valid_values="">
+If true, the COSP cloud simulator is run.
+Setting this namelist variable happens automatically if you compile with COSP.
+COSP will not run unless this is set to .true. in the namelist!
+Turn on the desired simulators using lXXX_sim namelist vars
+If no specific simulators are specified, all of the simulators
+are run on all columns and all output is saved. (useful for testing).
+COSP is available with CAM4, CAM5, CAM6 and CAM7 physics.
+This default logical is set in cospsimulator_intr.F90.
+Default: FALSE
+</entry>
+
+<entry id="cosp_amwg" type="logical"  category="cosp"
+       group="cospsimulator_nl" valid_values="">
+If true, COSP cloud simulators are run to produce
+all output required for the COSP plots in the AMWG diagnostics package.
+sets cosp_ncolumns=10 and cosp_nradsteps=3
+(appropriate for COSP statistics derived from seasonal averages),
+and runs MISR, ISCCP, MODIS, CloudSat radar and CALIPSO lidar simulators
+(cosp_lmisr_sim=.true.,cosp_lisccp_sim=.true.,
+cosp_lmodis_sim=.true.,cosp_lradar_sim=.true.,cosp_llidar_sim=.true.).
+This default logical is set in cospsimulator_intr.F90.
+Default: FALSE
+</entry>
+
+<entry id="cosp_lite" type="logical"  category="cosp"
+       group="cospsimulator_nl" valid_values="">
+If true, the COSP cloud simulators are run to produce
+select output for the AMWG diagnostics package.
+sets cosp_ncolumns=10 and cosp_nradsteps=3
+(appropriate for COSP statistics derived from seasonal averages),
+and runs MISR, ISCCP, MODIS, and CALIPSO lidar simulators
+(cosp_lmisr_sim=.true.,cosp_lisccp_sim=.true.,
+cosp_lmodis_sim=.true.,cosp_llidar_sim=.true.).
+This default logical is set in cospsimulator_intr.F90.
+Default: FALSE
+</entry>
+
+<entry id="cosp_passive" type="logical"  category="cosp"
+       group="cospsimulator_nl" valid_values="">
+If true, the passive COSP cloud simulators are run to produce
+select output for the AMWG diagnostics package.
+sets cosp_ncolumns=10 and cosp_nradsteps=3
+(appropriate for COSP statistics derived from seasonal averages),
+and runs MISR, ISCCP, and MODIS simulators
+(cosp_lmisr_sim=.true.,cosp_lisccp_sim=.true.,cosp_lmodis_sim=.true.).
+This default logical is set in cospsimulator_intr.F90.
+Default: FALSE
+</entry>
+
+<entry id="cosp_active" type="logical"  category="cosp"
+       group="cospsimulator_nl" valid_values="">
+If true, the active COSP cloud simulators are run to produce
+select output for the AMWG diagnostics package.
+sets cosp_ncolumns=10 and cosp_nradsteps=3
+(appropriate for COSP statistics derived from seasonal averages),
+and runs CloudSat radar and CALIPSO lidar simulators
+(cosp_lradar_sim=.true.,cosp_llidar_sim=.true.).
+This default logical is set in cospsimulator_intr.F90.
+Default: FALSE
+</entry>
+
+<entry id="cosp_isccp" type="logical"  category="cosp"
+       group="cospsimulator_nl" valid_values="">
+If true, the ISCCP cloud simulator is run to produce
+select output for the AMWG diagnostics package.
+sets cosp_ncolumns=10 and cosp_nradsteps=3
+(appropriate for COSP statistics derived from seasonal averages),
+and runs ISCCP simulator
+(cosp_lmisr_sim=.false.,cosp_lisccp_sim=.true.,
+cosp_lmodis_sim=.false.,cosp_lradar_sim=.false.,cosp_llidar_sim=.false.).
+This default logical is set in cospsimulator_intr.F90.
+1236: Default: FALSE
+</entry>
+
+<entry id="cosp_runall" type="logical"  category="cosp"
+       group="cospsimulator_nl" valid_values="">
+If true, run all simulators using the default values cosp_ncolumns=50 and
+cosp_nradsteps=1.  This option is mainly intended for testing, but it also
+must be used in order to output the input fields needed to run the
+simulator in an offline mode (via setting cosp_histfile_aux=.true.).
+Default: FALSE
+</entry>
+
+<entry id="cosp_lradar_sim" type="logical"  category="cosp"
+       group="cospsimulator_nl" valid_values="">
+If true, COSP radar simulator will be run and all non-subcolumn output
+will be saved.
+Default: FALSE
+</entry>
+
+<entry id="cosp_llidar_sim" type="logical"  category="cosp"
+       group="cospsimulator_nl" valid_values="">
+If true, COSP lidar simulator will be run and all non-subcolumn output
+will be saved
+Default: FALSE
+</entry>
+
+<entry id="cosp_lisccp_sim" type="logical"  category="cosp"
+       group="cospsimulator_nl" valid_values="">
+If true, COSP ISCCP simulator will be run and all non-subcolumn output
+will be saved.  ISCCP simulator is run on only daylight
+columns.
+Default: FALSE
+</entry>
+
+<entry id="cosp_lmisr_sim" type="logical"  category="cosp"
+       group="cospsimulator_nl" valid_values="">
+If true, MISR simulator will be run and all non-subcolumn output
+will be saved.  MISR simulator is run on only daylight
+columns.
+Default: FALSE
+</entry>
+
+<entry id="cosp_lmodis_sim" type="logical"  category="cosp"
+       group="cospsimulator_nl" valid_values="">
+If true, MODIS simulator will be run and all non-subcolumn output
+will be saved.
+
+Default: FALSE
+</entry>
+
+<entry id="cosp_lrttov_sim" type="logical"  category="cosp"
+       group="cospsimulator_nl" valid_values="">
+If true, RTTOV simulator will be run and output
+will be saved according to the appropriate RTTOV
+instrument namelist files in "rttov_instrument_namelists".
+
+Default: FALSE
+</entry>
+
+<!-- COSP input control parameters -->
+
+<entry id="cosp_ncolumns" type="integer"  category="cosp"
+       group="cospsimulator_nl" valid_values="">
+Number of subcolumns in SCOPS
+This default logical is set in cospsimulator_intr.F90
+Default: 50
+</entry>
+
+<entry id="cosp_rttov_Ninstruments" type="integer"  category="cosp"
+       group="cospsimulator_nl" valid_values="">
+Number of RTTOV instruments to simulate.
+This default logical is set in cospsimulator_intr.F90
+Default: 0
+</entry>
+    
+<entry id="cosp_rttov_instrument_namelists" type="char*256(50)"  category="cosp"
+       group="cospsimulator_nl" valid_values="" >
+List of RTTOV instrument namelist files to read when running RTTOV in COSP.
+File paths are read relative to the case run directory 
+(e.g. /glade/derecho/scratch/$USER/$CASENAME/run/) if an absolute path is not provided (recommended). Each namelist file
+contains information specifying the simulated instrument, channels, and
+outputs. Templates and instructions can be found in src/physics/cosp2/COSP-RTTOV_examples/.
+Default: none
+</entry>
+
+<!-- Swathing input control parameters. -->
+<entry id="cosp_N_SWATHS_ISCCP" type="integer*10"  category="cosp"
+       group="cospsimulator_nl" valid_values="" >
+Number of satellite sampling swaths used to mask COSP ISCCP data.
+Default: none
+</entry>
+
+<entry id="cosp_N_SWATHS_MISR" type="integer*10"  category="cosp"
+       group="cospsimulator_nl" valid_values="" >
+Number of satellite sampling swaths used to mask COSP MISR data.
+Default: none
+</entry>
+
+<entry id="cosp_N_SWATHS_MODIS" type="integer*10"  category="cosp"
+       group="cospsimulator_nl" valid_values="" >
+Number of satellite sampling swaths used to mask COSP MODIS data.
+Default: none
+</entry>
+
+<entry id="cosp_N_SWATHS_CSCAL" type="integer*10"  category="cosp"
+       group="cospsimulator_nl" valid_values="" >
+Number of satellite sampling swaths used to mask COSP CloudSat-CALIPSO data.
+Default: none
+</entry>
+
+<entry id="cosp_N_SWATHS_PARASOL" type="integer*10"  category="cosp"
+       group="cospsimulator_nl" valid_values="" >
+Number of satellite sampling swaths used to mask COSP PARASOL data.
+Default: none
+</entry>
+
+<entry id="cosp_N_SWATHS_ATLID" type="integer*10"  category="cosp"
+       group="cospsimulator_nl" valid_values="" >
+Number of satellite sampling swaths used to mask COSP ATLID data.
+Default: none
+</entry>
+
+<entry id="cosp_SWATH_LOCALTIMES_ISCCP" type="real*10"  category="cosp"
+       group="cospsimulator_nl" valid_values="" >
+Swath localtimes (hours) for masking COSP ISCCP data. The sampling 
+"local time" refers to a linear shift from UTC as a function of a 
+gridcell’s longitude (t_local = t_UTC − longitude * 24/360).
+Default: none
+</entry>
+
+<entry id="cosp_SWATH_LOCALTIMES_MISR" type="real*10"  category="cosp"
+       group="cospsimulator_nl" valid_values="" >
+Swath localtimes (hours) for masking COSP MISR data. The sampling 
+"local time" refers to a linear shift from UTC as a function of a 
+gridcell’s longitude (t_local = t_UTC − longitude * 24/360).
+Default: none
+</entry>
+
+<entry id="cosp_SWATH_LOCALTIMES_MODIS" type="real*10"  category="cosp"
+       group="cospsimulator_nl" valid_values="" >
+Swath localtimes (hours) for masking COSP MODIS data. The sampling 
+"local time" refers to a linear shift from UTC as a function of a 
+gridcell’s longitude (t_local = t_UTC − longitude * 24/360).
+Default: none
+</entry>
+
+<entry id="cosp_SWATH_LOCALTIMES_CSCAL" type="real*10"  category="cosp"
+       group="cospsimulator_nl" valid_values="" >
+Swath localtimes (hours) for masking COSP CloudSat-CALIPSO data. The  
+sampling "local time" refers to a linear shift from UTC as a function of a 
+gridcell’s longitude (t_local = t_UTC − longitude * 24/360).
+Default: none
+</entry>
+
+<entry id="cosp_SWATH_LOCALTIMES_PARASOL" type="real*10"  category="cosp"
+       group="cospsimulator_nl" valid_values="" >
+Swath localtimes (hours) for masking COSP PARASOL data. The sampling 
+"local time" refers to a linear shift from UTC as a function of a 
+gridcell’s longitude (t_local = t_UTC − longitude * 24/360).
+Default: none
+</entry>
+
+<entry id="cosp_SWATH_LOCALTIMES_ATLID" type="real*10"  category="cosp"
+       group="cospsimulator_nl" valid_values="" >
+Swath localtimes (hours) for masking COSP ATLID data. The sampling 
+"local time" refers to a linear shift from UTC as a function of a 
+gridcell’s longitude (t_local = t_UTC − longitude * 24/360).
+Default: none
+</entry>
+
+<entry id="cosp_SWATH_WIDTHS_ISCCP" type="real*10"  category="cosp"
+       group="cospsimulator_nl" valid_values="" >
+Swath widths (kilometers) for masking COSP ISCCP data. The "swath width"
+determines the spatial region around each local time that is simulated. 
+Supplying a swath width in units of distance rather than radians produces
+a larger sampling density at higher latitudes that is consistent with
+observations.
+Default: none
+</entry>
+
+<entry id="cosp_SWATH_WIDTHS_MISR" type="real*10"  category="cosp"
+       group="cospsimulator_nl" valid_values="" >
+Swath widths (kilometers) for masking COSP MISR data. The "swath width"
+determines the spatial region around each local time that is simulated. 
+Supplying a swath width in units of distance rather than radians produces
+a larger sampling density at higher latitudes that is consistent with
+observations.
+Default: none
+</entry>
+
+<entry id="cosp_SWATH_WIDTHS_MODIS" type="real*10"  category="cosp"
+       group="cospsimulator_nl" valid_values="" >
+Swath widths (kilometers) for masking COSP MODIS data. The "swath width"
+determines the spatial region around each local time that is simulated. 
+Supplying a swath width in units of distance rather than radians produces
+a larger sampling density at higher latitudes that is consistent with
+observations.
+Default: none
+</entry>
+
+<entry id="cosp_SWATH_WIDTHS_CSCAL" type="real*10"  category="cosp"
+       group="cospsimulator_nl" valid_values="" >
+Swath widths (kilometers) for masking COSP CSCAL data. The "swath width"
+determines the spatial region around each local time that is simulated. 
+Supplying a swath width in units of distance rather than radians produces
+a larger sampling density at higher latitudes that is consistent with
+observations.
+Default: none
+</entry>
+
+<entry id="cosp_SWATH_WIDTHS_PARASOL" type="real*10"  category="cosp"
+       group="cospsimulator_nl" valid_values="" >
+Swath widths (kilometers) for masking COSP PARASOL data. The "swath width"
+determines the spatial region around each local time that is simulated. 
+Supplying a swath width in units of distance rather than radians produces
+a larger sampling density at higher latitudes that is consistent with
+observations.
+Default: none
+</entry>
+
+<entry id="cosp_SWATH_WIDTHS_ATLID" type="real*10"  category="cosp"
+       group="cospsimulator_nl" valid_values="" >
+Swath widths (kilometers) for masking COSP ATLID data. The "swath width"
+determines the spatial region around each local time that is simulated. 
+Supplying a swath width in units of distance rather than radians produces
+a larger sampling density at higher latitudes that is consistent with
+observations.
+Default: none
+</entry>
+
+<!-- COSP output parameters -->
+
+<entry id="cosp_histfile_num" type="integer"  category="cosp"
+       group="cospsimulator_nl" valid_values="">
+This specifies the CAM history tape where COSP diagnostics will be written.
+Ignored/not used if any of the cosp_cfmip_* namelist variables are invoked.
+
+This default is set in cospsimulator_intr.F90
+Default: 1
+</entry>
+<entry id="cosp_histfile_aux" type="logical"  category="cosp"
+       group="cospsimulator_nl" valid_values="">
+If true, additional output is added to make it possible to
+run COSP off-line.
+
+This default is set in cospsimulator_intr.F90
+Default: FALSE
+</entry>
+<entry id="cosp_histfile_aux_num" type="integer"  category="cosp"
+       group="cospsimulator_nl" valid_values="">
+This specifies the CAM history tape where extra COSP diagnostics will be written.
+
+This default is set in cospsimulator_intr.F90
+Default: -1
+</entry>
+
+<entry id="cosp_nradsteps" type="integer"  category="cosp"
+       group="cospsimulator_nl" valid_values="">
+This specifies the frequency at which is COSP is called,
+every cosp_nradsteps radiation timestep.
+
+This default is set in cospsimulator_intr.F90
+Default: 1
+</entry>
+
+<entry id="cosp_lfrac_out" type="logical"  category="cosp"
+       group="cospsimulator_nl" valid_values="">
+Turns on sub-column output from COSP.
+If both the isccp/misr simulators and the lidar/radar simulators
+are run, lfrac_out is from the isccp/misr simulators columns.
+This default logical is set in cospsimulator_intr.F90
+Default: FALSE
+</entry>
+
+<!-- Cloud Macro/Micro-physics -->
+
+<entry id="cld_macmic_num_steps" type="integer" category="conv"
+       group="phys_ctl_nl" valid_values="" >
+Number of macrophysics/microphysics substeps.
+Default: 1
+</entry>
+
+<!-- Cldwat -->
+<entry id="rk_strat_icritc" type="real" category="conv"
+       group="rk_stratiform_nl" valid_values="" >
+Threshold for autoconversion of cold ice in RK microphysics scheme.
+Default: set by build-namelist
+</entry>
+
+<entry id="rk_strat_icritw" type="real" category="conv"
+       group="rk_stratiform_nl" valid_values="" >
+Threshold for autoconversion of warm ice in RK microphysics scheme.
+Default: set by build-namelist
+</entry>
+
+<entry id="rk_strat_conke" type="real" category="conv"
+       group="rk_stratiform_nl" valid_values="" >
+Tunable constant for evaporation of precip in RK microphysics scheme.
+Default: set by build-namelist
+</entry>
+
+<entry id="rk_strat_r3lcrit" type="real" category="conv"
+       group="rk_stratiform_nl" valid_values="" >
+Critical radius at which autoconversion become efficient in RK microphysics
+scheme.
+Default: set by build-namelist
+</entry>
+
+<entry id="rk_strat_polstrat_rhmin" type="real" category="conv"
+       group="rk_stratiform_nl" valid_values="" >
+Relative humidity threshold for stratospheric cloud water condensation in RK microphysics
+poleward of 50 degrees.
+Default: none
+</entry>
+
+<!-- macro_park -->
+<entry id="macro_park_do_cldice" type="logical" category="conv"
+       group="macro_park_nl" valid_values="" >
+Switch to control whether Park macrophysics should prognose
+cloud ice (cldice).
+Default: .true., except for carma=cirrus and carma=carma_dust
+</entry>
+
+<entry id="macro_park_do_cldliq" type="logical" category="conv"
+       group="macro_park_nl" valid_values="" >
+Switch to control whether Park macrophysics should prognose
+cloud liquid (cldliq).
+Default: .true.
+</entry>
+
+<entry id="macro_park_do_detrain" type="logical" category="conv"
+       group="macro_park_nl" valid_values="" >
+Switch to control whether Park macrophysics should perform
+detrainment into the stratiform cloud scheme.
+Default: .true., except for carma=cirrus and carma=carma_dust
+</entry>
+
+<!-- micro_mg -->
+
+<entry id="micro_mg_version" type="integer" category="microphys"
+       group="micro_mg_nl" valid_values="" >
+Version number for MG microphysics.  This value is set automatically based
+on settings in configure and passed to build-namelist
+Default: 1 for CAM5, 2 for CAM6 and 3 for CAM7
+</entry>
+
+<entry id="micro_mg_sub_version" type="integer" category="microphys"
+       group="micro_mg_nl" valid_values="" >
+Sub-version number for MG microphysics
+Default: 0
+</entry>
+
+<entry id="micro_mg_dcs" type="real" category="microphys"
+       group="micro_mg_nl" valid_values="" >
+Autoconversion size threshold
+Default: set by build-namelist
+</entry>
+
+<entry id="micro_mg_do_cldice" type="logical" category="microphys"
+       group="micro_mg_nl" valid_values="" >
+Switch to control whether MG microphysics should prognose
+cloud ice (cldice).
+Default: .true., except for carma=cirrus and carma=carma_dust
+</entry>
+
+<entry id="micro_mg_do_cldliq" type="logical" category="microphys"
+       group="micro_mg_nl" valid_values="" >
+Switch to control whether MG microphysics should prognose
+cloud liquid (cldliq).
+Default: .true.
+</entry>
+
+<entry id="micro_mg_do_graupel" type="logical" category="microphys"
+       group="micro_mg_nl" valid_values="" >
+Switch to control whether MG microphysics should prognose
+dense precipitating ice as graupel. mg3 only.
+Default: .true. for mg3
+</entry>
+
+<entry id="micro_mg_do_hail" type="logical" category="microphys"
+       group="micro_mg_nl" valid_values="" >
+Switch to control whether MG microphysics should prognose
+dense precipitating ice as hail. mg3 only.
+Default: .false.
+</entry>
+
+<entry id="micro_mg_num_steps" type="integer" category="microphys"
+       group="micro_mg_nl" valid_values="" >
+Number of substeps over MG microphysics.
+Default: 1
+</entry>
+
+<entry id="micro_mg_precip_frac_method" type="char*16" category="microphys"
+       group="micro_mg_nl" valid_values="max_overlap,in_cloud" >
+Type of precipitation fraction.
+Default: for CLUBB runs =&gt; in_cloud;
+             all others =&gt; max_overlap
+</entry>
+
+<entry id="micro_mg_berg_eff_factor" type="real" category="microphys"
+       group="micro_mg_nl" valid_values="" >
+Efficiency factor for berg
+Default: 1
+</entry>
+
+<entry id="micro_mg_accre_enhan_fact" type="real" category="microphys"
+       group="micro_mg_nl" valid_values="" >
+Unitless ratio to increase the accretion process in microphysics as a method of accounting for unrepresented subgridscale variability.
+Default: 1
+</entry>
+
+<entry id="micro_mg_autocon_fact" type="real" category="microphys"
+       group="micro_mg_nl" valid_values="" >
+Unitless ratio to directly scale the autoconversion process in microphysics as a method of accounting for unrepresented subgridscale variability.
+Default: 0.01
+</entry>
+
+<entry id="micro_mg_autocon_nd_exp" type="real" category="microphys"
+       group="micro_mg_nl" valid_values="" >
+Unitless exponent of cloud number condensation in the KK autoconversion parameterization equation. See Khairoutdinov and Kogan, 2002.
+Default: -1.1
+</entry>
+
+<entry id="micro_mg_autocon_lwp_exp" type="real" category="microphys"
+       group="micro_mg_nl" valid_values="" >
+Unitless exponent of liquid water path in the KK autoconversion parameterization equation. See Khairoutdinov and Kogan, 2002.
+Default: 2.47
+</entry>
+
+<entry id="micro_mg_homog_size" type="real" category="microphys"
+       group="micro_mg_nl" valid_values="" >
+Mean volume radius of droplets used in the process of homogeneously freezing below -40C in (m). Default value is currently the previously assumed 25 microns.
+Default: 25.e-6 m
+</entry>
+
+<entry id="micro_mg_vtrmi_factor" type="real" category="microphys"
+       group="micro_mg_nl" valid_values="" >
+Unitless scaling factor for ice fall speed to account for sub-grid scale ice crystal shape variability.
+Default: 1.0
+</entry>
+
+<entry id="micro_mg_vtrms_factor" type="real" category="microphys"
+       group="micro_mg_nl" valid_values="" >
+Unitless scaling factor for snow fall speed to account for sub-grid scale ice crystal shape variability.
+Default: 1.0
+</entry>
+
+<entry id="micro_mg_effi_factor" type="real" category="microphys"
+       group="micro_mg_nl" valid_values="" >
+Unitless scaling factor for ice effective radius as seen by radiation. This scaling factor adjusts for sub-grid scale ice crystal shape variability.
+Default: 1.0
+</entry>
+
+<entry id="micro_mg_iaccr_factor" type="real" category="microphys"
+       group="micro_mg_nl" valid_values="" >
+Ice accrete cloud droplet factor
+Default: 1
+</entry>
+
+<entry id="micro_mg_max_nicons" type="real" category="microphys"
+       group="micro_mg_nl" valid_values="" >
+Maximum allowed ice number concentration
+Default: 1.0e8
+</entry>
+
+<entry id="micro_do_sb_physics" type="logical" category="microphys"
+       group="micro_mg_nl" valid_values="" >
+Do Seifert and Behang (2001) autoconversion and accretion physics when set to true.
+Default: .false.
+</entry>
+
+<entry id="micro_mg_warm_rain" type="char*16" category="microphys"
+       group="micro_mg_nl" valid_values="kk2000,sb2001,tau,emulated" >
+Warm rain process
+sb2001 turns on alternative autoconversion and accretion scheme for liquid in microphysics (Seifert and Behang 2001)
+kk2000 uses original autoconversion and accretion scheme for liquid in microphysics
+tau replaces autoconversion and accretion with a faster emulator to generate machine learning training data
+emulated turns on use of machine learning for warm rain
+Default: set in namelist_defaults
+</entry>
+
+<entry id="stochastic_emulated_filename_quantile" type="char*256" input_pathname="abs" category="microphys"
+       group="stochastic_emulated_nl" >
+Neural net file for warm_rain machine learning
+</entry>
+
+<entry id="stochastic_emulated_filename_input_scale" type="char*256" input_pathname="abs" category="microphys"
+       group="stochastic_emulated_nl" >
+Neural net input scaling values file for warm_rain machine learning
+</entry>
+
+<entry id="stochastic_emulated_filename_output_scale" type="char*256" input_pathname="abs" category="microphys"
+       group="stochastic_emulated_nl" >
+Neural net output scaling values file for warm_rain machine learning
+</entry>
+
+<entry id="pumas_stochastic_tau_kernel_filename" type="char*256" input_pathname="abs" category="microphys"
+       group="pumas_stochastic_tau_nl" >
+Coefficients for the stochastic collection kernel used by the TAU stochastic collection code, invoked in PUMAS with micro_pumas_warm_rain = 'tau'
+</entry>
+
+<entry id="micro_do_massless_droplet_destroyer" type="logical" category="microphys"
+       group="micro_mg_nl" valid_values="" >
+Do destruction of massless droplets
+Default: .false.
+</entry>
+
+<entry id="microp_uniform" type="logical" category="microphys"
+       group="micro_mg_nl" valid_values="" >
+Switch to control whether MG microphysics performs a uniform calculation or not
+(useful for sub-columns)
+Default: .false. unless use_subcol_microp is true
+</entry>
+
+<entry id="micro_mg_adjust_cpt" type="logical" category="microphys"
+       group="micro_mg_nl" valid_values="" >
+Switch to control whether MG microphysics should adjust the temperature
+at the level containing the cold point tropopause by using the value
+obtain by extrapolating between levels.
+Default: set by build-namelist
+</entry>
+
+<entry id="micro_mg_nccons" type="logical" category="microphys"
+       group="micro_mg_nl" valid_values="" >
+Set .true. to hold cloud droplet number constant.
+Default: .false.
+</entry>
+
+<entry id="micro_mg_nicons" type="logical" category="microphys"
+       group="micro_mg_nl" valid_values="" >
+Set .true. to hold cloud ice number constant.
+Default: .false.
+</entry>
+
+<entry id="micro_mg_ngcons" type="logical" category="microphys"
+       group="micro_mg_nl" valid_values="" >
+Set .true. to hold cloud graupel number constant.
+Default: .false.
+</entry>
+
+<entry id="micro_mg_ncnst" type="real" category="microphys"
+       group="micro_mg_nl" valid_values="" >
+In-cloud droplet number concentration when micro_mg_nccons=.true.
+Default: 100.e6 m-3
+</entry>
+
+<entry id="micro_mg_ninst" type="real" category="microphys"
+       group="micro_mg_nl" valid_values="" >
+In-cloud ice number concentration when micro_mg_nicons=.true.
+Default: 0.1e6 m-3
+</entry>
+
+<entry id="micro_mg_ngnst" type="real" category="microphys"
+       group="micro_mg_nl" valid_values="" >
+In-cloud graupel number concentration when micro_mg_nicons=.true.
+Default: 0.0005e6 m-3
+</entry>
+
+<entry id="micro_mg_nrcons" type="logical" category="microphys"
+       group="micro_mg_nl" valid_values="" >
+Set .true. to hold cloud rain number constant.
+Default: .false.
+</entry>
+
+<entry id="micro_mg_nrnst" type="real" category="microphys"
+       group="micro_mg_nl" valid_values="" >
+In-cloud rain number concentration when micro_mg_nrcons=.true.
+Default: 0.2e6 m-3
+</entry>
+
+<entry id="micro_mg_nscons" type="logical" category="microphys"
+       group="micro_mg_nl" valid_values="" >
+Set .true. to hold cloud snow number constant.
+Default: .false.
+</entry>
+
+<entry id="micro_mg_nsnst" type="real" category="microphys"
+       group="micro_mg_nl" valid_values="" >
+In-cloud snow number concentration when micro_mg_nscons=.true.
+Default: 0.005e6 m-3
+</entry>
+
+<entry id="micro_mg_evap_sed_off" type="logical" category="microphys"
+       group="micro_mg_nl" valid_values="" >
+If .true., sedimenting condensate does not evaporate
+Default: .false.
+</entry>
+
+<entry id="micro_mg_icenuc_rh_off" type="logical" category="microphys"
+       group="micro_mg_nl" valid_values="" >
+If .true., remove RH threshold from ice nucelation calculation
+Default: .false.
+</entry>
+
+<entry id="micro_mg_icenuc_use_meyers" type="logical" category="microphys"
+       group="micro_mg_nl" valid_values="" >
+Hard code Meyers 1992 Temp dependent ice nucleation in microphysics
+Default: .false.
+</entry>
+
+<entry id="micro_mg_evap_scl_ifs" type="logical" category="microphys"
+       group="micro_mg_nl" valid_values="" >
+Apply 0.3 scaling factor to evaporation of precipitation as done in the
+IFS model (https://www.ecmwf.int/en/forecasts/documentation-and-support)
+Default: .false.
+</entry>
+
+<entry id="micro_mg_evap_rhthrsh_ifs" type="logical" category="microphys"
+       group="micro_mg_nl" valid_values="" >
+Do not evaporate precipitation until RH &lt; 90% as done in the
+IFS model (https://www.ecmwf.int/en/forecasts/documentation-and-support)
+Default: .false.
+</entry>
+
+<entry id="micro_mg_rainfreeze_ifs" type="logical" category="microphys"
+       group="micro_mg_nl" valid_values="" >
+Freeze rain at 0C as done in the
+IFS model (https://www.ecmwf.int/en/forecasts/documentation-and-support)
+Default: .false.
+</entry>
+
+<entry id="micro_mg_ifs_sed" type="logical" category="microphys"
+       group="micro_mg_nl" valid_values="" >
+If .false., use the default sedimentation fall speed calculation from MG2 for all species. If .true., use constant sedimentation fall speeds for snow and ice, and no sedimentation of liquid, to be consistant with how species descend in the IFS model (https://www.ecmwf.int/en/forecasts/documentation-and-support)
+Default: .false.
+</entry>
+
+<entry id="micro_mg_precip_fall_corr" type="logical" category="microphys"
+       group="micro_mg_nl" valid_values="" >
+If .true., ensure non-zero precipitation fallspeed (rain,snow and graupel) if precipitation exists above in column (from M2005 in WRFv3.3)
+Default: .false.
+</entry>
+
+<entry id="micro_mg_implicit_fall" type="logical" category="microphys"
+       group="micro_mg_nl" valid_values="" >
+If .true., use implicit fall speed (sedimentation) routine for all hydrometeors. Improves numerical stability of precipitation
+Default: .true.
+</entry>
+
+<entry id="micro_mg_accre_sees_auto" type="logical" category="microphys"
+       group="micro_mg_nl" valid_values="" >
+If true, then the autoconverted liquid is added to rain and removed from cloud before accretion is estimated.
+Default: .true.
+</entry>
+
+
+<!-- Aerosol microphysics -->
+<entry id="microp_aero_bulk_scale" type="real" category="microphys"
+       group="microp_aero_nl" valid_values="" >
+prescribed aerosol bulk sulfur scale factor
+Default: 2
+</entry>
+
+<entry id="microp_aero_npccn_scale" type="real" category="microphys"
+       group="microp_aero_nl" valid_values="" >
+Unitless scaling factor for the activated number concentration of cloud condensation nuclei.
+Default: 1.0
+</entry>
+
+<entry id="microp_aero_wsub_scale" type="real" category="microphys"
+       group="microp_aero_nl" valid_values="" >
+Unitless scaling factor for the liquid droplet subgrid scale vertical velocity during aerosol activation.
+Default: set by build-namelist
+</entry>
+
+<entry id="microp_aero_wsubi_scale" type="real" category="microphys"
+       group="microp_aero_nl" valid_values="" >
+Unitless scaling factor for ice droplet subgrid scale vertical velocity during aerosol activation.
+Default: 1.0
+</entry>
+
+<entry id="microp_aero_wsub_min" type="real" category="microphys"
+       group="microp_aero_nl" valid_values="" >
+Minimum subgrid vertical velocity (before scale factor) for liquid droplets during aerosol activation with units of (m s-1).
+Default: set by build-namelist
+</entry>
+
+<entry id="microp_aero_wsub_min_asf" type="real" category="microphys"
+       group="microp_aero_nl" valid_values="" >
+Minimum subgrid vertical velocity (after scale factor) for liquid droplets during aerosol activation with units of (m s-1).
+Default: set by build-namelist
+</entry>
+
+<entry id="microp_aero_wsubi_min" type="real" category="microphys"
+       group="microp_aero_nl" valid_values="" >
+Minimum subgrid vertical velocity for ice droplets during aerosol activation with units of (m s-1).
+Default: 0.001 m s-1
+</entry>
+
+<entry id="use_hetfrz_classnuc" type="logical" category="microphys"
+       group="phys_ctl_nl" valid_values="" >
+Switch to turn on heterogeneous freezing code.
+Default: .false.
+</entry>
+
+<entry id="hist_hetfrz_classnuc" type="logical" category="microphys"
+       group="hetfrz_classnuc_nl" valid_values="" >
+Add diagnostic output for heterogeneous freezing code.
+Default: .false.
+</entry>
+
+<entry id="hetfrz_bc_scalfac" type="real" category="microphys"
+       group="hetfrz_classnuc_nl" valid_values="" >
+Heterogeneous freezing scaling factor for black carbon aerosols.
+Default: 0.01
+</entry>
+
+<entry id="hetfrz_dust_scalfac" type="real" category="microphys"
+       group="hetfrz_classnuc_nl" valid_values="" >
+Heterogeneous freezing scaling factor for dust aerosols.
+Default: 0.05
+</entry>
+
+<entry id="use_preexisting_ice" type="logical" category="microphys"
+       group="nucleate_ice_nl" valid_values="" >
+Switch to turn on treatment of pre-existing ice in the ice nucleation code.
+Default: .false., except .true. for CAM6 and CAM7
+</entry>
+
+<entry id="hist_preexisting_ice" type="logical" category="microphys"
+       group="nucleate_ice_nl" valid_values="" >
+Add diagnostics for pre-existing ice option in ice nucleation code to history output.
+Default: .false.
+</entry>
+
+<entry id="nucleate_ice_subgrid" type="real" category="microphys"
+       group="nucleate_ice_nl" valid_values="" >
+Subgrid scaling factor for relative humidity in ice nucleation code. If it has
+a value of -1, then indicates that the subgrid scaling factor will be
+calculated on the fly as 1 / qsatfac (i.e. the saturation scaling factor).
+Default: set by build-namelist
+</entry>
+
+<entry id="nucleate_ice_subgrid_strat" type="real" category="microphys"
+       group="nucleate_ice_nl" valid_values="" >
+Subgrid scaling factor for relative humidity in ice nucleation code in the
+stratosphere. If it has a value of -1, then indicates that the subgrid
+scaling factor will be calculated on the fly as 1 / qsatfac (i.e. the
+saturation scaling factor).
+Default: set by build-namelist
+</entry>
+
+<entry id="nucleate_ice_incloud" type="logical" category="microphys"
+       group="nucleate_ice_nl" valid_values="" >
+Switch to determine whether ice nucleation happens using the incloud (true) or
+the gridbox average (false) relative humidity.  When true, it is assumed that
+the incloud relative humidity for nucleation is 1.
+Default: .true., except .false. for CAM6 and CAM7
+</entry>
+
+<entry id="nucleate_ice_strat" type="real" category="microphys"
+       group="nucleate_ice_nl" valid_values="" >
+Fraction of Aitken mode sulfate particles assumed to nucleate ice in the polar
+stratospheric. Provides an increase in homogeneous freezing over the Liu&amp;Penner method.
+Temporary solution to adjust ice surface area density and dehydration in the
+polar stratosphere where there doesn't seem to be enough nucleation. A value of
+zero means Liu&amp;Penner is used.
+Default: 1.0
+</entry>
+
+<entry id="nucleate_ice_use_troplev" type="logical" category="microphys"
+       group="nucleate_ice_nl" valid_values="" >
+Indicates whether to use the tropopause level to determine where to adjust
+nucleation for the stratosphere (true) or whether to use a hard coded transition
+level from 100 to 125 hPa applied only in the polar regions (false).
+Default: .true.
+</entry>
+
+
+
+
+<!-- hkconv Moist Convection -->
+<entry id="hkconv_cmftau" type="real" category="conv"
+       group="hkconv_nl" valid_values="" >
+Characteristic adjustment time scale for Hack shallow scheme.
+Default: 1800.0
+</entry>
+
+<entry id="hkconv_c0" type="real" category="conv"
+       group="hkconv_nl" valid_values="" >
+Rain water autoconversion coefficient for Hack shallow scheme.
+Default: set by build-namelist
+</entry>
+
+<!-- uwshcu Moist Convection -->
+<entry id="uwshcu_rpen" type="real" category="conv"
+       group="uwshcu_nl" valid_values="">
+Penetrative entrainment efficiency in UW shallow scheme.
+Default: set by build-namelist
+</entry>
+
+<!-- Cloud fraction -->
+
+<entry id="cldfrc_freeze_dry" type="logical" category="cldfrc"
+       group="cldfrc_nl" valid_values="" >
+Switch for Vavrus "freeze dry" adjustment in cloud fraction.  Set to FALSE to
+turn the adjustment off.
+Default: .true.
+</entry>
+
+<entry id="cldfrc_ice" type="logical" category="cldfrc"
+       group="cldfrc_nl" valid_values="" >
+Switch for ice cloud fraction calculation.
+Default: .true. for CAM5, CAM6 and CAM7, otherwise .false.
+</entry>
+
+<entry id="cldfrc_rhminl" type="real" category="cldfrc"
+       group="cldfrc_nl" valid_values="" >
+Minimum rh for low stable clouds.
+Default: set by build-namelist
+</entry>
+
+<entry id="cldfrc_rhminl_adj_land" type="real" category="conv"
+       group="cldfrc_nl" valid_values="" >
+Adjustment to rhminl for land without snow cover.
+Default: 0.0 for CAM6 and CAM7;
+         all others =&gt; 0.10
+</entry>
+
+<entry id="cldfrc_rhminh" type="real" category="cldfrc"
+       group="cldfrc_nl" valid_values="" >
+Minimum rh for high stable clouds.
+Default: set by build-namelist
+</entry>
+
+<entry id="cldfrc_sh1" type="real" category="cldfrc"
+       group="cldfrc_nl" valid_values="" >
+parameter for shallow convection cloud fraction.
+Default: set by build-namelist
+</entry>
+
+<entry id="cldfrc_sh2" type="real" category="cldfrc"
+       group="cldfrc_nl" valid_values="" >
+parameter for shallow convection cloud fraction.
+Default: set by build-namelist
+</entry>
+
+<entry id="cldfrc_dp1" type="real" category="cldfrc"
+       group="cldfrc_nl" valid_values="" >
+parameter for deep convection cloud fraction.
+Default: set by build-namelist
+</entry>
+
+<entry id="cldfrc_dp2" type="real" category="cldfrc"
+       group="cldfrc_nl" valid_values="" >
+parameter for deep convection cloud fraction.
+Default: set by build-namelist
+</entry>
+
+<entry id="cldfrc_premit" type="real" category="cldfrc"
+       group="cldfrc_nl" valid_values="" >
+top pressure bound for mid level cloud.
+Default: set by build-namelist
+</entry>
+
+<entry id="cldfrc_premib" type="real" category="conv"
+       group="cldfrc_nl" valid_values="" >
+Bottom height (Pa) for mid-level liquid stratus fraction.
+Default: 700.e2 for CAM5, CAM6 and CAM7; all others=&gt; 750.e2
+</entry>
+
+<entry id="cldfrc_iceopt" type="integer" category="conv"
+       group="cldfrc_nl" valid_values="" >
+Scheme for ice cloud fraction: 1=wang &amp; sassen, 2=schiller (iciwc),
+3=wood &amp; field, 4=Wilson (based on smith), 5=modified slingo (ssat &amp; empty cloud)
+Default: set by build-namelist
+</entry>
+
+<entry id="cldfrc_icecrit" type="real" category="conv"
+       group="cldfrc_nl" valid_values="" >
+Critical RH for ice clouds (Wilson &amp; Ballard scheme).
+Default: set by build-namelist
+</entry>
+
+<entry id="cldfrc2m_rhmini" type="real" category="conv"
+       group="cldfrc2m_nl" valid_values="" >
+Minimum rh for ice cloud fraction &gt; 0.
+Default: set by build-namelist
+</entry>
+
+<entry id="cldfrc2m_rhmaxi" type="real" category="conv"
+       group="cldfrc2m_nl" valid_values="" >
+rhi at which ice cloud fraction = 1.
+Default: set by build-namelist
+</entry>
+
+<entry id="cldfrc2m_rhminis" type="real" category="conv"
+       group="cldfrc2m_nl" valid_values="" >
+Minimum rh for ice cloud fraction &gt; 0 in the stratosphere.
+Default: set by build-namelist
+</entry>
+
+<entry id="cldfrc2m_rhmaxis" type="real" category="conv"
+       group="cldfrc2m_nl" valid_values="" >
+rhi at which ice cloud fraction = 1 in the stratosphere.
+Default: set by build-namelist
+</entry>
+
+<entry id="cldfrc2m_qist_min" type="real" category="conv"
+       group="cldfrc2m_nl" valid_values="" >
+Minimum in-stratus IWC constraint greater than 0 [ kg/kg ]
+Default: set by build-namelist
+</entry>
+
+<entry id="cldfrc2m_qist_max" type="real" category="conv"
+       group="cldfrc2m_nl" valid_values="" >
+Maximum in-stratus IWC constraint [ kg/kg ]
+Default: set by build-namelist
+</entry>
+
+<entry id="cldfrc2m_do_subgrid_growth" type="logical" category="conv"
+       group="cldfrc2m_nl" valid_values="" >
+Use cloud fraction to determine whether to do growth of ice clouds below
+RHice of 1 down to RHice = rhmini.
+Default: .true. for CAM6 and CAM7; all others =&gt; .false.
+</entry>
+
+<entry id="cldfrc2m_do_avg_aist_algs" type="logical" category="conv"
+       group="cldfrc2m_nl" valid_values="" >
+For small ice cloud concentrations, take the geometric mean of the iceopt=4 and iceopt=5 area fractions
+Default: .true. for CAM_DEV; all others .false.
+</entry>
+
+<entry id="zmconv_momcu" type="real" category="conv"
+       group="zmconv_nl" valid_values="" >
+Convective momentum transport parameter (upward)
+Default: set by build-namelist
+</entry>
+
+<entry id="zmconv_momcd" type="real" category="conv"
+       group="zmconv_nl" valid_values="" >
+Convective momentum transport parameter (downward)
+Default: set by build-namelist
+</entry>
+
+<!-- condensate to rain autoconversion coefficient -->
+<entry id="zmconv_c0_lnd" type="real" category="conv"
+       group="zmconv_nl" valid_values="" >
+Autoconversion coefficient over land in ZM deep convection scheme.
+Default: set by build-namelist
+</entry>
+
+<entry id="zmconv_c0_ocn" type="real" category="conv"
+       group="zmconv_nl" valid_values="" >
+Autoconversion coefficient over ocean in ZM deep convection scheme.
+Default: set by build-namelist
+</entry>
+
+<entry id="zmconv_ke_lnd" type="real" category="conv"
+       group="zmconv_nl" valid_values="" >
+Tunable evaporation efficiency for land in ZM deep convection scheme.
+Default: set by build-namelist
+</entry>
+
+<entry id="zmconv_ke" type="real" category="conv"
+       group="zmconv_nl" valid_values="" >
+Tunable evaporation efficiency in ZM deep convection scheme.
+Default: set by build-namelist
+</entry>
+
+<entry id="zmconv_num_cin" type="integer" category="conv"
+       group="zmconv_nl" valid_values="" >
+The number of negative buoyancy regions that are allowed before the convection top and CAPE calculations are completed.
+Default: =&gt; 1 for CAM6 and CAM7;
+         =&gt; 5 for all other
+</entry>
+
+<entry id="zmconv_dmpdz" type="real" category="conv"
+       group="zmconv_nl" valid_values="" >
+Tunable entrainment rate in ZM deep convection scheme in units of (m-1).
+Default: -1.0e-3 m-1
+</entry>
+
+<entry id="zmconv_tiedtke_add" type="real" category="conv"
+       group="zmconv_nl" valid_values="" >
+Tunable parcel temperature perturbation in ZM deep convection scheme in units of (K).
+Default: 0.5K perturbation
+</entry>
+
+<entry id="zmconv_capelmt" type="real" category="conv"
+       group="zmconv_nl" valid_values="" >
+Tunable triggering threshold for convection in ZM deep scheme in units of (J kg-1).
+Default: 70.0 J kg-1
+</entry>
+
+<entry id="zmconv_parcel_pbl" type="logical" category="conv"
+       group="zmconv_nl" valid_values="" >
+Turn on ZM deep convection initial parcel properties as a function of a well mixed boundary layer
+Default: .false.
+</entry>
+
+<entry id="zmconv_parcel_hscale" type="real" category="conv"
+       group="zmconv_nl" valid_values="" >
+ The fraction of the boundary layer (PBL) depth, over which to mix the initial ZM convective parcel properties (fraction).
+Default: 0.5
+</entry>
+
+<entry id="zmconv_tau" type="real" category="conv"
+       group="zmconv_nl" valid_values="" >
+Convective adjustment timescale in units of (s)
+Default: 3600.0 s
+</entry>
+
+<!-- Cloud sedimentation -->
+
+<entry id="cldsed_ice_stokes_fac" type="real" category="cldsed"
+       group="cldsed_nl" valid_values="" >
+Factor applied to the ice fall velocity computed from
+Stokes terminal velocity.
+Default: set by build-namelist
+</entry>
+
+<!-- Water Vapor Saturation -->
+
+<entry id="wv_sat_scheme" type="char*16" category="wv_sat"
+       group="wv_sat_nl" valid_values="GoffGratch,MurphyKoop" >
+Type of water vapor saturation vapor pressure scheme employed.  'GoffGratch' for
+Goff and Gratch (1946); 'MurphyKoop' for Murphy &amp; Koop (2005)
+Default: GoffGratch; except MurphyKoop for carma=cirrus or carma=cirrus_dust
+</entry>
+
+<!-- Physics sub-column switches -->
+
+<entry id="use_subcol_microp" type="logical" category="conv"
+       group="phys_ctl_nl" valid_values="" >
+Control use of sub-columns within macro/micro physics;
+'false' for no subcolumns.
+Default: 'false'
+</entry>
+
+<entry id="subcol_scheme" type="char*16" category="conv"
+       group="subcol_nl" valid_values="SILHS,CloudObj,tstcp,vamp,off" >
+Type of sub-column generator scheme employed.
+   'SIHLS'    Sub-columns generated with Latin Hypercube sampling of the CLUBB PDF;
+   'CloudObj' Create sub-columns where most water is assigned to cloud sub-columns;
+   'tstcp'    testing;
+   'vamp'     Variation Across Microphysics Profiles simple deterministic scheme;
+   'off'      None
+Default: 'off'
+</entry>
+
+<entry id="subcol_tstcp_noAvg" type="logical" category="conv"
+       group="subcol_tstcp_nl" valid_values="" >
+Turns off averaging and assigns first subcolumn back to grid.  Needed for BFB comparisons
+'true' for no averaging.
+Default: '.false.'
+</entry>
+
+<entry id="subcol_tstcp_filter" type="logical" category="conv"
+       group="subcol_tstcp_nl" valid_values="" >
+Turns on/off filtering during averaing in tstcp
+'true' to use filtering.
+Default: '.false.'
+</entry>
+
+<entry id="subcol_tstcp_weight" type="logical" category="conv"
+       group="subcol_tstcp_nl" valid_values="" >
+Turns on/off use of weights during averaging in tstcp
+'true' to use weights.
+Default: '.false.'
+</entry>
+
+<entry id="subcol_tstcp_perturb" type="logical" category="conv"
+       group="subcol_tstcp_nl" valid_values="" >
+Perturbs the temperatures in state after copying for testing purposes
+'true' to perturb temperatures.
+Default: '.false.'
+</entry>
+
+<entry id="subcol_tstcp_restart" type="logical" category="conv"
+       group="subcol_tstcp_nl" valid_values="" >
+Tests the restart capabilities of weights with a more adequate test
+'true' to set the weights to a slightly more complicated pattern for restart testing
+Default: '.false.'
+</entry>
+
+<entry id="subcol_silhs_weight" type="logical" category="conv"
+       group="subcol_silhs_nl" valid_values="" >
+Turns on/off use of weights during averaging in tstcp
+'true' to use weights.
+Default: '.true.'
+</entry>
+
+<entry id="subcol_silhs_numsubcol" type="integer" category="conv"
+       group="subcol_silhs_nl" valid_values="" >
+Number of subcolumns/samples to use in this simulation. Must be less than psubcols.
+Default: 4
+</entry>
+
+<entry id="subcol_silhs_corr_file_path" type="char*256" category="conv"
+       group="subcol_silhs_nl" valid_values="" >
+Location of SILHS correlation input files - usually the path to the SILHS code directory.
+</entry>
+
+<entry id="subcol_silhs_corr_file_name" type="char*16" category="conv"
+       group="subcol_silhs_nl" valid_values="" >
+Correlation input file run name (as in 'rico' or 'arm97' or 'default')
+</entry>
+
+<entry id="subcol_silhs_meanice" type="logical" category="conv"
+       group="subcol_silhs_nl" valid_values="" >
+A special configuration that sends mean ice mixing ratios and number concentrations to microphysics but allows cloud liquid water and number concentrations to vary. Should reduce the impact of negative condensate. Default False.
+</entry>
+
+<entry id="subcol_silhs_q_to_micro" type="logical" category="conv"
+       group="subcol_silhs_nl" valid_values="" >
+Whether to send SILHS liq and ice mixing ratios to microphysics (if false, uses grid mean values).
+</entry>
+
+<entry id="subcol_silhs_n_to_micro" type="logical" category="conv"
+       group="subcol_silhs_nl" valid_values="" >
+Whether to send SILHS liq and ice num concentrations to microphysics (if false, uses grid mean values).
+</entry>
+
+<entry id="subcol_silhs_constrainmn" type="logical" category="conv"
+       group="subcol_silhs_nl" valid_values="" >
+Whether to constrain samples of ice, liquid and vapor to the same subcolumn mean as the grid mean value.
+</entry>
+
+<entry id="subcol_silhs_use_clear_col" type="logical" category="conv"
+       group="subcol_silhs_nl" valid_values="" >
+Whether to use a clear-air only column to ensure consistant subcolumn cloud fraction
+</entry>
+
+<entry id="subcol_silhs_var_covar_src" type="logical" category="conv"
+       group="subcol_silhs_nl" valid_values="" >
+Flag to use SILHS to calculate the effect of microphysics on CLUBB's predictive
+(co)variances rtp2 (total water variance), thlp2 (theta-l variance), and rtpthlp
+(covariance of total water and theta-l), as well as on CLUBB's predictive fluxes
+wprtp (total water flux) and wpthlp (flux of theta-l).
+</entry>
+
+<entry id="subcol_silhs_ncnp2_on_ncnm2" type="real" category="conv"
+       group="subcol_silhs_nl" valid_values="" >
+Prescribed in-cloud ratio [N_cn'^2] / [N_cn]^2 [no units]
+</entry>
+
+<entry id="subcol_silhs_hmp2_ip_on_hmm2_ip_slope%rr" type="real" category="conv"
+       group="subcol_silhs_nl" valid_values="" >
+Slope of linear equation that calculates precribed in-cloud rain water mixing ratio [r_r'^2] / [r_r]^2   [1/m]
+</entry>
+
+<entry id="subcol_silhs_hmp2_ip_on_hmm2_ip_slope%Nr" type="real" category="conv"
+       group="subcol_silhs_nl" valid_values="" >
+Slope of linear equation that calculates precribed in-cloud rain drop concentration ratio [N_r'^2] / [N_r]^2   [1/m]
+</entry>
+
+<entry id="subcol_silhs_hmp2_ip_on_hmm2_ip_slope%rs" type="real" category="conv"
+       group="subcol_silhs_nl" valid_values="" >
+Slope of linear equation that calculates precribed in-cloud snow mixing ratio [r_s'^2] / [r_s]^2   [1/m]
+</entry>
+
+<entry id="subcol_silhs_hmp2_ip_on_hmm2_ip_slope%Ns" type="real" category="conv"
+       group="subcol_silhs_nl" valid_values="" >
+Slope of linear equation that calculates precribed in-cloud snow concentration ratio [N_s'^2] / [N_s]^2   [1/m]
+</entry>
+
+<entry id="subcol_silhs_hmp2_ip_on_hmm2_ip_slope%ri" type="real" category="conv"
+       group="subcol_silhs_nl" valid_values="" >
+Slope of linear equation that calculates precribed in-cloud ice mixing ratio [r_i'^2] / [r_i]^2   [1/m]
+</entry>
+
+<entry id="subcol_silhs_hmp2_ip_on_hmm2_ip_slope%Ni" type="real" category="conv"
+       group="subcol_silhs_nl" valid_values="" >
+Slope of linear equation that calculates precribed in-cloud ice concentration ratio [N_i'^2] / [N_i]^2   [1/m]
+</entry>
+
+<entry id="subcol_silhs_hmp2_ip_on_hmm2_ip_intrcpt%rr" type="real" category="conv"
+       group="subcol_silhs_nl" valid_values="" >
+Intercept of linear equation that calculates precribed in-cloud rain water mixing ratio [r_r'^2] / [r_r]^2   [1/m]
+</entry>
+
+<entry id="subcol_silhs_hmp2_ip_on_hmm2_ip_intrcpt%Nr" type="real" category="conv"
+       group="subcol_silhs_nl" valid_values="" >
+Intercept of linear equation that calculates precribed in-cloud rain drop concentration ratio [N_r'^2] / [N_r]^2   [-]
+</entry>
+
+<entry id="subcol_silhs_hmp2_ip_on_hmm2_ip_intrcpt%rs" type="real" category="conv"
+       group="subcol_silhs_nl" valid_values="" >
+Intercept of linear equation that calculates precribed in-cloud snow mixing ratio [r_s'^2] / [r_s]^2   [-]
+</entry>
+
+<entry id="subcol_silhs_hmp2_ip_on_hmm2_ip_intrcpt%Ns" type="real" category="conv"
+       group="subcol_silhs_nl" valid_values="" >
+Intercept of linear equation that calculates precribed in-cloud snow concentration ratio [N_s'^2] / [N_s]^2   [-]
+</entry>
+
+<entry id="subcol_silhs_hmp2_ip_on_hmm2_ip_intrcpt%ri" type="real" category="conv"
+       group="subcol_silhs_nl" valid_values="" >
+Intercept of linear equation that calculates precribed in-cloud ice mixing ratio [r_i'^2] / [r_i]^2   [-]
+</entry>
+
+<entry id="subcol_silhs_hmp2_ip_on_hmm2_ip_intrcpt%Ni" type="real" category="conv"
+       group="subcol_silhs_nl" valid_values="" >
+Intercept of linear equation that calculates precribed in-cloud ice concentration ratio [N_i'^2] / [N_i]^2   [-]
+</entry>
+
+<entry id="subcol_silhs_l_lh_importance_sampling" type="logical" category="conv"
+       group="silhs_config_flags_nl" valid_values="" >
+Enables importance sampling for SILHS subcolumns
+</entry>
+
+<entry id="subcol_silhs_l_Lscale_vert_avg" type="logical" category="conv"
+       group="silhs_config_flags_nl" valid_values="" >
+Enables calculation of Lscale_vert_avg, used to generate SILHS samples.
+</entry>
+
+<entry id="subcol_silhs_l_lh_straight_mc" type="logical" category="conv"
+       group="silhs_config_flags_nl" valid_values="" >
+Enables straight Monte Carlo sampling, this overrides l_lh_importance_sampling.
+</entry>
+
+<entry id="subcol_silhs_l_lh_clustered_sampling" type="logical" category="conv"
+       group="silhs_config_flags_nl" valid_values="" >
+Enables the "new" SILHS importance sampling scheme with prescribed probabilities. Requires l_lh_importance_sampling.
+</entry>
+
+<entry id="subcol_silhs_l_rcm_in_cloud_k_lh_start" type="logical" category="conv"
+       group="silhs_config_flags_nl" valid_values="" >
+Determine starting SILHS first sampling level (k_lh_start) based on maximum within-cloud rcm. If false, and if l_random_k_lh_start is also false, then the SILHS first sampling level is the column maximum of liquid cloud water.
+</entry>
+
+<entry id="subcol_silhs_l_random_k_lh_start" type="logical" category="conv"
+       group="silhs_config_flags_nl" valid_values="" >
+Determine starting SILHS first sampling level (k_lh_start) based on random choice. Overrides l_rcm_in_cloud_k_lh_start if true.
+</entry>
+
+<entry id="subcol_silhs_l_max_overlap_in_cloud" type="logical" category="conv"
+       group="silhs_config_flags_nl" valid_values="" >
+Assumption of maximum vertical overlap when grid-box rcm exceeds cloud threshold.
+</entry>
+
+<entry id="subcol_silhs_l_lh_instant_var_covar_src" type="logical" category="conv"
+       group="silhs_config_flags_nl" valid_values="" >
+Produces "instantaneous" variance-covariance microphysical source terms, ignoring discretization effects.
+</entry>
+
+<entry id="subcol_silhs_l_lh_limit_weights" type="logical" category="conv"
+       group="silhs_config_flags_nl" valid_values="" >
+Limit SILHS sample point weights for stability.
+</entry>
+
+<entry id="subcol_silhs_l_lh_var_frac" type="logical" category="conv"
+       group="silhs_config_flags_nl" valid_values="" >
+Prescribe variance fractions.
+</entry>
+
+<entry id="subcol_silhs_l_lh_normalize_weights" type="logical" category="conv"
+       group="silhs_config_flags_nl" valid_values="" >
+Scale sample point weights to sum to num_samples (the "ratio estimate").
+</entry>
+
+<!-- VAMP Sub-Column Generator -->
+
+<entry id="subcol_vamp_ctyp" type="integer" category="conv"
+       group="subcol_vamp_nl" valid_values="" >
+Type of condensate to assume in VAMP Generator
+1 Uniform Condensate
+2 Variable Condensate Uniform Number
+3 Variable Condensate Variable Number
+Default: 3
+</entry>
+
+<entry id="subcol_vamp_otyp" type="integer" category="conv"
+       group="subcol_vamp_nl" valid_values="" >
+Type of overlap to assume in VAMP Generator 1 Maximum
+Default: 1
+</entry>
+
+<entry id="subcol_vamp_nsubc" type="integer" category="conv"
+       group="subcol_vamp_nl" valid_values="" >
+Number of subcolumns in VAMP Generator
+Default: 10
+</entry>
+
+
+
+<!-- Moist Convection and Microphysics -->
+
+<entry id="deep_scheme" type="char*16" category="conv"
+       group="phys_ctl_nl" valid_values="ZM,off,CLUBB_SGS" >
+Type of deep convection scheme employed.  'ZM' for Zhang-McFarlane;
+'off' for none.
+Default: 'ZM' unless using 'pbl=none'
+</entry>
+
+<entry id="microp_scheme" type="char*16" category="conv"
+       group="phys_ctl_nl" valid_values="NONE,RK,MG" >
+Type of microphysics scheme employed.  'RK' for Rasch and Kristjansson
+(1998); 'MG' for Morrison and Gettelman (2008), Gettelman et al (2010)
+two moment scheme for CAM5 and CAM6
+Default: set by build-namelist (depends on value set in configure).
+</entry>
+
+<entry id="macrop_scheme" type="char*16" category="conv"
+       group="phys_ctl_nl" valid_values="none,park,RK,CLUBB_SGS" >
+Type of macrophysics scheme employed.  'park' for Park
+(1998); 'RK' for Rasch and Kristjansson (1998); 'CLUBB_SGS' clubb.
+Default: set by build-namelist
+</entry>
+
+<entry id="do_clubb_sgs" type="logical" category="conv"
+       group="phys_ctl_nl" valid_values="" >
+Flag for CLUBB_SGS.  N.B. this variable may not be set by the user.  It is
+set by build-namelist via information in the configure cache file to be
+consistent with how CAM was built.
+Default: set by build-namelist
+</entry>
+
+<entry id="shallow_scheme" type="char*16" category="conv"
+       group="phys_ctl_nl" valid_values="Hack,UW,CLUBB_SGS" >
+Type of shallow convection scheme employed.
+ 'Hack' for Hack shallow convection;
+ 'UW' for original McCaa UW pbl scheme, modified by Sungsu Park;
+ 'CLUBB_SGS' for CLUBB_SGS
+Default: set by build-namelist (depends on {{ hilight }}eddy_scheme{{ closehilight }}).
+</entry>
+
+<entry id="yog_scheme" type="char*16" category="conv"
+       group="phys_ctl_nl" valid_values="on,off" >
+Whether to run the Yuval-O'Gorman Scheme.
+'off' for no running; or 'on' to run.
+Default: 'off'.
+</entry>
+
+<entry id="do_beljaars" type="logical" category="pbl"
+       group="blj_nl" valid_values="" >
+Logical switch to turn on the beljaars scheme
+Default: set by build-namelist
+</entry>
+
+<entry id="do_tms" type="logical" category="pbl"
+       group="tms_nl" valid_values="" >
+Logical switch to turn on turbulent mountain stress calculation in
+vertical diffusion routine.
+Default: set by build-namelist
+</entry>
+
+<entry id="tms_orocnst" type="real" category="pbl"
+       group="tms_nl" valid_values="" >
+Turbulent mountain stress parameter used when turbulent mountain stress calculation
+is turned on. See {{ hilight }}do_tms{{ closehilight }}.
+Default: 1.0 for CAM, set by build-namelist for WACCM, T31
+</entry>
+
+<entry id="tms_z0fac" type="real" category="pbl"
+       group="tms_nl" valid_values="" >
+Factor determining z_0 from orographic standard deviation [ no unit ]
+Used when turbulent mountain stress calc is turned on. See {{ hilight }}do_tms{{ closehilight }}.
+Default: set by build-namelist for WACCM, T31
+</entry>
+
+<entry id="eddy_lbulk_max" type="real" category="pbl"
+       group="eddy_diff_nl" valid_values="" >
+Maximum master length scale designed to address issues in diag_TKE outside the
+boundary layer.
+In order not to disturb turbulence characteristics in the lower troposphere,
+this should be set at least larger than a few km. However, this does not
+significantly improve the values outside of the boundary layer. Smaller values
+make some improvement, but it is also noisy. Better results are seen using
+eddy_leng_max or kv_freetrop_scale.
+Default: 40.e3 (m)
+</entry>
+
+<entry id="eddy_leng_max" type="real" category="pbl"
+       group="eddy_diff_nl" valid_values="" >
+Maximum dissipation length scale designed to address issues with diag_TKE outside
+the boundary layer, where the default value generates large diffusivities. A value
+of 30 m is consistent with the length scales used in the HB scheme; however, this
+will also reduce value in the boundary layer.
+Default: 40.e3 (m)
+</entry>
+
+<entry id="eddy_max_bot_pressure" type="real" category="pbl"
+       group="eddy_diff_nl" valid_values="" >
+Bottom pressure level at which namelist values for eddy_leng_max and
+eddy_lbulk_max are applied. Default values are used at lower levels (i.e. the
+boundary layer).
+Default: 100.e3 (hPa)
+</entry>
+
+<entry id="eddy_moist_entrain_a2l" type="real" category="pbl"
+       group="eddy_diff_nl" valid_values="" >
+Moist entrainment enhancement parameter.
+Default: 30.D0
+</entry>
+
+<entry id="kv_top_pressure" type="real" category="pbl"
+       group="eddy_diff_nl" valid_values="" >
+Pressure (Pa) that defines the upper atmosphere for adjustment of
+eddy diffusivities from diag_TKE using kv_top_scale.
+Default: 0.
+</entry>
+
+<entry id="kv_top_scale" type="real" category="pbl"
+       group="eddy_diff_nl" valid_values="" >
+Scaling factor that is applied (multiplied) to the eddy diffusivities
+in the upper atmosphere (see kv_top_pressure).
+Default: 1.0
+</entry>
+
+<entry id="kv_freetrop_scale" type="real" category="pbl"
+       group="eddy_diff_nl" valid_values="" >
+Scaling factor that is applied (multiplied) to the eddy diffusivities
+in the free troposphere (boundary layer to kv_top_pressure)
+Default: 1.0
+</entry>
+
+<entry id="diff_cnsrv_mass_check" type="logical" category="pbl"
+       group="vert_diff_nl" valid_values="" >
+Perform mass conservation check on eddy diffusion operation.
+Default: FALSE
+</entry>
+
+<entry id="do_iss" type="logical" category="pbl"
+       group="vert_diff_nl" valid_values="" >
+Logical switch to turn on implicit turbulent surface stress calculation in
+diffusion solver routine.
+Default: set by build-namelist
+</entry>
+
+<entry id="diff_sponge_fac" type="real" category="pbl"
+       group="vert_diff_nl" valid_values="" >
+Factor to add sponge layer vertical diffusion of zonal and meridional components
+of the wind verctor (following the profile for del2 damping in the spectral-element dycore).
+
+Sponge layer interface coefficients for model tops above ptop=1E-3Pa (e.g. WACCM):
+
+        kvm_sponge(1) = 2.e5*diff_sponge_fac
+        kvm_sponge(2) = 2.e5*diff_sponge_fac
+        kvm_sponge(3) = 1.5e5*diff_sponge_fac
+        kvm_sponge(4) = 1.0e5*diff_sponge_fac
+        kvm_sponge(5) = 0.5e5*diff_sponge_fac
+        kvm_sponge(6) = 0.1e5*diff_sponge_fac
+
+Else:
+
+	kvm_sponge(1) = 2.e4*diff_sponge_fac
+        kvm_sponge(2) = 2.e4*diff_sponge_fac
+        kvm_sponge(3) = 0.4e*diff_sponge_fac
+        kvm_sponge(4) = 0.1e4*diff_sponge_fac
+
+Vertical diffusion in configurations with model tops below ~80km
+(e.g., LT and MT) is only recommended for spin-up with diff_sponge_fac=1.
+For higher tops diff_sponge_fac=1 can improve model stability in general.
+
+A too large diff_sponge_fac value can lead to "stove pipes" in the
+the zonally averaged zonal wind in the sponge layer.
+
+Default: 0.0
+</entry>
+
+<!-- CLUBB PBL Diff nl -->
+
+<entry id="clubb_cloudtop_cooling" type="logical"  category="pblrad"
+       group="clubbpbl_diff_nl" valid_values="" >
+Apply cloud top radiative cooling parameterization
+</entry>
+
+<entry id="clubb_rainevap_turb" type="logical"  category="pblrad"
+       group="clubbpbl_diff_nl" valid_values="" >
+Include effects of precip evaporation on turbulent moments
+</entry>
+
+<entry id="clubb_do_adv" type="logical" category="pblrad"
+       group="clubbpbl_diff_nl" valid_values="" >
+Switch for CLUBB_ADV parameter that turns on advection of CLUBB pdf moments by
+the dynamics core. Very experimental.
+</entry>
+
+<entry id="clubb_l_ascending_grid" type="logical" category="pblrad"
+       group="clubbpbl_diff_nl" valid_values="" >
+Causes advance_clubb_core to run in ascending mode, where the surface is at k=1, which is opposite
+of the descending cam grid. This is mainly a testing/debugging option - it requires an expensive 
+data flipping step and should not change answers significantly.
+</entry>
+
+<!-- Clubb timestep -->
+<entry id="clubb_timestep" type="real" category="pblrad"
+       group="clubbpbl_diff_nl" valid_values="" >
+CLUBB timestep, set by build-namelist, do not adjust.
+</entry>
+
+<entry id="clubb_rnevap_effic" type="real" category="pblrad"
+       group="clubbpbl_diff_nl" valid_values="" >
+Rain evaporation efficiency factor.
+</entry>
+
+<entry id="clubb_do_icesuper" type="logical"  category="pblrad"
+       group="clubbpbl_diff_nl" valid_values="" >
+Flag to perform a saturation adjustment for ice which will add ice mass if the
+air is supersaturated with respect to ice.
+</entry>
+
+<!-- CLUBB params namelist -->
+
+<entry id="clubb_beta" type="real" category="pblrad"
+       group="clubb_params_nl" valid_values="" >
+Plume widths for theta_l and rt
+</entry>
+
+<entry id="clubb_bv_efold" type="real" category="pblrad"
+       group="clubb_params_nl" valid_values="" >
+E-folding parameter for mixed Brunt Vaisala Frequency
+</entry>
+
+<entry id="clubb_c1" type="real" category="pblrad"
+       group="clubb_params_nl" valid_values="" >
+Limiting value of C1 when skewness of w (vertical velocity) is small in
+magnitude in the C1 skewness function.  Increasing the value of C1 increases the
+damping of CLUBB's wp2 (variance of vertical velocity).
+</entry>
+
+<entry id="clubb_c1b" type="real" category="pblrad"
+       group="clubb_params_nl" valid_values="" >
+Limiting value of C1 when skewness of w (vertical velocity) is large in
+magnitude in the C1 skewness function.  Increasing the value of C1 increases the
+damping of CLUBB's wp2 (variance of vertical velocity).
+</entry>
+
+<entry id="clubb_c11" type="real" category="pblrad"
+       group="clubb_params_nl" valid_values="" >
+Low Skewness in C11 Skew Function
+</entry>
+
+<entry id="clubb_c11b" type="real" category="pblrad"
+       group="clubb_params_nl" valid_values="" >
+High Skewness in C11 Skew Function
+</entry>
+
+<entry id="clubb_c14" type="real" category="pblrad"
+       group="clubb_params_nl" valid_values="" >
+Constant for u'^2 and v'^2 terms
+</entry>
+
+<entry id="clubb_C2rt" type="real" category="pblrad"
+       group="clubb_params_nl" valid_values="" >
+C2 coef. for the rtp2_dp1 term
+</entry>
+
+<entry id="clubb_C2rtthl" type="real" category="pblrad"
+       group="clubb_params_nl" valid_values="" >
+C2 coef. for the rtpthlp_dp1 term
+</entry>
+
+<entry id="clubb_C2thl" type="real" category="pblrad"
+       group="clubb_params_nl" valid_values="" >
+C2 coef. for the thlp2_dp1 term
+</entry>
+
+<entry id="clubb_C4" type="real" category="pblrad"
+       group="clubb_params_nl" valid_values="" >
+C4 coefficient in the wp2 return-to-isotropy term.  A higher value of C4
+tends wp2 more towards the value of subgrid TKE.
+</entry>
+
+<entry id="clubb_c6rt" type="real" category="pblrad"
+       group="clubb_params_nl" valid_values="" >
+CLUBB tunable parameter - Low Skewness in C6rt Skw. Function
+</entry>
+
+<entry id="clubb_c6rtb" type="real" category="pblrad"
+       group="clubb_params_nl" valid_values="" >
+CLUBB tunable parameter - High Skewness in C6rt Skw. Function
+</entry>
+
+<entry id="clubb_c6rtc" type="real" category="pblrad"
+       group="clubb_params_nl" valid_values="" >
+CLUBB tunable parameter - Degree of Slope of C6rt Skw. Function
+</entry>
+
+<entry id="clubb_c6thl" type="real" category="pblrad"
+       group="clubb_params_nl" valid_values="" >
+CLUBB tunable parameter - Low Skewness in C6thl Skw. Function
+</entry>
+
+<entry id="clubb_c6thlb" type="real" category="pblrad"
+       group="clubb_params_nl" valid_values="" >
+CLUBB tunable parameter - High Skewness in C6thl Skw. Function
+</entry>
+
+<entry id="clubb_c6thlc" type="real" category="pblrad"
+       group="clubb_params_nl" valid_values="" >
+CLUBB tunable parameter - Degree of Slope of C6thl Skw. Function
+</entry>
+
+<entry id="clubb_C7" type="real" category="pblrad"
+       group="clubb_params_nl" valid_values="" >
+Low Skewness in C7 Skw. Function
+</entry>
+
+<entry id="clubb_C7b" type="real" category="pblrad"
+       group="clubb_params_nl" valid_values="" >
+High Skewness in C7 Skw. Function
+</entry>
+
+<entry id="clubb_C8" type="real" category="pblrad"
+       group="clubb_params_nl" valid_values="" >
+Coef. #1 in C8 Skewness Equation
+</entry>
+
+<entry id="clubb_C8b" type="real" category="pblrad"
+       group="clubb_params_nl" valid_values="" >
+Coefficient in the C8 skewness equation.  Increasing the value of C8b increases
+the damping of CLUBB's wp3 when skewness of w (vertical velocity) is large in
+magnitude.
+</entry>
+
+<entry id="clubb_C_invrs_tau_bkgnd" type="real" category="pblrad"
+       group="clubb_params_nl" valid_values="" >
+Coefficient of inverse tau term contributed by background constant value (units: none)
+</entry>
+
+<entry id="clubb_C_invrs_tau_sfc" type="real" category="pblrad"
+       group="clubb_params_nl" valid_values="" >
+Coefficient of inverse tau term contributed by surface log law (units: none)
+</entry>
+
+<entry id="clubb_C_invrs_tau_shear" type="real" category="pblrad"
+       group="clubb_params_nl" valid_values="" >
+Coefficient of inverse tau term contributed by vertical wind shear (units: none)
+</entry>
+
+<entry id="clubb_C_invrs_tau_N2" type="real" category="pblrad"
+       group="clubb_params_nl" valid_values="" >
+Coefficient of inverse tau term contributed by Brunt Vaisala frequency (units: none)
+</entry>
+
+<entry id="clubb_C_invrs_tau_N2_clear_wp3" type="real" category="pblrad"
+      group="clubb_params_nl" valid_values="" >
+Coefficient of inverse tau term contributed by Brunt Vaisala frequency but for wp3 (units: none)
+</entry>
+
+<entry id="clubb_C_invrs_tau_N2_wp2" type="real" category="pblrad"
+       group="clubb_params_nl" valid_values="" >
+Coefficient of inverse tau term contributed by Brunt Vaisala frequency but for wp3_wp2 (units: none)
+</entry>
+
+<entry id="clubb_C_invrs_tau_N2_wpxp" type="real" category="pblrad"
+       group="clubb_params_nl" valid_values="" >
+Coefficient of inverse tau term contributed by Brunt Vaisala frequency but for xm_wpxp (units: none)
+</entry>
+
+<entry id="clubb_C_invrs_tau_N2_xp2" type="real" category="pblrad"
+       group="clubb_params_nl" valid_values="" >
+Coefficient of inverse tau term contributed by Brunt Vaisala frequency but for xp2_wpxp (units: none)
+</entry>
+
+<entry id="clubb_c_K1" type="real" category="pblrad"
+       group="clubb_params_nl" valid_values="" >
+Coefficient of Kh_zm (diffusivity on momentum grid levels) in the wp2 (variance
+of vertical velocity) predictive equation.
+</entry>
+
+<entry id="clubb_c_K10" type="real" category="pblrad"
+       group="clubb_params_nl" valid_values="" >
+Momentum coefficient of Kh_zm
+</entry>
+
+<entry id="clubb_c_K10h" type="real" category="pblrad"
+       group="clubb_params_nl" valid_values="" >
+Thermo of Kh_zm
+</entry>
+
+<entry id="clubb_c_K2" type="real" category="pblrad"
+       group="clubb_params_nl" valid_values="" >
+Coefficient of Kh_zm (diffusivity on momentum grid levels) in the scalar
+variance predictive equations (e.g. rtp2, variance of total water).
+</entry>
+
+<entry id="clubb_c_K8" type="real" category="pblrad"
+       group="clubb_params_nl" valid_values="" >
+Coefficient of Kh_zt (diffusivity on thermodynamic grid levels) in the wp3
+(third-order moment of vertical velocity) predictive equation.
+</entry>
+
+<entry id="clubb_c_K9" type="real" category="pblrad"
+       group="clubb_params_nl" valid_values="" >
+Coefficient of Kh_zm (diffusivity on momentum grid levels) in the up2 (variance
+of the west-east wind component) and vp2 (variance of the south-north wind
+component) predictive equations.
+</entry>
+
+<entry id="clubb_C_uu_shr" type="real" category="pblrad"
+       group="clubb_params_nl" valid_values="" >
+Coefficient in the wp2 (variance of vertical velocity) pressure terms opposing shear production.
+</entry>
+
+<entry id="clubb_C_uu_buoy" type="real" category="pblrad"
+       group="clubb_params_nl" valid_values="" >
+Coefficient in the wp2 (variance of vertical velocity) pressure terms opposing buoyancy production.
+</entry>
+
+<entry id="clubb_C_wp2_splat" type="real" category="pblrad"
+       group="clubb_params_nl" valid_values="" >
+Coefficient for gustiness near ground.
+</entry>
+
+<entry id="clubb_C_wp3_pr_turb" type="real" category="pblrad"
+       group="clubb_params_nl" valid_values="" >
+Coefficient in the pressure-turbulence term of CLUBB's wp3 predictive equation.
+</entry>
+
+<entry id="clubb_detice_rad" type="real" category="pblrad"
+       group="clubb_params_nl" valid_values="" >
+Radius of detrained ice drops as they are used in the CLUBB parameterization in units of (m).
+</entry>
+
+<entry id="clubb_detliq_rad" type="real" category="pblrad"
+       group="clubb_params_nl" valid_values="" >
+Radius of detrained liquid drops as they are used in the CLUBB parameterization in units of (m).
+</entry>
+
+<entry id="clubb_detphase_lowtemp" type="real" category="pblrad"
+       group="clubb_params_nl" valid_values="" >
+Temperature at which detrained water is classified as entirely ice (no liquid)
+in the CLUBB parameterization in units of (K).
+</entry>
+
+<entry id="clubb_do_energyfix" type="logical"  category="conv"
+       group="clubb_params_nl" valid_values="" >
+Apply adjustments to dry static energy so that CLUBB conserves
+energy.
+</entry>
+
+<entry id="clubb_do_liqsupersat" type="logical"  category="conv"
+       group="clubb_params_nl" valid_values="" >
+Apply liquid supersaturation adjustment code
+</entry>
+
+<entry id="clubb_gamma_coef" type="real" category="pblrad"
+       group="clubb_params_nl" valid_values="" >
+Low Skewness in gamma coefficient Skewness Function (units: none)
+Default changes depending on grid and physics options
+</entry>
+
+<entry id="clubb_gamma_coefb" type="real" category="pblrad"
+       group="clubb_params_nl" valid_values="" >
+Limiting value of gamma when skewness of w (vertical velocity) is large in
+magnitude in the gamma skewness function.  Increasing the value of gamma
+increases the standard deviation of w in both Gaussians in CLUBB's double
+Gaussian PDF, and also decreases the difference between the means of w from
+each Gaussian.
+</entry>
+
+<entry id="clubb_grid_adapt_in_time_method" type="integer" category="pblrad"
+       group="clubb_params_nl" valid_values="0,1" >
+Specifier for method to construct a grid density function to adapt grid to.
+Valid values: 0 (no grid adaptation), 1 (use Lscale and wp2)
+</entry>
+
+<entry id="clubb_fill_holes_type" type="integer" category="pblrad"
+       group="clubb_params_nl" valid_values="0,1,2,3,4,5,6" >
+Selects which algorithm the fill_holes routine uses to correct 
+below threshold values in field solutions.
+0: off - Skip the mass conservative hole filling step, rely on blunt clipping
+1: global - Fast but minimally local, most methods use this as a fallback step
+2: sliding_window - Expensive but highly local when possible, falls back to global fill if needed
+3: widening_windows - Slightly parallelizable, local when possible, falls back to global if needed
+4: smart_window - Uses hueristics to determine ranges to fill, fast and highly local when possible, falls back to global if needed
+5: smart_window_smooth - Same as smart_window, but with experimental smoothing features that slightly increases cost, NO GLOBAL FALLBACK
+6: parallel_fill - Highly local when possible, completely parallelizable but computationally wasteful, falls back to global if needed
+See CLUBB_core/model_flags.F90 or CLUBB_core/fill_holes.F90 for more detail.
+</entry>
+
+<entry id="clubb_grid_remap_method" type="integer" category="pblrad"
+       group="clubb_params_nl" valid_values="1" >
+Specifier for method to remap values from one grid to another.
+Valid values: 1 (ullrich remapping)
+</entry>
+
+<entry id="clubb_iiPDF_type" type="integer" category="pblrad"
+       group="clubb_params_nl" valid_values="1,2,3,4,5,6,7" >
+Selected option for the two-component normal (double Gaussian) PDF type to use for the w, rt,
+and theta-l (or w, chi, and eta) portion of CLUBB's multivariate, two-component PDF.
+iiPDF_ADG1 = 1 (ADG1 PDF), iiPDF_ADG2 = 2 (ADG2 PDF), iiPDF_3D_Luhar = 3 (3D Luhar PDF),
+iiPDF_new = 4 (new PDF), iiPDF_TSDADG = 5 (TSDADG PDF), iiPDF_LY93 = 6 (Lewellen and Yoh (1993)),
+iiPDF_new_hybrid = 7 (new hybrid PDF)
+</entry>
+
+<entry id="clubb_ipdf_call_placement" type="integer" category="pblrad"
+       group="clubb_params_nl" valid_values="1,2,3" >
+Option for the placement of the call to CLUBB's PDF closure. The options include: ipdf_pre_advance_fields (1) calls the PDF closure before advancing prognostic fields. ipdf_post_advance_fields (2) calls after advancing prognostic fields, and ipdf_pre_post_advance_fields (3) calls both before and after advancing prognostic fields.
+</entry>
+
+<entry id="clubb_lambda0_stability_coef" type="real" category="pblrad"
+       group="clubb_params_nl" valid_values="">
+Intensity of stability correction applied to C1 and C6
+</entry>
+
+<entry id="clubb_lmin_coef" type="real" category="pblrad"
+       group="clubb_params_nl" valid_values="">
+Coefficient used to determine the minimum allowable value of CLUBB's length
+scale (Lscale) in a grid-spacing dependent formula.  Increasing the value of
+clubb_lmin_coef increases the minimum allowable value for length scale.
+</entry>
+
+<entry id="clubb_l_add_dycore_grid" type="logical" category="pblrad"
+       group="clubb_params_nl" valid_values="" >
+Flag to remap values from the dycore grid.
+</entry>
+
+<entry id="clubb_l_brunt_vaisala_freq_moist" type="logical" category="pblrad"
+       group="clubb_params_nl" valid_values="" >
+Flag to uses an alternate equation to calculate the Brunt-Vaisala frequency.
+This equation calculates an in-cloud Brunt-Vaisala frequency.
+</entry>
+
+<entry id="clubb_l_C2_cloud_frac" type="logical" category="pblrad"
+       group="clubb_params_nl" valid_values="" >
+Flag to use cloud fraction to adjust the value of the
+turbulent dissipation coefficient, C2.
+</entry>
+
+<entry id="clubb_l_calc_thlp2_rad" type="logical" category="pblrad"
+       group="clubb_params_nl" valid_values="" >
+Include the contribution of radiation to thlp2
+</entry>
+
+<entry id="clubb_l_calc_w_corr" type="logical" category="pblrad"
+       group="clubb_params_nl" valid_values="" >
+Calculate the correlations between w and the hydrometeors
+</entry>
+
+<entry id="clubb_l_call_pdf_closure_twice" type="logical" category="pblrad"
+       group="clubb_params_nl" valid_values="" >
+Flag to call CLUBB's PDF closure at both thermodynamic and momentum vertical
+grid levels.  When this flag is turned off, CLUBB's PDF closure is only called
+on thermodynamic grid levels.
+</entry>
+
+<entry id="clubb_l_const_Nc_in_cloud" type="logical" category="pblrad"
+       group="clubb_params_nl" valid_values="" >
+Use a constant cloud droplet conc. within cloud
+</entry>
+
+<entry id="clubb_l_damp_wp2_using_em" type="logical" category="pblrad"
+       group="clubb_params_nl" valid_values="" >
+Flag to use a dissipation formula of -(2/3)*em/tau_zm, as in Bougeault (1981),
+in the wp2 (variance of vertical velocity) predictive equation.
+</entry>
+
+<entry id="clubb_l_damp_wp3_Skw_squared" type="logical" category="pblrad"
+       group="clubb_params_nl" valid_values="" >
+Flag to damp CLUBB's wp3 by the square of skewness of w (Skw).  When this flag
+is turned off, wp3 is damped according to Skw to the 4th power.  This damping
+equation also involves the coefficient clubb_C8b (see description of clubb_C8b).
+</entry>
+
+<entry id="clubb_l_diag_Lscale_from_tau" type="logical" category="pblrad"
+       group="clubb_params_nl" valid_values="" >
+Flag that, when it is enabled, first calculates dissipation time tau, and then
+calculates the mixing length scale as Lscale = tau * sqrt(tke).  When the flag
+is turned off, Lscale is calculated first, and then dissipation time-scale tau
+is calculated as tau = Lscale / sqrt(tke).
+</entry>
+
+<entry id="clubb_l_diagnose_correlations" type="logical" category="pblrad"
+       group="clubb_params_nl" valid_values="" >
+Diagnose correlations instead of using fixed ones
+</entry>
+
+<entry id="clubb_l_diffuse_rtm_and_thlm" type="logical" category="pblrad"
+       group="clubb_params_nl" valid_values="" >
+Implicit diffusion on moisture and temperature, implemented within CLUBB's
+matrix equations for wprtp/rtm and wpthlp/thlm.
+</entry>
+
+<entry id="clubb_l_do_expldiff_rtm_thlm" type="logical"  category="pblrad"
+       group="clubb_params_nl" valid_values="" >
+Explicit diffusion on temperature and moisture by CLUBB, in addition to CLUBB's
+normal prognostic equations for rtm and thlm.
+</entry>
+
+<entry id="clubb_l_e3sm_config" type="logical" category="pblrad"
+       group="clubb_params_nl" valid_values="" >
+Flag to run CLUBB with E3SM settings.
+</entry>
+
+<entry id="clubb_l_enable_relaxed_clipping" type="logical" category="pblrad"
+       group="clubb_params_nl" valid_values="" >
+Flag to relax clipping on wpxp in xm_wpxp_clipping_and_stats.
+</entry>
+
+<entry id="clubb_l_fix_w_chi_eta_correlations" type="logical" category="pblrad"
+       group="clubb_params_nl" valid_values="" >
+Use a fixed correlation for s and t Mellor(chi/eta)
+</entry>
+
+<entry id="clubb_l_godunov_upwind_wpxp_ta" type="logical" category="pblrad"
+       group="clubb_params_nl" valid_values="" >
+This flag determines whether we want to use an upwind differencing approximation
+rather than a centered differencing for turbulent advection terms. It affects
+wpxp only.
+</entry>
+
+<entry id="clubb_l_godunov_upwind_xpyp_ta" type="logical" category="pblrad"
+       group="clubb_params_nl" valid_values="" >
+This flag determines whether we want to use an upwind differencing approximation
+rather than a centered differencing for turbulent advection terms. It affects
+xpyp only.
+</entry>
+
+<entry id="clubb_l_intr_sfc_flux_smooth" type="logical" category="pblrad"
+       group="clubb_params_nl" valid_values="" >
+Flag to apply a locally calculated ustar to momentum surface fluxes in the
+clubb interface.
+</entry>
+
+<entry id="clubb_l_lmm_stepping" type="logical" category="pblrad"
+       group="clubb_params_nl" valid_values="" >
+Flag to apply Linear Multistep Method (LMM) stepping in CLUBB.
+</entry>
+
+<entry id="clubb_l_lscale_plume_centered" type="logical" category="pblrad"
+       group="clubb_params_nl" valid_values="" >
+Uses PDF to compute perturbed values for l_avg_Lscale code
+</entry>
+
+<entry id="clubb_l_min_wp2_from_corr_wx" type="logical" category="pblrad"
+       group="clubb_params_nl" valid_values="" >
+Flag to set an additional minimum threshold on wp2 (in addition to w_tol_sqd)
+based on maintaining a realizable correlation (value between -1 and 1) of w and
+another variable, x.  When this flag is enabled, the value of wp2 will be
+increased when the correlation is not realizable until the correlation becomes
+realizable.  When this flag is turned off, the magnitude of wpxp will be
+decreased when the correlation is not realizable until the correlation becomes
+realizable.  This correction is applied at the point in the code where wp2 is
+advanced one timestep.
+</entry>
+
+<entry id="clubb_l_min_xp2_from_corr_wx" type="logical" category="pblrad"
+       group="clubb_params_nl" valid_values="" >
+Flag to set an additional minimum threshold on xp2 (in addition to x_tol^2),
+where xp2 is a variance such as rtp2 (variance of total water) or thlp2
+(variance of liquid water potential temperature).  This threshold is based on
+maintaining a realizable correlation (value between -1 and 1) of w and x.  When
+this flag is enabled, the value of xp2 will be increased when the correlation is
+not realizable until the correlation becomes realizable.  When this flag is
+turned off, the magnitude of wpxp will be decreased when the correlation is not
+realizable until the correlation becomes realizable.  This correction is applied
+at the point in the code where xp2 is advanced one timestep.
+</entry>
+
+<entry id="clubb_l_mono_flux_lim_rtm" type="logical" category="pblrad"
+       group="clubb_params_nl" valid_values="" >
+Flag to turn on the clubb monotonic flux limiter for rtm.
+</entry>
+
+<entry id="clubb_l_mono_flux_lim_spikefix" type="logical" category="pblrad"
+       group="clubb_params_nl" valid_values="" >
+Flag to turn on the smoothing code options for the monotonic flux limiter.
+</entry>
+
+<entry id="clubb_l_mono_flux_lim_thlm" type="logical" category="pblrad"
+       group="clubb_params_nl" valid_values="" >
+Flag to turn on the clubb monotonic flux limiter for thlm.
+</entry>
+
+<entry id="clubb_l_mono_flux_lim_um" type="logical" category="pblrad"
+       group="clubb_params_nl" valid_values="" >
+Flag to turn on the clubb monotonic flux limiter for um (zonal momemtum).
+</entry>
+
+<entry id="clubb_l_mono_flux_lim_vm" type="logical" category="pblrad"
+       group="clubb_params_nl" valid_values="" >
+Flag to turn on the clubb monotonic flux limiter for vm (meridional momemtum).
+</entry>
+
+<entry id="clubb_l_partial_upwind_wp3" type="logical" category="pblrad"
+       group="clubb_params_nl" valid_values="" >
+Flag to use an "upwind" discretization rather than a centered discretization
+for the portion of the wp3 turbulent advection term for ADG1 that is linearized
+in terms of wp3(t+1). (Requires ADG1 PDF and l_standard_term_ta=true).
+</entry>
+
+<entry id="clubb_l_predict_upwp_vpwp" type="logical" category="pblrad"
+       group="clubb_params_nl" valid_values="" >
+Flag to predict horizontal momentum fluxes upwp and vpwp along with mean
+horizontal winds um and vm.  When this flag is turned off, upwp and vpwp are
+calculated by down-gradient diffusion.
+</entry>
+
+<entry id="clubb_l_ho_nontrad_coriolis" type="logical" category="pblrad"
+       group="clubb_params_nl" valid_values="" >
+Flag to implement the nontraditional Coriolis terms in the 
+prognostic equations of w'w', u'w', and u'u.
+</entry>
+
+<entry id="clubb_l_ho_trad_coriolis" type="logical" category="pblrad"
+       group="clubb_params_nl" valid_values="" >
+Flag to implement the traditional Coriolis terms in the
+prognostic equations of v'w' and u'w'.
+</entry>
+
+<entry id="clubb_l_prescribed_avg_deltaz" type="logical" category="pblrad"
+       group="clubb_params_nl" valid_values="" >
+used in adj_low_res_nu. If .true., avg_deltaz = deltaz
+</entry>
+
+<entry id="clubb_l_rcm_supersat_adj" type="logical" category="pblrad"
+       group="clubb_params_nl" valid_values="" >
+Flag to take any remaining supersaturation after CLUBB PDF call and add it to
+rcm (mean cloud water mixing ratio).  Supersaturation may be found after the
+PDF call due to issues when the PDF is called on both the thermodynamic grid
+levels and the momentum grid levels and variables are interpolated between the
+two grid level types.
+</entry>
+
+<entry id="clubb_l_rtm_nudge" type="logical" category="pblrad"
+       group="clubb_params_nl" valid_values="" >
+Turn on (true) and off (false) rtm nudging.
+</entry>
+
+<entry id="clubb_l_smooth_Heaviside_tau_wpxp" type="logical" category="pblrad"
+       group="clubb_params_nl" valid_values="" >
+Flag to use smooth Heaviside 'Peskin' in computation of invrs_tau.
+</entry>
+
+<entry id="clubb_l_standard_term_ta" type="logical" category="pblrad"
+       group="clubb_params_nl" valid_values="" >
+Use the standard discretization for the turbulent advection terms.  Setting to
+.false. means that a_1 and a_3 are pulled outside of the derivative in
+advance_wp2_wp3_module.F90 and in advance_xp2_xpyp_module.F90.
+</entry>
+
+<entry id="clubb_l_stability_correct_Kh_N2_zm" type="logical" category="pblrad"
+       group="clubb_params_nl" valid_values="" >
+Whether or not we want CLUBB to apply a stability correction Kh_N2_zm.
+</entry>
+
+<entry id="clubb_l_stability_correct_tau_zm" type="logical" category="pblrad"
+       group="clubb_params_nl" valid_values="" >
+Flag to use a stability corrected version of CLUBB's time scale (tau_zm).  This
+creates a time scale that provides stronger damping at altitudes where
+Brunt-Vaisala frequency is large.
+</entry>
+
+<entry id="clubb_l_tke_aniso" type="logical" category="pblrad"
+       group="clubb_params_nl" valid_values="" >
+Use anisotropic turbulent kinetic energy in the CLUBB higher order closure, i.e.
+calculate TKE = 1/2 (u'^2 + v'^2 + w'^2). This improves the simulation of complex
+turbulence but at a greater cost than running without.
+</entry>
+
+<entry id="clubb_l_trapezoidal_rule_zm" type="logical" category="pblrad"
+       group="clubb_params_nl" valid_values="" >
+Flag that uses the trapezoidal rule to adjust fields calculated by CLUBB's PDF
+(e.g. cloud fraction) by taking into account the values of these fields from an
+adjacent vertical grid level.  The clubb_l_trapezoidal_rule_zm flag applies this
+adjustment to PDF fields calculated on momentum vertical grid levels.
+</entry>
+
+<entry id="clubb_l_trapezoidal_rule_zt" type="logical" category="pblrad"
+       group="clubb_params_nl" valid_values="" >
+Flag that uses the trapezoidal rule to adjust fields calculated by CLUBB's PDF
+(e.g. cloud fraction) by taking into account the values of these fields from an
+adjacent vertical grid level.  The clubb_l_trapezoidal_rule_zt flag applies this
+adjustment to PDF fields calculated on thermodynamic vertical grid levels.
+</entry>
+
+<entry id="clubb_l_upwind_xm_ma" type="logical" category="pblrad"
+       group="clubb_params_nl" valid_values="" >
+This flag determines whether we want to use an upwind differencing approximation
+rather than a centered differencing for turbulent or mean advection terms. It
+affects rtm, thlm, sclrm, um and vm.
+</entry>
+
+<entry id="clubb_l_upwind_xpyp_ta" type="logical" category="pblrad"
+       group="clubb_params_nl" valid_values="" >
+Flag to use "upwind" discretization in the turbulent advection term in the
+xpyp predictive equation, where xpyp is a field such as rtp2 (variance of
+vertical velocity) or rtpthlp (covariance of total water and liquid water
+potential temperature).  When this flag is turned off, centered discretization
+is used.
+</entry>
+
+<entry id="clubb_l_uv_nudge" type="logical" category="pblrad"
+       group="clubb_params_nl" valid_values="" >
+Turn on (true) or off (false) uv wind speed nudging.
+</entry>
+
+<entry id="clubb_l_use_C11_Richardson" type="logical" category="pblrad"
+       group="clubb_params_nl" valid_values="" >
+Flag to calculate the value of CLUBB's C11 based on Richardson number, where
+C11 is a coefficient in a wp3 pressure term and is used to balance the effects
+of pressure and buoyancy in the wp3 predictive equation.
+</entry>
+
+<entry id="clubb_l_use_C7_Richardson" type="logical" category="pblrad"
+       group="clubb_params_nl" valid_values="" >
+Flag to calculate the value of CLUBB's C7 based on Richardson number, where
+C7 is a coefficient in a wpxp pressure term and is used to balance the effects
+of pressure and buoyancy in the wpxp predictive equation.  The variable wpxp is
+a flux such as total water flux or flux of liquid water potential temperature.
+</entry>
+
+<entry id="clubb_l_use_cloud_cover" type="logical" category="pblrad"
+       group="clubb_params_nl" valid_values="" >
+Flag to allow cloud fraction and mean cloud water at adjacent vertical grid
+levels influence the amount of cloudiness and amount of cloud water in a
+grid box.
+</entry>
+
+<entry id="clubb_l_use_precip_frac" type="logical" category="pblrad"
+       group="clubb_params_nl" valid_values="" >
+Flag to use precipitation fraction in KK microphysics. The
+precipitation fraction is automatically set to 1 when this
+flag is turned off.
+</entry>
+
+<entry id="clubb_l_use_shear_Richardson" type="logical" category="pblrad"
+       group="clubb_params_nl" valid_values="" >
+Flag to use shear in the calculation of Richardson number.
+</entry>
+
+<entry id="clubb_l_use_thvm_in_bv_freq" type="logical" category="pblrad"
+       group="clubb_params_nl" valid_values="" >
+Flag to use mean theta-v in the calculation of Brunt-Vaisala frequency.
+</entry>
+
+<entry id="clubb_l_use_tke_in_wp2_wp3_K_dfsn" type="logical" category="pblrad"
+       group="clubb_params_nl" valid_values="" >
+Flag to use Total Kenetic Energy (TKE) in eddy diffusion for wp2 and wp3.
+</entry>
+
+<entry id="clubb_l_use_tke_in_wp3_pr_turb_term" type="logical" category="pblrad"
+       group="clubb_params_nl" valid_values="" >
+Flag to use Total Kenetic Energy (TKE) formulation for wp3 pr_turb (turbulent
+production) term.
+</entry>
+
+<entry id="clubb_l_vary_convect_depth" type="logical" category="pblrad"
+       group="clubb_params_nl" valid_values="" >
+Flag used to calculate convective velocity using a variable estimate of layer
+depth based on the depth over which wpthlp is positive near the ground when true
+</entry>
+
+<entry id="clubb_l_vert_avg_closure" type="logical" category="pblrad"
+       group="clubb_params_nl" valid_values="" >
+Flag that, when it is enabled, automatically enables CLUBB's
+l_trapezoidal_rule_zt, l_trapezoidal_rule_zm, and l_call_pdf_closure_twice.
+</entry>
+
+<entry id="clubb_mult_coef" type="real" category="pblrad"
+       group="clubb_params_nl" valid_values="" >
+Coef. applied to log(avg dz/thresh)
+</entry>
+
+<entry id="clubb_nu2" type="real" category="pblrad"
+       group="clubb_params_nl" valid_values="" >
+Constant in the diffusivity term in the scalar variance predictive equations
+(e.g. rtp2, variance of total water).
+</entry>
+
+<entry id="clubb_nu9" type="real" category="pblrad"
+       group="clubb_params_nl" valid_values="" >
+Constant in the diffusivity term in the up2 (variance of the west-east wind
+component) and vp2 (variance of the south-north wind component) predictive
+equations.
+</entry>
+
+<entry id="clubb_penta_solve_method" type="integer" category="pblrad"
+       group="clubb_params_nl" valid_values="" >
+Specifier for method to solve the penta-diagonal system that is common in CLUBB.
+Valid values: 0 (lapack), 1 (penta_lu), 2 (penta_bicgstab)
+</entry>
+
+<entry id="clubb_Skw_denom_coef" type="real" category="pblrad"
+       group="clubb_params_nl" valid_values="" >
+Factor to decrease sensitivity in the denominator of Skw calculation
+</entry>
+
+<entry id="clubb_skw_max_mag" type="real" category="pblrad"
+       group="clubb_params_nl" valid_values="" >
+Maximum magnitude of skewness allowed.
+</entry>
+
+<entry id="clubb_tridiag_solve_method" type="integer" category="pblrad"
+       group="clubb_params_nl" valid_values="" >
+Specifier for method to solve tri-diagonal systems that are common in CLUBB.
+Experimental option and currently the only valid value is 1: lapack
+</entry>
+
+<entry id="clubb_up2_sfc_coef" type="real" category="pblrad"
+       group="clubb_params_nl" valid_values="" >
+Factor used in calculating the surface values of up2 (variance of the u wind
+component) and vp2 (variance of the v wind component).  Increasing
+clubb_up2_sfc_coef increases the values of up2 and vp2 at the surface.
+</entry>
+
+<entry id="clubb_wpxp_L_thresh" type="real" category="pblrad"
+       group="clubb_params_nl" valid_values="" >
+CLUBB tunable parameter - Lscale threshold: damp C6 and C7 (units: m)
+</entry>
+
+<entry id="clubb_wpxp_Ri_exp"  type="real" category="pblrad"
+       group="clubb_params_nl" valid_values="" >
+Exponent for Richardson number in calculation of invrs_tau_wpxp term
+</entry>
+
+<entry id="clubb_z_displace"  type="real" category="pblrad"
+       group="clubb_params_nl" valid_values="" >
+Displacement of log law profile above ground  (units: m)
+</entry>
+
+<!-- for CLUBB+MF -->
+<entry id="do_clubb_mf" type="logical" category="conv"
+       group="clubb_mf_nl" valid_values="" >
+If .true. add ensemble mass fluxes to CLUBB's higher-order equation set.
+Together with CLUBB, this constitutes an eddy-diffusivity mass-flux approach.
+Default: .false.
+</entry>
+
+<entry id="do_clubb_mf_diag" type="logical" category="conv"
+       group="clubb_mf_nl" valid_values="" >
+If .true. add detailed budget terms to output by default.  Note that do_clubb_mf must also be set to .true.
+Default: .false.
+</entry>
+
+<entry id="clubb_mf_L0" type="real" category="conv"
+       group="clubb_mf_nl" valid_values="" >
+Entrainment length scale in meters for individual plumes. Not used if
+do_clubb_mf=FALSE.
+Default: 50.0
+</entry>
+
+<entry id="clubb_mf_ent0" type="real" category="conv"
+       group="clubb_mf_nl" valid_values="" >
+Entrainment efficiency for individual plumes. Not used if
+do_clubb_mf=FALSE.
+Default: 0.22
+</entry>
+
+<entry id="clubb_mf_nup" type="integer" category="conv"
+       group="clubb_mf_nl" valid_values="" >
+Real: number of plumes in mass flux ensemble
+Default: 10
+</entry>
+
+<!-- YOG parameters -->
+<entry id="yog_nn_weights" type="char*132" input_pathname="abs" category="conv"
+       group="yog_params_nl" valid_values="" >
+Absolute path to the neural net weights used for the YOG deep convection scheme.
+</entry>
+
+<!-- YOG parameters -->
+<entry id="yog_nn_scale" type="char*132" input_pathname="abs" category="conv"
+       group="yog_params_nl" valid_values="" >
+Absolute path to the neural net weights used for the YOG deep convection scheme.
+</entry>
+
+<entry id="SAM_sounding" type="char*132" input_pathname="abs" category="conv"
+       group="yog_params_nl" valid_values="" >
+Absolute path to the SAM sounding profile used for the YOG deep convection scheme.
+</entry>
+
+<entry id="yog_lat_max" type="real" category="conv"
+       group="yog_params_nl" valid_values="" >
+Maximum absolute latitude (degrees) at which the YOG deep convection scheme
+is applied. The YOG neural net was trained on tropical SAM data; outside
+this latitude band its tendencies are zeroed and the standard ZM deep
+convection scheme (which always runs) is left unmodified.
+Default: 30.0
+</entry>
+
+<!-- CARMA Sectional Microphysics -->
+
+<entry id="carma_model" type="char*32" category="carma"
+       group="carma_nl" valid_values="" >
+The name of the active CARMA microphysics model or none when CARMA
+is not active.
+Default: none
+</entry>
+
+<entry id="carma_sulfnuc_method" type="char*10" category="carma"
+       group="carma_nl" valid_values="ZhaoTurco,Vehkamaki" >
+ Nucleation methods:
+  ZhaoTurco
+      Zhao, J. and Turco, R.,
+      Nucleation simulations in the wake of a jet aircraft in stratospheric flight,
+      J. Aerosol Sci., 26, 779-795, 1995,
+      https://doi.org/10.1016/0021-8502(95)00010-A
+  Vehkamaki
+     Vehkamaki, H., M. Kulmala, I. Napari, K.E.J. Lehtinen,
+     C. Timmreck, M. Noppel and A. Laaksonen, 2002,
+     An improved parameterization for sulfuric acid-water nucleation
+     rates for tropospheric and stratospheric conditions,
+     J. Geophys. Res., 107, 4622, doi:10.1029/2002jd002184
+Default: none
+</entry>
+
+<entry id="carma_conmax" type="real" category="carma"
+       group="carma_nl" valid_values="" >
+A fraction that scales how tight the convergence criteria are to
+determine that the substepping has resulted in a valid solution.
+Smaller values will force more substepping.
+CARMA particles.
+Default: 0.1
+</entry>
+
+<entry id="carma_dt_threshold" type="real" category="carma"
+       group="carma_nl" valid_values="" >
+When non-zero, the largest change in temperature (K)
+allowed per substep.
+Default: 0.
+</entry>
+
+<entry id="carma_do_coremasscheck" type="logical" category="carma"
+       group="carma_nl" valid_values="" >
+Flag indicating that do coremasscheck after certain subroutines
+and abort the model if the check not pass.
+Default: FALSE
+</entry>
+
+<entry id="carma_do_aerosol" type="logical" category="carma"
+       group="carma_nl" valid_values="" >
+Flag indicating that the CARMA model is an aerosol model, and
+should be called in tphysac.
+Default: TRUE
+</entry>
+
+<entry id="carma_do_cldice" type="logical" category="carma"
+       group="carma_nl" valid_values="" >
+Flag indicating that CARMA is a cloud ice model and should
+be called in tphysbc.
+Default: FALSE
+</entry>
+
+<entry id="carma_do_cldliq" type="logical" category="carma"
+       group="carma_nl" valid_values="" >
+Flag indicating that CARMA is a cloud liquid model and should
+be called in tphysbc.
+Default: FALSE
+</entry>
+
+<entry id="carma_do_clearsky" type="logical" category="carma"
+       group="carma_nl" valid_values="" >
+Flag indicating that CARMA should do clear sky calculations for
+particles that are not part of a cloud in addition to doing a
+separate calculation for incloud particles. Only valid when
+carma_do_incloud is true.
+Default: FALSE
+</entry>
+
+<entry id="carma_do_cloudborne" type="logical" category="carma"
+       group="carma_nl" valid_values="" >
+Flag indicating whether CARMA aerosol should be allowed to become
+cloudborne. It is actually CAM and not CARMA that moves aerosol
+between cloudborne and interstitial.
+Default: FALSE
+</entry>
+
+<entry id="carma_do_coag" type="logical" category="carma"
+       group="carma_nl" valid_values="" >
+Flag indicating whether the coagulation process is enabled for
+CARMA particles.
+Default: FALSE
+</entry>
+
+<entry id="carma_do_detrain" type="logical" category="carma"
+       group="carma_nl" valid_values="" >
+Flag indicating that CARMA is responsible for detrain condensate
+from convection into the model.
+Default: FALSE
+</entry>
+
+<entry id="carma_do_drydep" type="logical" category="carma"
+       group="carma_nl" valid_values="" >
+Flag indicating that the dry deposition process is enabled for
+CARMA particles.
+Default: FALSE
+</entry>
+
+<entry id="carma_do_emission" type="logical" category="carma"
+       group="carma_nl" valid_values="" >
+Flag indicating that the emission of particles is enabled for
+CARMA.
+Default: FALSE
+</entry>
+
+<entry id="carma_do_explised" type="logical" category="carma"
+       group="carma_nl" valid_values="" >
+Flag indicating that sedimentation should be calculated using an
+explicit technique where the substepping is used to keep the CFL
+condition from being violated rather than the default PPM scheme.
+Default: FALSE
+</entry>
+
+<entry id="carma_do_fixedinit" type="logical" category="carma"
+       group="carma_nl" valid_values="" >
+Flag indicating CARMA coefficients should only be initialized once from
+a fixed temperature profile rather than recomputed for each column. This
+improves performance, but reduces accuracy. By default the temperature
+profile used is calculated as the average of the initial condition file,
+but a predefined profile can be provided.
+Default: FALSE
+</entry>
+
+<entry id="carma_do_partialinit" type="logical" category="carma"
+       group="carma_nl" valid_values="" >
+Flag indicating used in cunjunction with carma_do_fixedinit to indicate
+that only the coagulation coefficients should only be initialized from
+a fixed temperature profile and all other coeeficients will be recalculated.
+Coagulation is the slowest initialization, so this improves performance while
+still retaining accuracy for most processes.
+Default: FALSE
+</entry>
+
+<entry id="carma_do_grow" type="logical" category="carma"
+       group="carma_nl" valid_values="" >
+Flag indicating that the condensational growth process is enabled for
+CARMA particles.
+Default: FALSE
+</entry>
+
+<entry id="carma_do_budget_diags" type="logical" category="carma"
+       group="carma_nl" valid_values="" >
+Flag indicating that model specific budget diagnostics should be
+generated.
+Default: FALSE
+</entry>
+
+<entry id="carma_do_package_diags" type="logical" category="carma"
+       group="carma_nl" valid_values="" >
+Flag indicating that model specific budget diagnostics should be
+generated per physics package for the packages listed in
+carma_diag_packages.
+Default: FALSE
+</entry>
+
+<entry id="carma_diags_packages" type="char*12(100)" category="carma"
+       group="carma_nl" valid_values="" >
+List of physics packages for which diagnostic output is desired.
+Default: NONE
+</entry>
+
+<entry id="carma_debug_packages" type="char*32(100)" category="carma"
+       group="carma_nl" valid_values="" >
+List of physics packages for which debug output from the local carma
+state checker is desired.
+Default: NONE
+</entry>
+
+<entry id="carma_diags_file" type="integer" category="carma"
+       group="carma_nl" valid_values="" >
+When > 0, indicates the history file to be used by default for diagnostic output.
+A value of 1 indicates the h0 file. When 0 no diagnostics are output.
+Default: 0
+</entry>
+
+<entry id="carma_rad_feedback" type="logical" category="carma"
+       group="carma_nl" valid_values="" >
+Flag indicating that CARMA sulfate mass mixing ratio will be used
+in radiation calculation.
+Default: FALSE
+</entry>
+
+<entry id="carma_hetchem_feedback" type="logical" category="carma"
+       group="carma_nl" valid_values="" >
+Flag indicating that CARMA sulfate surface area density will be used
+in heterogeneous chemistry rate calculation.
+Default: FALSE
+</entry>
+
+<entry id="carma_do_incloud" type="logical" category="carma"
+       group="carma_nl" valid_values="" >
+Flag indicating that CARMA should treat cloud particles as incloud
+rather than gridbox average calculations.
+Default: FALSE
+</entry>
+
+<entry id="carma_do_optics" type="logical" category="carma"
+       group="carma_nl" valid_values="" >
+Flag indicating that carma should generate optical properties files
+for the CAM radiation code.
+Default: FALSE
+</entry>
+
+<entry id="carma_do_pheat" type="logical" category="carma"
+       group="carma_nl" valid_values="" >
+Flag indicating that particle heating will be used for the condensational
+growth process.
+Default: FALSE
+</entry>
+
+<entry id="carma_do_pheatatm" type="logical" category="carma"
+       group="carma_nl" valid_values="" >
+Flag indicating that particle heating will affect the atmospheric
+temperature.
+Default: FALSE
+</entry>
+
+<entry id="carma_do_substep" type="logical" category="carma"
+       group="carma_nl" valid_values="" >
+Flag indicating that substepping will be used for the condensational
+growth process.
+Default: FALSE
+</entry>
+
+<entry id="carma_do_thermo" type="logical" category="carma"
+       group="carma_nl" valid_values="" >
+Flag indicating that changes in heating will be calculated as a result
+CARMA processes and will affect the CAM heating tendency.
+Default: FALSE
+</entry>
+
+<entry id="carma_do_wetdep" type="logical" category="carma"
+       group="carma_nl" valid_values="" >
+Flag indicating that the wet deposition process is enabled for
+CARMA particles.
+Default: FALSE
+</entry>
+
+<entry id="carma_do_vdiff" type="logical" category="carma"
+       group="carma_nl" valid_values="" >
+Flag indicating that the effect of Brownian diffusion will be calculated for
+CARMA particles. NOTE: This needs to be used in conjunction with CARMA
+sedimentation.
+Default: FALSE
+</entry>
+
+<entry id="carma_do_vtran" type="logical" category="carma"
+       group="carma_nl" valid_values="" >
+Flag indicating that the sedimentation process is enabled for
+CARMA particles.
+Default: FALSE
+</entry>
+
+<entry id="carma_flag" type="logical" category="carma"
+       group="carma_nl" valid_values="" >
+Flag indicating whether CARMA is enabled. If CARMA has been included
+in the build (configure -carma with something other than none), then
+this will cause all of the CARMA constituents and field names to be
+registered, but no other CARMA process will be preformed. This overrides
+the individual CARMA process flags.
+Default: FALSE
+</entry>
+
+<entry id="carma_maxretries" type="integer" category="carma"
+       group="carma_nl" valid_values="" >
+Specifies the maximum number of retry attempts to be used when
+condensational growth requires substepping, but the original estimate
+for the amount of substepping was insufficient.
+Default: 8
+</entry>
+
+<entry id="carma_maxsubsteps" type="integer" category="carma"
+       group="carma_nl" valid_values="" >
+Specifies the maximum number of substeps that could be used for the
+first guess when condensational growth requires substepping.
+Default: 1
+</entry>
+
+<entry id="carma_cstick" type="real" category="carma"
+       group="carma_nl" valid_values="" >
+Accommodation coefficient for coagulation.
+Default: 1.0
+</entry>
+
+<entry id="carma_gsticki" type="real" category="carma"
+       group="carma_nl" valid_values="" >
+Accommodation coefficient for growth with ice.
+Default: 0.93
+</entry>
+
+<entry id="carma_gstickl" type="real" category="carma"
+       group="carma_nl" valid_values="" >
+Accommodation coefficient for growth with liquid.
+Default: 1.0
+</entry>
+
+<entry id="carma_tstick" type="real" category="carma"
+       group="carma_nl" valid_values="" >
+Accommodation coefficient for temperature.
+Default: 1.0
+</entry>
+
+<entry id="carma_rhcrit" type="real" category="carma"
+       group="carma_nl" valid_values="" >
+Critical relative humidity for liquid cloud formation, used
+for sub-grid scale in-cloud saturation.
+Default: 1.0
+</entry>
+
+<!-- CARMA model - meteor impact -->
+
+<entry id="carma_emis_dust" type="real" category="carma_model"
+       group="carma_model_nl" valid_values="" >
+Global mass of dust emission for the event.
+Default: 0. (kg)
+</entry>
+
+<entry id="carma_emis_soot" type="real" category="carma_model"
+       group="carma_model_nl" valid_values="" >
+Global mass of dust emission for the event.
+Default: 0. (kg)
+</entry>
+
+<entry id="carma_emis_startdate" type="integer" category="carma_model"
+       group="carma_model_nl" valid_values="" >
+Starting date for emissions in the form of (yyyyddd) where yyyy is a year and
+ddd is a day of year.
+Default: 1 (yyyyddd)
+</entry>
+
+<entry id="carma_emis_starttime" type="integer" category="carma_model"
+       group="carma_model_nl" valid_values="" >
+Starting time for the emission event in GMT.
+Default: 0. (s Z)
+</entry>
+
+<entry id="carma_emis_stopdate" type="integer" category="carma_model"
+       group="carma_model_nl" valid_values="" >
+Stopping date for emissions in the form of (yyyyddd) where yyyy is a year and
+ddd is a day of year.
+Default: 1 (yyyyddd)
+</entry>
+
+<entry id="carma_emis_stoptime" type="integer" category="carma_model"
+       group="carma_model_nl" valid_values="" >
+Stoping time for the emission event in GMT.
+Default: 0. (s)
+</entry>
+
+<entry id="carma_emis_minlat" type="real" category="carma_model"
+       group="carma_model_nl" valid_values="" >
+Minimum latitude of the area for emssions from the event.
+Default: -90. (degrees north)
+</entry>
+
+<entry id="carma_emis_maxlat" type="real" category="carma_model"
+       group="carma_model_nl" valid_values="" >
+Maximum latitude of the area for emssions from the event.
+Default: 90. (degrees north)
+</entry>
+
+<entry id="carma_emis_minlon" type="real" category="carma_model"
+       group="carma_model_nl" valid_values="" >
+Minimum longitude of the area for emssions from the event.
+Default: 0. (degrees east)
+</entry>
+
+<entry id="carma_emis_maxlon" type="real" category="carma_model"
+       group="carma_model_nl" valid_values="" >
+Maximum longitude of the area for emssions from the event.
+Default: 360. (degrees east)
+</entry>
+
+<entry id="carma_fractal_soot" type="logical" category="carma_model"
+       group="carma_model_nl" valid_values="" >
+Are the soot particles treated as fractals?
+Default: FALSE
+</entry>
+
+<!-- CARMA model - meteor smoke &amp; pmc -->
+
+<entry id="carma_do_escale" type="logical" category="carma_model"
+       group="carma_model_nl" valid_values="" >
+Flag indicating that meteor smoke emission will be scaled by a
+global relative flux based upon the carma_escale_file.
+Default: FALSE
+</entry>
+
+<entry id="carma_emis_total" type="real" category="carma_model"
+       group="carma_model_nl" valid_values="" >
+The total meteor smoke emission rate in kt/year. The flux will be
+scaled to total that value.
+Default: 16.0
+</entry>
+
+<entry id="carma_emis_file" type="char*256" input_pathname="abs" category="carma_model"
+       group="carma_model_nl" valid_values="" >
+Specifies the name of the file containing the meteor smoke emission
+(ablation) profile.
+Default: set by build-namelist.
+</entry>
+
+<entry id="carma_escale_file" type="char*256" input_pathname="abs" category="carma_model"
+       group="carma_model_nl" valid_values="" >
+Specifies the name of the file containing the global realtive flux
+specification.
+Default: set by build-namelist.
+</entry>
+
+<entry id="carma_launch_doy" type="integer" category="carma_model"
+       group="carma_model_nl" valid_values="" >
+Specifies the day of year when tracers will start being emitted for the tracer test.
+Default: 1
+</entry>
+
+<entry id="carma_emission_rate" type="real" category="carma_model"
+       group="carma_model_nl" valid_values="" >
+The emission rate of inert tracers used in the test. A positive value indicates that
+the rate is a column mass (kg/m2/s) and a negative value indicate that it is a mass
+mixing ratio (kg/kg/s).
+Default: 1e-9
+</entry>
+
+<entry id="carma_neutral_h2so4" type="logical" category="carma_model"
+       group="carma_model_nl" valid_values="" >
+Flag indicating that h2so4 vapor pressures should be calculated as if they were
+over sulfates that have been totally neutralized.
+Default: FALSE
+</entry>
+
+
+<!-- CARMA model - cirrus -->
+
+<entry id="carma_sulfate_method" type="char*32" category="carma_model"
+       group="carma_model_nl" valid_values="bulk,carma,fixed,modal" >
+Specifies the method to use to get the prescribed sulfate aerosols for use with nucleation
+of cirrus clouds. This can be different than the sulfate aerosols that are used with the
+climate.
+Default: fixed
+</entry>
+
+<!-- CARMA model - cirrus &amp; pmc -->
+
+<entry id="carma_mice_file" type="char*256" input_pathname="abs" category="carma_model"
+       group="carma_model_nl" valid_values="" >
+Specifies the name of the file containing ice refrative indicies as a function of wavelength
+used for the particle heating calculation.
+Default: set by build-namelist.
+</entry>
+
+<!-- CARMA model - dust -->
+
+<entry id="carma_soilerosion_file" type="char*256" input_pathname="abs" category="carma_model"
+       group="carma_model_nl" valid_values="" >
+Specifies the name of the file containing soil erosion factors. This is used by
+the dust model.
+Default: set by build-namelist.
+</entry>
+
+<entry id="carma_dustemisfactor" type="real" category="carma"
+       group="carma_model_nl" valid_values="" >
+CARMA dust emissions scaling factor
+Default: 0.5e-9_r8
+</entry>
+
+
+
+<!-- CARMA model - sea salt -->
+
+<entry id="carma_do_WeibullK" type="logical" category="carma_model"
+       group="carma_model_nl" valid_values="" >
+Flag indicating that a calculated Weibull K should be used.
+Default: FALSE
+</entry>
+
+<entry id="carma_seasalt_emis" type="char*32" category="carma_model"
+       group="carma_model_nl" valid_values="" >
+Specifies the name of the sea salt emission parameterization.
+Default: Gong
+</entry>
+
+<!-- CARMA model - aerosol -->
+<entry id="carma_BCOCemissions" type="char*32" category="carma_model"
+       group="carma_model_nl" valid_values="Yu2015,Specified" >
+Specifies the input method of black and organic carbon aerosol emissions
+for the trop_strat CARMA model.
+
+Valid options are:
+
+ Yu2015 -- method used in Yu et. al, 2015
+ Specified -- {{ hilight }}emissions_specifier{{ closehilight }} method which places emissions in physcis buffer
+
+Default: Yu2015
+</entry>
+
+<entry id="carma_SO4elevemis" type="char*32" category="carma_model"
+       group="carma_model_nl" valid_values="NONE,Specified" >
+Specifies the input method of sulfate emissions
+for the trop_strat CARMA model.
+
+Valid options are:
+
+ Specified -- {{ hilight }}elev_emis_specifier{{ closehilight }} method which places emissions in physcis buffer
+
+Default: NONE
+</entry>
+
+<entry id="elev_emis_specifier" type="char*256(50)" category="cam_chem"
+       group="elevated_emissions_opts" valid_values="" >
+List of full pathnames of surface emission datasets.
+
+Elevated emission data added to physcis buffer read from a set of netcdf file.
+Each tracer species emissions is read from its own file as directed by the
+namelist variable {{ hilight }}elev_emis_specifier{{ closehilight }}.  The
+{{ hilight }}emissions_specifier{{ closehilight }} variable tells the model
+which species have emissions and the file path for the corresponding species.
+That is, the {{ hilight }}elev_emis_specifier{{ closehilight }} variable is
+set something like:
+
+ elev_emis_specifier = 'SO4 -> /path/emis.SO4.nc',
+                       'OC -> /path/emis.OC.nc', etc...
+
+Each emission file can have more than one source.  When the emission are
+read in the sources are summed to give a total emission field for the
+corresponding species.  The emission can be read in as time series of data,
+cycle over a given year, or be fixed to a given date.
+
+Default: set by build-namelist.
+</entry>
+
+<entry id="elev_emis_type" type="char*32" category="cam_chem"
+       group="elevated_emissions_opts" valid_values="CYCLICAL,SERIAL,INTERP_MISSING_MONTHS,FIXED" >
+Type of time interpolation of emission datasets specified.
+Can be set to 'CYCLICAL', 'SERIAL', 'INTERP_MISSING_MONTHS', or 'FIXED'.
+by {{ hilight }}elev_emis_specifier{{ closehilight }}.
+Default: 'CYCLICAL'
+</entry>
+
+<entry id="elev_emis_cycle_yr" type="integer" category="cam_chem"
+       group="elevated_emissions_opts" valid_values="" >
+The  cycle year of the elevated emissions data
+if {{ hilight }}elev_emis_type{{ closehilight }}  is 'CYCLICAL'.
+Format: YYYY
+Default: 0
+</entry>
+
+<entry id="elev_emis_fixed_ymd" type="integer" category="cam_chem"
+       group="elevated_emissions_opts" valid_values="" >
+The date at which the elevated emissions are fixed
+if {{ hilight }}elev_emis_type{{ closehilight }} is 'FIXED'.
+Format: YYYYMMDD
+Default: 0
+</entry>
+
+<entry id="elev_emis_fixed_tod" type="integer" category="cam_chem"
+       group="elevated_emissions_opts" valid_values="" >
+The time of day (seconds) corresponding to {{ hilight }}elev_emis_fixed_ymd{{ closehilight }}
+at which the elevated emissions are fixed
+if {{ hilight }}elev_emis_type{{ closehilight }} is 'FIXED'.
+Default: 0 seconds
+</entry>
+
+<entry id="BC_GAINS_filename" type="char*256" input_pathname="abs" category="carma_model"
+       group="carma_model_nl" valid_values="" >
+BC GAINS file.
+Default: set by build-namelist.
+</entry>
+
+<entry id="OC_GAINS_filename" type="char*256" input_pathname="abs" category="carma_model"
+       group="carma_model_nl" valid_values="" >
+OC GAINS file.
+Default: set by build-namelist.
+</entry>
+
+<entry id="BC_ship_filename" type="char*256" input_pathname="abs" category="carma_model"
+       group="carma_model_nl" valid_values="" >
+BC ship file.
+Default: set by build-namelist.
+</entry>
+
+<entry id="OC_ship_filename" type="char*256" input_pathname="abs" category="carma_model"
+       group="carma_model_nl" valid_values="" >
+OC ship file.
+Default: set by build-namelist.
+</entry>
+
+<entry id="BC_GFEDv3_filename" type="char*256" input_pathname="abs" category="carma_model"
+       group="carma_model_nl" valid_values="" >
+BC GFEDv3 file.
+Default: set by build-namelist.
+</entry>
+
+<entry id="OC_GFEDv3_filename" type="char*256" input_pathname="abs" category="carma_model"
+       group="carma_model_nl" valid_values="" >
+OC GFEDv3 file.
+Default: set by build-namelist.
+</entry>
+
+<entry id="Chlorophy11_file" type="char*256" input_pathname="abs" category="carma_model"
+       group="carma_model_nl" valid_values="" >
+Dust erosion factor file.
+Default: set by build-namelist.
+</entry>
+
+<!-- Performance Tuning and Profiling -->
+
+<entry id="papi_ctr1_str" type="char*16"  category="performance"
+       group="papi_inparm" valid_values="">
+String identifying a hardware counter to the papi library.
+Default: PAPI_TOT_CYC
+</entry>
+
+<entry id="papi_ctr2_str" type="char*16"  category="performance"
+       group="papi_inparm" valid_values="">
+String identifying a hardware counter to the papi library.
+Default: PAPI_FP_OPS
+</entry>
+
+<entry id="papi_ctr3_str" type="char*16"  category="performance"
+       group="papi_inparm" valid_values="">
+String identifying a hardware counter to the papi library.
+Default: PAPI_FP_INS
+</entry>
+
+<entry id="papi_ctr4_str" type="char*16"  category="performance"
+       group="papi_inparm" valid_values="">
+String identifying a hardware counter to the papi library.
+Default: PAPI_NO_CTR
+</entry>
+
+<entry id="profile_barrier" type="logical"  category="performance"
+       group="prof_inparm" valid_values="">
+Flag indicating whether the mpi_barrier in t_barrierf should be called.
+Default: FALSE
+</entry>
+
+<entry id="profile_depth_limit" type="integer"  category="performance"
+       group="prof_inparm" valid_values="">
+Maximum number of levels of timer nesting .
+Default: 99999
+</entry>
+
+<entry id="profile_detail_limit" type="integer"  category="performance"
+       group="prof_inparm" valid_values="">
+Maximum detail level to profile.
+Default: 1
+</entry>
+
+<entry id="profile_disable" type="logical"  category="performance"
+       group="prof_inparm" valid_values="">
+Flag indicating whether timers are disabled.
+Default: FALSE
+</entry>
+
+<entry id="profile_global_stats" type="logical"  category="performance"
+       group="prof_inparm" valid_values="">
+Collect and print out global performance statistics (for this component communicator).
+Default: FALSE
+</entry>
+
+<entry id="profile_outpe_num" type="integer"  category="performance"
+       group="prof_inparm" valid_values="">
+Maximum number of processes writing out timing data (for this component communicator).
+Default: -1
+</entry>
+
+<entry id="profile_outpe_stride" type="integer"  category="performance"
+       group="prof_inparm" valid_values="">
+Separation between process ids for processes that are writing out timing data
+(for this component communicator).
+Default: 1
+</entry>
+
+<entry id="profile_papi_enable" type="logical"  category="performance"
+       group="prof_inparm" valid_values="">
+Flag indicating whether the PAPI namelist should be read and HW performance counters
+used in profiling.
+Default: FALSE
+</entry>
+
+<entry id="profile_single_file" type="logical"  category="performance"
+       group="prof_inparm" valid_values="">
+Flag indicating whether the performance timer output should be written to a
+single file (per component communicator) or to a separate file for each
+process.
+Default: TRUE
+</entry>
+
+<entry id="profile_timer" type="integer"  category="performance"
+       group="prof_inparm" valid_values="">
+Initialization of GPTL timing library.
+Default: GPTLmpiwtime
+</entry>
+
+<entry id="swap_comm_protocol" type="integer"  category="performance"
+       group="spmd_utils_nl" valid_values="">
+Swap communication protocol option (reduced set):
+ 3, 5:                  nonblocking send
+ 2, 3, 4, 5:            nonblocking receive
+ 4, 5:                  ready send
+Default: 4
+</entry>
+
+<entry id="swap_comm_maxreq" type="integer"  category="performance"
+       group="spmd_utils_nl" valid_values="">
+Swap communication maximum request count:
+ &lt;=0: do not limit number of outstanding send/receive requests
+  &gt;0: do not allow more than swap_comm_maxreq outstanding
+      nonblocking send requests or nonblocking receive requests
+Default: 128
+</entry>
+
+<entry id="fc_gather_flow_cntl" type="integer"  category="performance"
+       group="spmd_utils_nl" valid_values="">
+fc_gather flow control option:
+ &lt; 0 : use MPI_Gather
+ &gt;= 0: use point-to-point with handshaking messages and preposting
+       receive requests up to
+         max(min(1,fc_gather_flow_cntl),max_gather_block_size)
+       ahead. Default value is defined by private parameter
+       max_gather_block_size, which is currently set to 64.
+Default: 64
+</entry>
+
+<!-- Physics Buffer -->
+
+<entry id="pbuf_global_allocate" type="logical" category="pbuf"
+       group="pbuf_nl" valid_values="" >
+Allocate all buffers as global.  This is a performance optimization on
+machines for which allocation/deallocation of physpkg scope buffers on
+every timestep was slow (Cray-X1).
+Default: TRUE
+</entry>
+
+<!-- Physics control -->
+
+<entry id="cam_physpkg" type="char*16" category="build"
+       group="phys_ctl_nl" valid_values="cam4,cam5,cam6,cam7,adiabatic,held_suarez,kessler,frierson" >
+Name of the CAM physics package.  N.B. this variable may not be set by
+the user.  It is set by build-namelist via information in the configure
+cache file to be consistent with how CAM was built.
+Default: set by build-namelist
+</entry>
+
+<entry id="use_simple_phys" type="logical" category="build"
+       group="phys_ctl_nl" valid_values="" >
+Flag for simple physics package.  N.B. this variable may not be set by
+the user.  It is set by build-namelist via information in the configure
+cache file to be consistent with how CAM was built.
+Default: set by build-namelist
+</entry>
+
+<entry id="cam_chempkg" type="char*32" category="build" group="phys_ctl_nl"
+       valid_values="none,ghg_mam4,terminator,trop_mam3,trop_mam4,trop_mam7,trop_mozart,trop_strat_mam4_ts2,
+                     trop_strat_mam4_vbs,trop_strat_mam4_vbsext,trop_strat_mam4_slh,trop_strat_mam5_slh,
+                     trop_strat_mam5_t1s1,trop_strat_mam5_t1s2,trop_strat_mam5_t2s1,trop_strat_mam5_t4s2,
+                     trop_strat_mam5_vbsext,trop_strat_noaero,waccm_ma,waccm_mad,waccm_ma_sulfur,waccm_sc,
+                     waccm_sc_mam4,waccm_mad_mam4,waccm_ma_mam4,waccm_tsmlt_mam4,waccm_tsmlt_mam4_vbsext,
+                     waccm_tsmlt_mam4_slh,waccm_tsmlt_mam5_slh,waccm_mad_mam5,waccm_ma_mam5,waccm_tsmlt_mam5,
+                     waccm_tsmlt_mam5_vbsext,waccm_t4ma_mam5,waccm_ma_noaero,geoschem_mam4">
+Name of the CAM chemistry package.  N.B. this variable may not be set by
+the user.  It is set by build-namelist via information in the configure
+cache file to be consistent with how CAM was built.
+Default: set by build-namelist
+</entry>
+
+<entry id="cam_physics_mesh" type="char*256" input_pathname="abs"
+       category="build" group="phys_ctl_nl" valid_values="" >
+Full pathname to CAM physics grid ESMF mesh file.
+N.B. this variable may not be set by the user.
+It is set by build-namelist via information in the configure
+cache file to be consistent with how CAM was built.
+Default: set by build-namelist
+</entry>
+
+<entry id="use_hemco" type="logical" category="hemco"
+       group="phys_ctl_nl" valid_values="" >
+If TRUE then the Harmonized Emissions Component, HEMCO, will be used
+to calculate emissions in chemistry. ext_frc_specifier and srf_emis_specifier
+will be ignored.
+Default: FALSE
+</entry>
+
+<entry id="waccmx_opt" type="char*16" category="waccmx"
+       group="phys_ctl_nl" valid_values="ionosphere,neutral,off" >
+Runtime options of upper thermosphere WACCM-X.  'ionosphere' for
+full ionosphere and neutral thermosphere, 'neutral' for just
+neutral thermosphere, and off for no WACCM-X.
+Default: 'off'
+</entry>
+
+<entry id="oplus_adiff_limiter" type="real" category="waccmx"
+       group="ionosphere_nl" valid_values="" >
+Limiter for ambipolar diffusion coefficient used in O+ transport in the
+ionosphere.
+Default: 1.5e+8
+</entry>
+
+<entry id="oplus_shapiro_const" type="real" category="waccmx"
+       group="ionosphere_nl" valid_values="" >
+Shapiro constant for spatial smoother used in O+ transport in the
+ionosphere.
+Default: 0.03
+</entry>
+
+<entry id="oplus_enforce_floor" type="logical"  category="waccmx"
+       group="ionosphere_nl" valid_values="">
+Switch to apply floor to O+ concentrations within in ionosphere O+ transport.
+Default: TRUE
+</entry>
+
+<entry id="oplus_ring_polar_filter" type="logical"  category="waccmx"
+       group="ionosphere_nl" valid_values="">
+Switch to apply ring polar filter within in ionosphere O+ transport.
+Default: FALSE
+</entry>
+
+<entry id="oplus_grid" type="integer(2)"
+       category="waccmx" group="ionosphere_nl" valid_values="" >
+Oplus transport grid size, entered as num_longitudes, num_latitudes.
+Default: set by build-namelist
+</entry>
+
+<entry id="edyn_grid" type="char*8"
+       category="waccmx" group="ionosphere_nl" valid_values="80x97,160x193,320x385,640x769" >
+Magnetic grid resolution (nlon x nlat).
+Default: set by build-namelist
+</entry>
+
+<entry id="ionos_npes" type="integer"
+       category="waccmx" group="ionosphere_nl" valid_values="" >
+Number of MPI processes on which to run the WACCM-X ionosphere
+electro-dynamo and O+ ion transport modules.
+Default: 0 (use all atmosphere tasks)
+</entry>
+
+<entry id="ionos_xport_active" type="logical"  category="waccmx"
+       group="ionosphere_nl" valid_values="">
+Switch to to turn on/off O+ transport in ionosphere.
+Default: set by build-namelist
+</entry>
+
+<entry id="ionos_xport_nsplit" type="integer"  category="waccmx"
+       group="ionosphere_nl" valid_values="">
+Number of ion transport steps per physics timestep.
+Default: 5
+</entry>
+
+<entry id="ionos_edyn_active" type="logical"  category="waccmx"
+       group="ionosphere_nl" valid_values="">
+Switch to invoke electro-dynamo to compute ion drift velocities used in
+O+ transport in ionosphere.  If false, ExB empirical model is used to
+provide the ion drift velocities for O+ transport.
+Default: set by build-namelist
+</entry>
+
+<entry id="ionos_epotential_model" type="char*16"  category="waccmx"
+       group="ionosphere_nl" valid_values="heelis,weimer">
+Electric potential model used in the waccmx ionosphere.
+Default: set by build-namelist
+</entry>
+
+<entry id="ionos_debug_hist" type="logical"  category="waccmx"
+       group="ionosphere_nl" valid_values="">
+Switch to add history fields to master field list for the purpose
+of debugging ionospheric processes in WACCMX.
+Default: FALSE
+</entry>
+
+<entry id="epot_crit_colats" type="real*2"  category="waccmx"
+       group="ionosphere_nl" valid_values="">
+Co-latitudes (degrees) of the critical angles where the ionosphere
+high-latitude electric potential is merged with the low and middle
+latitude electric potential computed by the electro-dynamo of WACCM-X.
+Default: none
+</entry>
+
+<entry id="wei05_coefs_file" type="char*256" input_pathname="abs" category="waccmx"
+       group="ionosphere_nl" valid_values="" >
+Full pathname of dataset for coefficient data used in Weimer05
+high latitude electric potential model.
+Default: set by build-namelist.
+</entry>
+
+<entry id="ionos_epotential_amie" type="logical"  category="waccmx"
+       group="ionosphere_nl" valid_values="">
+Give the user the ability to input prescribed high-latitude electric potential.
+Default: FALSE
+</entry>
+
+<entry id="amienh_files" type="char*256(20)" input_pathname="abs" category="waccmx"
+       group="ionosphere_nl" valid_values="" >
+List of full pathnames of AMIE electic potential inputs for northern hemisphere.
+Default: NONE.
+</entry>
+
+<entry id="amiesh_files" type="char*256(20)" input_pathname="abs" category="waccmx"
+       group="ionosphere_nl" valid_values="" >
+List of full pathnames of AMIE electic potential inputs for southern hemisphere.
+Default: NONE.
+</entry>
+
+<entry id="ionos_epotential_ltr" type="logical"  category="waccmx"
+       group="ionosphere_nl" valid_values="">
+Give the user the ability to input LTR high-latitude electric potential.
+Default: FALSE
+</entry>
+
+<entry id="ltr_files" type="char*256(20)" input_pathname="abs" category="waccmx"
+       group="ionosphere_nl" valid_values="" >
+List of full pathnames of LTR electic potential inputs for both hemispheres.
+Default: NONE.
+</entry>
+
+<!-- HEMCO -->
+
+<entry id="hemco_data_root" type="char*256" input_pathname="abs" category="hemco"
+       group="hemco_nl" valid_values="" >
+Full pathname of HEMCO data root for use in reading HEMCO input files.
+(e.g., '$DIN_LOC_ROOT/atm/cam/geoschem/emis/ExtData/HEMCO').
+Default: set by build-namelist.
+</entry>
+
+<entry id="hemco_config_file" type="char*256" input_pathname="abs" category="hemco"
+       group="hemco_nl" valid_values="" >
+Full pathname of the HEMCO_Config.rc input file used to configure HEMCO.
+Default: set by build-namelist.
+</entry>
+
+<entry id="hemco_diagn_file" type="char*256" input_pathname="abs" category="hemco"
+       group="hemco_nl" valid_values="" >
+Full pathname of the HEMCO_Diagn.rc input file used to configure HEMCO diagnostics.
+Default: set by build-namelist.
+</entry>
+
+<entry id="hemco_grid_xdim" type="integer" category="hemco"
+       group="hemco_nl" valid_values="">
+Number of x-dimensions in HEMCO internal grid.
+Default: set by build-namelist.
+</entry>
+
+<entry id="hemco_grid_ydim" type="integer" category="hemco"
+       group="hemco_nl" valid_values="">
+Number of y-dimensions in HEMCO internal grid.
+Default: set by build-namelist.
+</entry>
+
+<entry id="hemco_emission_year" type="integer" category="hemco"
+       group="hemco_nl" valid_values="">
+Force emission year for HEMCO clock if positive. This will force cycling of data on this year.
+Default: set by build-namelist for climo cases, otherwise -1 to use model clock.
+</entry>
+
+<!-- GEOS-Chem model -->
+
+<entry id="geoschem_chem_inputs" type="char*256" input_pathname="abs" category="geoschem"
+       group="geoschem_nl" valid_values="" >
+Full pathname of the GEOS-Chem chemistry inputs directory.
+Default: set by build-namelist.
+</entry>
+
+<entry id="geoschem_aeropt_inputs" type="char*256" input_pathname="abs" category="geoschem"
+       group="geoschem_nl" valid_values="" >
+Full pathname of the aerosols optical property inputs directory used in GEOS-Chem outside of Cloud-J.
+Default: set by build-namelist.
+</entry>
+
+<entry id="geoschem_photol_inputs" type="char*256" input_pathname="abs" category="geoschem"
+       group="geoschem_nl" valid_values="" >
+Full pathname of the Cloud-J photolysis inputs directory used in GEOS-Chem.
+Default: set by build-namelist.
+</entry>
+
+<!-- Reference Pressures -->
+
+<entry id="trop_cloud_top_press" type="real" category="press_lim"
+       group="ref_pres_nl" valid_values="" >
+Troposphere cloud physics will be done only below the top defined
+by this pressure (Pa).
+Default: set by build-namelist
+</entry>
+
+<entry id="clim_modal_aero_top_press" type="real" category="press_lim"
+       group="ref_pres_nl" valid_values="" >
+MAM affects climate only below the top defined by this pressure (Pa).
+Default: 0 for non-MAM cases, otherwise set by build-namelist
+</entry>
+
+<entry id="do_molec_press" type="real" category="press_lim"
+       group="ref_pres_nl" valid_values="" >
+Molecular diffusion will be done only if the lowest pressure is
+below this limit (Pa).
+Default: 0.1
+</entry>
+
+<entry id="molec_diff_bot_press" type="real" category="press_lim"
+       group="ref_pres_nl" valid_values="" >
+The level closest to this pressure (Pa) is the bottom of the region
+where molecular diffusion is done.
+Default: 50.
+</entry>
+
+<!-- Physics Debugging -->
+
+<entry id="phys_debug_lat" type="real"  category="phys_debug"
+       group="phys_debug_nl" valid_values="">
+Use this variable to specify the latitude (in degrees) of a column to
+debug.  The closest column in the physics grid will be used.
+Default: none
+</entry>
+
+<entry id="phys_debug_lon" type="real"  category="phys_debug"
+       group="phys_debug_nl" valid_values="">
+Use this variable to specify the longitude (in degrees) of a column to
+debug.  The closest column in the physics grid will be used.
+Default: none
+</entry>
+
+<entry id="state_debug_checks" type="logical"  category="phys_debug"
+       group="phys_ctl_nl" valid_values="">
+If set to .true., turns on extra validation of physics_state objects
+in physics_update. Used mainly to track down which package is the
+source of invalid data in state.
+Default: .false.
+</entry>
+
+
+<!-- Planetary Boundary Layer and Vertical Diffusion -->
+
+<entry id="srf_flux_avg" type="integer" category="pbl"
+       group="phys_ctl_nl" valid_values="0,1" >
+Switch to turn on adjustment of the surface fluxes to reduce instabilities
+in the surface layer.  Set to 1 to turn on the adjustments.
+Default: 0
+</entry>
+
+<entry id="eddy_scheme" type="char*16" category="pbl"
+       group="phys_ctl_nl" valid_values="HB,diag_TKE,HBR,CLUBB_SGS" >
+Type of eddy scheme employed by the vertical diffusion package.  'HB' for
+Holtslag and Boville; 'diag_TKE' for diagnostic tke version of Grenier and
+Bretherton; 'HBR' for Rasch modified version of 'HB'.
+Default: set by build-namelist
+</entry>
+
+<entry id="do_hb_above_clubb" type="logical" category="pbl"
+       group="phys_ctl_nl" valid_values="" >
+Logical: If True activate Holtslag and Boville vertical diffusion scheme where CLUBB is not active
+         (note that CLUBB top is dynamic in each column)
+Default: Set by build-namelist.
+</entry>
+
+<!-- Convective Scavenging -->
+
+<entry id="convproc_do_aer" type="logical"  category="conv"
+       group="phys_ctl_nl" valid_values="" >
+Switch to use new convective scavenging for modal aerosols.  This scheme
+replaces the call to ZM's convtran for the the modal aerosol number and
+mass mixing ratio constituents.
+Default: .false.
+</entry>
+
+<entry id="convproc_do_gas" type="logical"  category="conv"
+       group="aerosol_convproc_opts" valid_values="" >
+Switch to turn on / off trace gas tendencies due to the MAM
+convective cloud processing scheme.
+Default: .false.
+</entry>
+
+<entry id="deepconv_wetdep_history" type="logical"  category="conv"
+       group="aerosol_convproc_opts" valid_values="" >
+Switch to turn on / off default history fields associated with aerosol
+wet deposition fluxes as computed in the MAM convective cloud processing scheme.
+Default: .true.
+</entry>
+
+<entry id="convproc_do_deep" type="logical"  category="conv"
+       group="aerosol_convproc_opts" valid_values="" >
+Switch to turn on / off deep convection in the MAM convective
+cloud processing scheme.
+Default: .true.
+</entry>
+
+<entry id="convproc_do_shallow" type="logical"  category="conv"
+       group="aerosol_convproc_opts" valid_values="" >
+Switch to turn on / off shallow convection in the MAM convective
+cloud processing scheme.
+Default: .false.
+</entry>
+
+<entry id="convproc_do_evaprain_atonce" type="logical"  category="conv"
+       group="aerosol_convproc_opts" valid_values="" >
+Switch to control when aerosols are released by rain re-evaporation in wet removal and redistribution
+of aerosol mass in modes. If FALSE then aerosols are immediately released back to its original mode
+from the rain as the rain evaporates. If TRUE the aerosols are released only when the rain totally
+evaporates and the mass of given aerosol components is released back in the most coarse mode for
+such component. For example, dust, sea salt and sulfate aerosols released by the rain evaporation are
+redistributed to coarse mode aerosol mass.  Also, released POM, SOA and BC mass are redistributed into
+accumulated mode aerosol mass.
+Default: .false.
+</entry>
+
+<entry id="convproc_pom_spechygro" type="real" category="conv"
+       group="aerosol_convproc_opts" valid_values="" >
+Hygroscopicity of primary organic mater used in MAM convective cloud processing scheme.
+Set to -1 to use the values defined in the physical properties file.
+Default: -1
+</entry>
+
+<entry id="convproc_wup_max" type="real" category="conv"
+       group="aerosol_convproc_opts" valid_values="" >
+Maximum updraft velocity (m/s) in MAM convective cloud processing scheme.
+Default: 4 m/s
+</entry>
+
+<!-- Diagnostics -->
+<entry id="thermo_budget_histfile_num" type="integer"  category="diagnostics"
+       group="thermo_budget_nl" valid_values="1,2,3,4,5,6,7,8,9,10" >
+History tape number thermo budget output is written to.
+Default: 1
+</entry>
+
+<entry id="thermo_budget_history" type="logical"  category="diagnostics"
+       group="thermo_budget_nl" valid_values="" >
+Produce output for the energy budget diagnostic package.
+Default: .false.
+</entry>
+
+<entry id="history_amwg" type="logical"  category="diagnostics"
+       group="phys_ctl_nl" valid_values="" >
+Produce output for the AMWG diagnostic package.
+Default: .true.
+</entry>
+
+<entry id="history_vdiag" type="logical"  category="diagnostics"
+       group="phys_ctl_nl" valid_values="" >
+Produce output for the AMWG variability diagnostics.
+Default: .false.
+</entry>
+
+<entry id="history_aerosol" type="logical"  category="diagnostics"
+       group="phys_ctl_nl" valid_values="" >
+Switch for diagnostic output of the aerosol tendencies
+Default: .false.
+</entry>
+
+<entry id="history_aero_optics" type="logical"  category="diagnostics"
+       group="phys_ctl_nl" valid_values="" >
+Switch for diagnostic output of the aerosol optics
+Default: .false.
+</entry>
+
+<entry id="history_eddy" type="logical"  category="diagnostics"
+       group="phys_ctl_nl" valid_values="" >
+Switch for diagnostic output of eddy variables
+Default: .false.
+</entry>
+
+<entry id="history_budget" type="logical"  category="diagnostics"
+       group="phys_ctl_nl" valid_values="" >
+Switch for cam4 T/Q budget diagnostic output
+Default: .false.
+</entry>
+
+<entry id="history_budget_histfile_num" type="integer"  category="diagnostics"
+       group="phys_ctl_nl" valid_values="1,2,3,4,5,6" >
+History tape number T/Q budget output is written to.
+Default: 1
+</entry>
+
+<entry id="history_waccm" type="logical"  category="diagnostics"
+       group="phys_ctl_nl" valid_values="" >
+Switch for diagnostic output used primarily for WACCM runs.
+Default: .true. if WACCM physics is on, .false. otherwise.
+</entry>
+
+<entry id="history_waccmx" type="logical"  category="diagnostics"
+       group="phys_ctl_nl" valid_values="" >
+Switch for diagnostic output used primarily for WACCM-X runs.
+Default: .true. if WACCM-X is on, .false. otherwise.
+</entry>
+
+<entry id="history_chemistry" type="logical"  category="diagnostics"
+       group="phys_ctl_nl" valid_values="" >
+Switch for diagnostics specific to the current chemistry package or
+configuration.
+Default: .true.
+</entry>
+
+<entry id="history_carma" type="logical"  category="diagnostics"
+       group="phys_ctl_nl" valid_values="" >
+Switch for diagnostics specific to the current CARMA model.
+Default: .false.
+</entry>
+
+<entry id="history_carma_srf_flx" type="logical"  category="diagnostics"
+       group="phys_ctl_nl" valid_values="" >
+Switch for diagnostics specific to the current CARMA model.
+Default: .false.
+</entry>
+
+<entry id="history_clubb" type="logical"  category="diagnostics"
+       group="phys_ctl_nl" valid_values="" >
+Switch for diagnostics specific to CLUBB.
+Default: .true.
+</entry>
+
+<entry id="history_cesm_forcing" type="logical"  category="diagnostics"
+       group="phys_ctl_nl" valid_values="" >
+Switch to turn on/off default output specific to CESM forcings.
+Default: .false.
+</entry>
+
+<entry id="history_dust" type="logical"  category="diagnostics"
+       group="phys_ctl_nl" valid_values="" >
+Switch for diagnostics specific to dust.
+Default: .false.
+</entry>
+
+<entry id="history_scwaccm_forcing" type="logical"  category="diagnostics"
+       group="phys_ctl_nl" valid_values="" >
+Switch to turn on/off default output specific to WACCM-SC forcings.
+Default: .false.
+</entry>
+
+<entry id="history_chemspecies_srf" type="logical"  category="diagnostics"
+       group="phys_ctl_nl" valid_values="" >
+Switch to turn on/off default output chemical species mixing ratios in the surface layer.
+Default: .false.
+</entry>
+
+<entry id="offline_driver" type="logical" category="offline_unit_driver"
+       group="phys_ctl_nl" valid_values="" >
+True when model is configured to use an offline driver.
+Default: Set by build-namelist.
+</entry>
+
+<entry id="atm_dep_flux" type="logical" category="fluxes"
+       group="phys_ctl_nl" valid_values="" >
+If FALSE then CAM will set the deposition fluxes to zero before sending
+them to the coupler.  A side effect of setting the
+variable {{ hilight }}chem_rad_passive{{ closehilight }} to TRUE is that this variable
+will be set to FALSE (the deposition fluxes must be set to zero in order
+for the chemistry not to impact the climate).
+Default: TRUE
+</entry>
+
+<entry id="cam_snapshot_before_num" type="integer"  category="diagnostics"
+       group="phys_ctl_nl" valid_values="" >
+History file number for before snapshots for CAM snapshot
+Default:
+</entry>
+
+<entry id="cam_snapshot_after_num" type="integer"  category="diagnostics"
+       group="phys_ctl_nl" valid_values="" >
+History file number for after snapshots for CAM snapshot
+Default:
+</entry>
+
+<entry id="cam_take_snapshot_before" type="char*32"  category="diagnostics"
+       group="phys_ctl_nl" valid_values="chem_emissions,aoa_tracers_timestep_tend,co2_cycle_set_ptend,chem_timestep_tend,orographic_form_drag_stress,vertical_diffusion_section,aero_model_drydep,gw_tend,qbo_relax,iondrag_calc_section,physics_dme_adjust,physics_dme_adjust,dadadj_tend,convect_deep_tend,convect_shallow_tend,convect_diagnostics_calc,macrop_driver_tend,clubb_tend_cam,microp_section,microp_driver_tend_subcol,aero_model_wetdep,radiation_tend,held_suarez_tend,kessler_tend,thatcher_jablonowski_precip_tend,rk_stratiform_tend,rayleigh_friction_tend,user_set" >
+Name of parameterization to take snapshot before running
+user_set is used when a user inserts a call to cam_snapshot_all_outfld
+  using cam_snapshot_before_num as the first argument.
+Default: Unused
+</entry>
+
+<entry id="cam_take_snapshot_after" type="char*32"  category="diagnostics"
+       group="phys_ctl_nl" valid_values="chem_emissions,aoa_tracers_timestep_tend,co2_cycle_set_ptend,chem_timestep_tend,orographic_form_drag_stress,vertical_diffusion_section,aero_model_drydep,gw_tend,qbo_relax,iondrag_calc_section,physics_dme_adjust,physics_dme_adjust,dadadj_tend,convect_deep_tend,convect_shallow_tend,convect_diagnostics_calc,macrop_driver_tend,clubb_tend_cam,microp_section,microp_driver_tend_subcol,aero_model_wetdep,radiation_tend,held_suarez_tend,kessler_tend,thatcher_jablonowski_precip_tend,rk_stratiform_tend,rayleigh_friction_tend,user_set" >
+Name of parameterization to take snapshot after running
+user_set is used when a user inserts a call to cam_snapshot_all_outfld
+  using cam_snapshot_after_num as the first argument.
+Default: Unused
+</entry>
+
+<!-- Radiation -->
+<entry id="radiation_scheme" type="char*16" category="radiation"
+       group="phys_ctl_nl" valid_values="rrtmgp,rrtmg,camrt" >
+Type of radiation scheme employed.
+Default: set by build-namelist
+</entry>
+
+<entry id="conv_water_in_rad" type="integer" category="radiation"
+       group="conv_water_nl" valid_values="0,1,2" >
+Convective water used in radiation?
+0 ==> No
+1 ==> Yes - Arithmetic average.
+2 ==> Yes - Average in emissivity.
+Default: set by build-namelist
+</entry>
+
+<entry id="conv_water_frac_limit" type="real" category="radiation"
+       group="conv_water_nl" valid_values="" >
+Lower limit of cumulus cloud fraction.
+Default: set by build-namelist
+</entry>
+
+<entry id="use_rad_uniform_angle" type="logical" category="radiation"
+       group="radiation_nl" valid_values="" >
+If true, use a uniform angle for the calculation of coszrs within radiation
+Default: set by build-namelist.
+</entry>
+
+<entry id="rad_uniform_angle" type="real" category="radiation"
+       group="radiation_nl" valid_values="" >
+The angle (in radians) to use in the calculation of coszrs within radiation
+Default: set by build-namelist.
+</entry>
+
+<entry id="absems_data" type="char*256" input_pathname="abs" category="radiation"
+       group="radiation_nl" valid_values="" >
+Full pathname of absorption/emission dataset.  Used only by camrt scheme.
+It consists of terms used for determining the absorptivity and
+emissivity of water vapor in the longwave parameterization of radiation.
+Default: set by build-namelist.
+</entry>
+
+<entry id="iradae" type="integer"  category="radiation"
+       group="radiation_nl" valid_values="">
+Frequency of absorptivity/emissivity calculations in time steps (if
+positive) or model hours (if negative).  To avoid having the abs/ems values
+saved on the restart output, make sure that the interval of the abs/ems
+calculation evenly divides the restart interval.
+Default: -12
+</entry>
+
+<entry id="iradlw" type="integer"  category="radiation"
+       group="radiation_nl" valid_values="">
+Frequency of long-wave radiation calculation in timesteps (if positive) or
+model hours (if negative).
+Default: -1
+</entry>
+
+<entry id="iradsw" type="integer"  category="radiation"
+       group="radiation_nl" valid_values="">
+Frequency of short-wave radiation calculation in timesteps (if positive) or
+model hours (if negative).
+Default: -1
+</entry>
+
+<entry id="irad_always" type="integer"  category="radiation"
+       group="radiation_nl" valid_values="">
+Specifies length of time in timesteps (positive) or hours (negative) SW/LW
+radiation will be run for every timestep from the start of an initial run.
+Default: 0
+</entry>
+
+<entry id="spectralflux" type="logical"  category="radiation"
+       group="radiation_nl" valid_values="" >
+Return fluxes per band in addition to the total fluxes.
+Default: FALSE
+</entry>
+
+<entry id="graupel_in_rad" type="logical"  category="radiation"
+       group="radiation_nl" valid_values="" >
+Calculate radiative effect of graupel/hail (using snow optics)
+Default: FALSE
+</entry>
+
+<entry id="p_top_for_equil_rad" type="real"  category="radiation"
+       group="radheat_nl" valid_values="" >
+Top valid pressure level LTE radiation scheme
+Default: 1.0 for WACCM/WACCMX
+         2. for all other RRTMGP runs
+         0.0 for all other runs
+</entry>
+
+<entry id="p_top_for_radmrg" type="real"  category="radiation"
+       group="radheat_nl" valid_values="" >
+Top pressure level LTE/non-LTE merger region
+</entry>
+
+<entry id="p_bot_for_radmrg" type="real"  category="radiation"
+       group="radheat_nl" valid_values="" >
+Bottom pressure level LTE/non-LTE merger region
+</entry>
+
+<entry id="qrsmlt_scaling" type="real"  category="radiation"
+       group="radheat_nl" valid_values="" >
+Scaling factor for simplified QRS MLT heating in CAM
+</entry>
+
+<entry id="use_rad_dt_cosz" type="logical"  category="radiation"
+       group="radiation_nl" valid_values="" >
+If true, then average the zenith angle over the radiation timestep rather
+than using instantaneous values.
+Default: FALSE
+</entry>
+
+<entry id="mode_defs" type="char*256(120)"  category="radiation"
+       group="rad_cnst_nl" valid_values="" >
+Definitions for the aerosol modes that may be used in the rad_climate and
+rad_diag_* variables.
+Default: set by build-namelist
+</entry>
+
+<entry id="bin_defs" type="char*256(640)"  category="radiation"
+       group="rad_cnst_nl" valid_values="" >
+Definitions for the aerosol bins that may be used in the rad_climate and
+rad_diag_* variables.
+Default: set by build-namelist
+</entry>
+
+<entry id="rad_climate" type="char*256(n_rad_cnst)"  category="radiation"
+       group="rad_cnst_nl" valid_values="" >
+A list of the radiatively active species, i.e., species that affect the
+climate simulation via the radiative heating rate calculation.
+Default: set by build-namelist
+</entry>
+
+<entry id="rad_diag_1" type="char*256(n_rad_cnst)"  category="radiation"
+       group="rad_cnst_nl" valid_values="" >
+A list of species to be used in the first diagnostic radiative heating rate
+calculation.  These species are not the ones affecting the climate
+simulation.  This is a hook for performing radiative forcing calculations.
+Default: none
+</entry>
+
+<entry id="rad_diag_2" type="char*256(n_rad_cnst)"  category="radiation"
+       group="rad_cnst_nl" valid_values="" >
+Analogous to rad_diag_1, but for the 2nd diagnostic calculation.
+Default: none
+</entry>
+
+<entry id="rad_diag_3" type="char*256(n_rad_cnst)"  category="radiation"
+       group="rad_cnst_nl" valid_values="" >
+Analogous to rad_diag_1, but for the 3rd diagnostic calculation.
+Default: none
+</entry>
+
+<entry id="rad_diag_4" type="char*256(n_rad_cnst)"  category="radiation"
+       group="rad_cnst_nl" valid_values="" >
+Analogous to rad_diag_1, but for the 4th diagnostic calculation.
+Default: none
+</entry>
+
+<entry id="rad_diag_5" type="char*256(n_rad_cnst)"  category="radiation"
+       group="rad_cnst_nl" valid_values="" >
+Analogous to rad_diag_1, but for the 5th diagnostic calculation.
+Default: none
+</entry>
+
+<entry id="rad_diag_6" type="char*256(n_rad_cnst)"  category="radiation"
+       group="rad_cnst_nl" valid_values="" >
+Analogous to rad_diag_1, but for the 6th diagnostic calculation.
+Default: none
+</entry>
+
+<entry id="rad_diag_7" type="char*256(n_rad_cnst)"  category="radiation"
+       group="rad_cnst_nl" valid_values="" >
+Analogous to rad_diag_1, but for the 7th diagnostic calculation.
+Default: none
+</entry>
+
+<entry id="rad_diag_8" type="char*256(n_rad_cnst)"  category="radiation"
+       group="rad_cnst_nl" valid_values="" >
+Analogous to rad_diag_1, but for the 8th diagnostic calculation.
+Default: none
+</entry>
+
+<entry id="rad_diag_9" type="char*256(n_rad_cnst)"  category="radiation"
+       group="rad_cnst_nl" valid_values="" >
+Analogous to rad_diag_1, but for the 9th diagnostic calculation.
+Default: none
+</entry>
+
+<entry id="rad_diag_10" type="char*256(n_rad_cnst)"  category="radiation"
+       group="rad_cnst_nl" valid_values="" >
+Analogous to rad_diag_1, but for the 10th diagnostic calculation.
+Default: none
+</entry>
+
+
+<entry id="rad_data_output" type="logical"   category="radiation"
+       group="rad_data_nl" valid_values="" >
+output data needed for off-line radiation calculations
+Default: FALSE
+</entry>
+
+<entry id="rad_data_histfile_num" type="integer"   category="radiation"
+       group="rad_data_nl" valid_values="" >
+History tape number radiation driver output data is written to.
+Default: 0
+</entry>
+
+<entry id="rad_data_avgflag" type="char*1"   category="radiation"
+       group="rad_data_nl" valid_values="" >
+Averaging flag for radiation driver output data.
+Default: 'A'
+</entry>
+
+<entry id="rad_data_fdh" type="logical"  category="offline_unit_driver"
+       group="rad_data_nl" valid_values="" >
+Switch to turn on Fixed Dynamical Heating in the offline radiation tool (PORT).
+Default: false
+</entry>
+
+<!-- RRTMGP -->
+
+<entry id="rrtmgp_coefs_lw_file" type="char*256" category="radiation"
+       group="radiation_nl" valid_values="" >
+Relative pathname for LW gas optics coefficients for RRTMGP.  This data is
+part of the RRTMGP source, thus this pathname is relative to the root source
+code directory for the CAM component.
+Default: set by build-namelist.
+</entry>
+
+<entry id="rrtmgp_coefs_sw_file" type="char*256" category="radiation"
+       group="radiation_nl" valid_values="" >
+Relative pathname for SW gas optics coefficients for RRTMGP.  This data is
+part of the RRTMGP source, thus this pathname is relative to the root source
+code directory for the CAM component.
+Default: set by build-namelist.
+</entry>
+
+
+<!-- Aerosol and cloud optics -->
+
+<entry id="water_refindex_file" type="char*256" input_pathname="abs" category="radiation"
+       group="aerosol_optics_nl" valid_values="" >
+Full pathname of dataset for water refractive indices used in modal aerosol optics
+Default: none
+</entry>
+
+
+<entry id="drydep_srf_file" type="char*256" input_pathname="abs" category="cam_chem"
+       group="chem_inparm" valid_values="">
+Dry deposition surface values interpolated to model grid, required for unstructured atmospheric grids
+with modal chemistry.
+Default: none
+</entry>
+
+<entry id="oldcldoptics" type="logical"  category="radiation"
+       group="rad_cnst_nl" valid_values="" >
+filepath and name for ice optics data for rrtmg
+Default: none
+</entry>
+
+<entry id="liqcldoptics" type="char*32"  category="radiation"
+       group="rad_cnst_nl" valid_values="slingo,gammadist" >
+filepath and name for ice optics data for rrtmg
+Default: none
+</entry>
+
+<entry id="icecldoptics" type="char*32"  category="radiation"
+       group="rad_cnst_nl" valid_values="ebertcurry,mitchell" >
+filepath and name for ice optics data for rrtmg
+Default: none
+</entry>
+
+<entry id="iceopticsfile" type="char*256" input_pathname="abs"  category="radiation"
+       group="rad_cnst_nl" valid_values="" >
+filepath and name for ice optics data for rrtmg
+Default: none
+</entry>
+
+<entry id="liqopticsfile" type="char*256" input_pathname="abs"  category="radiation"
+       group="rad_cnst_nl" valid_values="" >
+filepath and name for liquid cloud (gamma distributed) optics data for rrtmg
+Default: none
+</entry>
+
+
+<!-- Rayleigh Friction Parameterization -->
+
+<entry id="rayk0" type="integer" category="rayleigh_friction"
+       group="rayleigh_friction_nl" valid_values="">
+Variable to specify the vertical index at which the
+Rayleigh friction term is centered (the peak value).
+Default: 2
+</entry>
+
+<entry id="raykrange" type="real" category="rayleigh_friction"
+       group="rayleigh_friction_nl" valid_values="">
+Rayleigh friction parameter to determine the width of the profile.  If set
+to 0 then a width is chosen by the algorithm (see rayleigh_friction.F90).
+Default: 0.
+</entry>
+
+<entry id="raytau0" type="real" category="rayleigh_friction"
+       group="rayleigh_friction_nl" valid_values="">
+Rayleigh friction parameter to determine the approximate value of the decay
+time (days) at model top.  If 0.0 then no Rayleigh friction is applied.
+Default: 0.
+</entry>
+
+
+<!-- Single column mode -->
+
+<entry id="iopfile" type="char*128" input_pathname="abs" category="scam"
+       group="scam_nl" valid_values="" >
+Full pathname of IOP dataset.
+Default: set by build-namelist.
+</entry>
+
+<entry id="scm_cambfb_mode" type="logical" category="scam"
+       group="scam_nl" valid_values="">
+Column bfb match with cam generated IOP.
+Default: FALSE
+</entry>
+
+<entry id="scm_backfill_iop_w_init" type="logical" category="scam"
+       group="scam_nl" valid_values="">
+Backfill missing IOP values for omega/T/q/Ps from initial data file.
+Default: FALSE
+</entry>
+
+<entry id="scm_crm_mode" type="logical" category="scam"
+       group="scam_nl" valid_values="">
+Column radiation mode.
+Default: FALSE
+</entry>
+
+<entry id="scm_iop_tg" type="logical" category="scam"
+       group="scam_nl" valid_values="">
+Use the specified surface properties.
+Default: FALSE
+</entry>
+
+<entry id="scm_clubb_iop_name" type="char*200" category="scam"
+       group="scam_nl" valid_values="">
+IOP name for CLUBB running in single column mode
+Default: ""
+</entry>
+
+<entry id="scm_relaxation" type="logical" category="scam"
+       group="scam_nl" valid_values="">
+Use relaxation.
+Default: FALSE
+</entry>
+
+<entry id="scm_relax_fincl" type="char*24(1000)"  category="scam"
+       group="scam_nl" valid_values="" >
+List of fields that will be relaxed to obs
+Default: none
+</entry>
+
+<entry id="scm_relax_linear" type="logical" category="scam"
+       group="scam_nl" valid_values="">
+Use relaxation. Linearly interpolate the timescale within specified
+pressure range. (bpm)
+Default: FALSE
+</entry>
+
+<entry id="scm_relax_top_p" type="real" category="scam"
+       group="scam_nl" valid_values="">
+Upper most pressure that will be relaxed.
+Default: 1e36
+</entry>
+
+<entry id="scm_relax_bot_p" type="real" category="scam"
+       group="scam_nl" valid_values="">
+Lower most pressure that will be relaxed.
+Default: -1e36
+</entry>
+
+<entry id="scm_relax_tau_sec" type="real" category="scam"
+       group="scam_nl" valid_values="">
+SCAM relaxation time constant in seconds
+Default: 10800
+</entry>
+
+<entry id="scm_relax_tau_top_sec" type="real" category="scam"
+       group="scam_nl" valid_values="">
+SCAM relaxation time constant in seconds that will be used at
+top of pressure range (i.e., the smaller pressure value). Will
+be used from top of pressure range to model top.
+Default: 10800
+</entry>
+
+<entry id="scm_relax_tau_bot_sec" type="real" category="scam"
+       group="scam_nl" valid_values="">
+SCAM relaxation time constant in seconds that will be used at
+bottom of pressure range (i.e., the larger pressure value).
+Default: 10800
+</entry>
+
+<entry id="scm_use_obs_T" type="logical" category="scam"
+       group="scam_nl" valid_values="">
+Use the SCAM-IOP specified T instead of using forecasted T at each time step.
+Default: FALSE
+</entry>
+
+<entry id="scm_use_obs_uv" type="logical" category="scam"
+       group="scam_nl" valid_values="">
+Use the SCAM-IOP specified u,v instead of using forecasted u,v at each time step.
+Default: TRUE
+</entry>
+
+<entry id="scm_zadv_T"  type="char*16" category="scam"
+       group="scam_nl" valid_values="iop,eulc,off">
+Use specific type of vertical advection for T.  Possible choices are 'iop', 'eulc' and 'off'
+Default: 'eulc'
+</entry>
+
+<entry id="scm_zadv_uv" type="char*16" category="scam"
+       group="scam_nl" valid_values="iop,eulc,off">
+Use specific type of vertical advection for uv. Possible choices are 'iop', 'eulc' and 'off'
+Default: 'eulc'
+</entry>
+
+<entry id="scm_zadv_q" type="char*16" category="scam"
+       group="scam_nl" valid_values="iop,eulc,slt,off">
+Use specific type of vertical advection for q. Possible choices are 'iop', 'eulc', 'slt'  and 'off'
+Default: 'slt'
+</entry>
+
+<entry id="scm_iop_lhflxshflxTg" type="logical" category="scam"
+       group="scam_nl" valid_values="">
+Use the SCAM-IOP specified surface LHFLX/SHFLX/ustar/Tg instead of using internally-computed values
+Default: FALSE
+</entry>
+
+<entry id="scm_use_obs_qv" type="logical" category="scam"
+       group="scam_nl" valid_values="">
+Use the SCAM-IOP specified observed water vapor at each time step instead of forecast value
+Default: FALSE
+</entry>
+
+<entry id="scm_use_3dfrc" type="logical" category="scam"
+       group="scam_nl" valid_values="">
+Use the SCAM-IOP 3d forcing if true, use combination of dycore vertical advection and iop horiz advection if false
+Default:False
+</entry>
+
+<entry id="scm_force_latlon" type="logical" category="scam"
+       group="scam_nl" valid_values="">
+Force scam to use the lat lon fields specified in the scam namelist not what is closest to IOP avail lat lon
+Default: FALSE
+</entry>
+
+<!-- Solar Parameters -->
+
+<entry id="solar_const" type="real" category="solar"
+       group="solar_data_opts" valid_values="">
+Total solar irradiance (W/m2).
+Default: 1361.27
+</entry>
+
+<entry id="solar_irrad_data_file" type="char*256" input_pathname="abs" category="solar"
+       group="solar_data_opts" valid_values="" >
+Full pathname of dataset for file that contains the solar photon energy spectra or TSI data
+as a time series
+Default: set by build-namelist
+</entry>
+
+<entry id="solar_euv_data_file" type="char*256" input_pathname="abs" category="solar"
+       group="solar_data_opts" valid_values="" >
+Full pathname of dataset for file that contains the solar EUV data
+as a time series
+Default: none
+</entry>
+
+<entry id="solar_parms_data_file" type="char*256" input_pathname="abs" category="waccm"
+       group="solar_data_opts" valid_values="" >
+Full pathname of time-variant dataset for the time-dependent proxies for
+solar and geomagnetic activity( F10.7, F10.7a, Kp, Ap ).
+Default: set by build-namelist.
+</entry>
+
+<entry id="solar_wind_data_file" type="char*256" input_pathname="abs" category="waccm"
+       group="solar_data_opts" valid_values="" >
+Full pathname of time-variant  dataset for the time-dependent solar wind parameters
+(solar wind velocity and density; IMF By and Bz components).
+Default: set by build-namelist.
+</entry>
+
+<entry id="solar_data_type" type="char*8" category="solar"
+       group="solar_data_opts" valid_values="FIXED,SERIAL" >
+Type of time interpolation for data in {{ hilight }}solar_irrad_data_file{{ closehilight }}.
+Can be set to "FIXED" or "SERIAL".
+Default: SERIAL
+</entry>
+
+<entry id="solar_data_ymd" type="integer"  category="solar"
+       group="solar_data_opts" valid_values="" >
+If {{ hilight }}solar_data_type{{ closehilight }} is "FIXED" then solar_data_ymd
+is the date the solar data is fixed to.  If {{ hilight }}solar_data_type{{ closehilight }}
+is "SERIAL" the solar_data_ymd is the start date of the time series
+of solar data.
+Format: YYYYMMDD
+Default: none
+</entry>
+
+<entry id="solar_data_tod" type="integer"  category="solar"
+       group="solar_data_opts" valid_values="" >
+Seconds of the day corresponding to {{ hilight }}solar_data_ymd{{ closehilight }}
+Default: current model time of day
+</entry>
+
+<entry id="solar_htng_spctrl_scl" type="logical"  category="solar"
+       group="solar_data_opts" valid_values="" >
+Use spectral scaling in the radiation heating
+Default: set by build-namelist
+</entry>
+
+<!-- Test Tracers -->
+
+<entry id="test_tracer_names" type="char*16(30)" category="test_tracers"
+       group="test_tracers_nl" valid_values="" >
+User can specify names for test tracers to be read from the initial file.
+The number of names specified should be given as the value of the -nadv_tt
+option to configure.
+Default: ''
+</entry>
+
+<entry id="test_tracer_num" type="logical" category="test_tracers"
+       group="test_tracers_nl" valid_values="" >
+This variable should not be set by the user.  If configure has been invoked
+with the '-nadv_tt N' option then build-namelist will set this variable to
+the value N.  If {{ hilight }}test_tracer_names{{ closehilight }} have been specified
+then N should be the number of names supplied.
+If {{ hilight }}test_tracer_names{{ closehilight }} have not been specified, then the
+tracer_suite module generates the tracer names and supplies the initial
+values.
+Default: set by configure
+</entry>
+
+<entry id="aoa_tracers_flag" type="logical" category="test_tracers"
+       group="aoa_tracers_nl" valid_values="" >
+If true age of air tracers are included.  This variable should not be set
+by the user.  It will be set by build-namelist to be consistent with the
+'-age_of_air_trcs' argument specified to configure.
+Default: set by configure
+</entry>
+
+<entry id="aoa_read_from_ic_file" type="logical" category="test_tracers"
+       group="aoa_tracers_nl" valid_values="" >
+If true age of air tracers are read from the initial conditions file.
+If this is not specified then they are not read from IC file.
+Default: TRUE
+</entry>
+
+<!-- Time step -->
+
+<entry id="dtime" type="integer"  category="time_mgr"
+       group="camexp" valid_values="">
+The length (in seconds) of the atm time step, i.e., the driver calls the
+atm component once every dtime seconds.  This is also the coupling interval
+between the dynamics and physics packages.  This variable is not actually
+used in the atm model, but rather is used by build-namelist to set the
+value of {{ hilight }}atm_cpl_dt{{ closehilight }}.  So it will have an effect only
+when running CAM using standalone scripts.  The CESM scripts have their own
+method for setting {{ hilight }}atm_cpl_dt{{ closehilight }}.
+Default: is resolution and dycore dependent and is set by build-namelist.
+</entry>
+
+<!-- Topography -->
+
+<entry id="bnd_topo" type="char*256" input_pathname="abs" category="topo"
+       group="cam_initfiles_nl" valid_values="" >
+Full pathname of time-invariant boundary dataset for topography fields.
+Default: set by build-namelist.
+</entry>
+
+<entry id="use_topo_file" type="logical" category="topo"
+       group="cam_initfiles_nl" valid_values="" >
+Setting use_topo_file=.false. allows the user to specify that PHIS, SGH,
+SGH30, and LANDM_COSLAT are all zero without having to supply a topo file
+full of zeros.
+Default: set by build-namelist.
+</entry>
+
+<!-- Tropopause -->
+
+<entry id="tropopause_climo_file" type="char*256" input_pathname="abs" category="tropo"
+       group="tropopause_nl" valid_values="" >
+Full pathname of boundary dataset for tropopause climatology.
+Default: set by build-namelist.
+</entry>
+
+<!-- CAM-CHEM -->
+
+<entry id="ipcc_aircraft_emis" type="logical" category="cam_chem"
+       group="camexp" valid_values="" >
+Flag to tell build-namelist to use time-dependent external forcing
+files for the aircraft emissions.
+Default: FALSE
+</entry>
+
+<entry id="chem_rad_passive" type="logical" category="cam_chem"
+       group="chem_inparm" valid_values="" >
+Flag to set rad_climate variable so that the chemical tracers are
+radiatively passive.
+Default: FALSE
+</entry>
+
+<entry id="gas_wetdep_method" type="char*3" category="cam_chem"
+       group="wetdep_inparm" valid_values="MOZ,NEU,OFF" >
+Wet deposition method used
+  MOZ --> mozart scheme is used
+  NEU --> J Neu's scheme is used
+  OFF --> wet deposition is turned off
+Default: NEU
+</entry>
+
+<entry id="gas_wetdep_list" type="char*16(1000)" category="cam_chem"
+       group="wetdep_inparm" valid_values="" >
+List of gas-phase species that undergo wet deposition via the wet deposition scheme.
+Default: NONE
+</entry>
+
+<entry id="gas_wetdep_ice_uptake_list" type="char*16(1000)" category="cam_chem"
+       group="wetdep_inparm" valid_values="" >
+List of gas-phase species that undergo ice scavenging in the NEU
+wet deposition scheme.
+Default: set by build-namelist
+</entry>
+
+<!-- Short-Lived Halogen (SLH) Namelist Definitions -->
+
+<entry id="SSAdehal_ScalingFactor" type="real" category="cam_chem"
+       group="slh_nl" valid_values="" >
+Scaling-factor for SLH dehalogenation reaction (XONO2,XNO2,HOX) on Sea-Salt Aerosols.
+Default: set by build-namelist
+</entry>
+
+<entry id="SSAhno3_ScalingFactor" type="real" category="cam_chem"
+       group="slh_nl" valid_values="" >
+Scaling-factor for SLH acid displacement reaction (HNO3-->HCl) on Sea-Salt Aerosols.
+Default: set by build-namelist
+</entry>
+
+<entry id="SSAn2o5_ScalingFactor" type="real" category="cam_chem"
+       group="slh_nl" valid_values="" >
+Scaling-factor for SLH dinitrogen pentoxide reaction (N2O5-->HNO3+CLNO2) on Sea-Salt Aerosols
+Default: set by build-namelist.
+</entry>
+
+<entry id="LIQfraprx_ScalingFactor_I" type="real" category="cam_chem"
+       group="slh_nl" valid_values="" >
+Scaling-factor for SLH washout (Iodine) on liquid droplets based on Free-Regime Approx.
+Default: set by build-namelist
+</entry>
+
+<entry id="ICEfraprx_ScalingFactor_I" type="real" category="cam_chem"
+       group="slh_nl" valid_values="" >
+Scaling-factor for SLH washout (Iodine) on ice crystals based on Free-Regime Approx.
+Default: set by build-namelist
+</entry>
+
+<entry id="ICEfraprx_ScalingFactor_Br" type="real" category="cam_chem"
+       group="slh_nl" valid_values="" >
+Scaling-factor for SLH washout (Bromine) on ice crystals based on Free-Regime Approx.
+Default: set by build-namelist
+</entry>
+
+<entry id="modal_accum_coarse_exch" type="logical" category="cam_chem"
+       group="aerosol_nl" valid_values="" >
+Turns on accumulation to coarse mode exchange appropriate for the stratosphere.
+This also changes the default mode definitions (widths and edges) via default
+aerosol property input files.
+Default: FALSE
+</entry>
+
+<entry id="modal_strat_sulfate" type="logical" category="cam_chem"
+       group="aerosol_nl" valid_values="" >
+Turns on prognostic modal sulfate aerosols in the stratosphere.
+Default: FALSE
+</entry>
+
+<entry id="aer_wetdep_list" type="char*16(1000)" category="cam_chem"
+       group="aerosol_nl" valid_values="" >
+List of aerosol species that undergo wet deposition.
+Default: set by build-namelist.
+</entry>
+
+<entry id="SO4_sol_facti" type="real" category="cam_chem"
+       group="camexp" valid_values="" >
+In-cloud solubility factor used in SO4 wet removal
+Default: set by build-namelist.
+</entry>
+<entry id="SO4_sol_factb" type="real" category="cam_chem"
+       group="camexp" valid_values="" >
+Below-cloud solubility factor used in SO4 wet removal
+Default: set by build-namelist.
+</entry>
+<entry id="NH4_sol_facti" type="real" category="cam_chem"
+       group="camexp" valid_values="" >
+In-cloud solubility factor used in NH4 wet removal
+Default: set by build-namelist.
+</entry>
+<entry id="NH4_sol_factb" type="real" category="cam_chem"
+       group="camexp" valid_values="" >
+Below-cloud solubility factor used in NH4 wet removal
+Default: set by build-namelist.
+</entry>
+<entry id="NH4NO3_sol_facti" type="real" category="cam_chem"
+       group="camexp" valid_values="" >
+In-cloud solubility factor used in NH4NO3 wet removal
+Default: set by build-namelist.
+</entry>
+<entry id="NH4NO3_sol_factb" type="real" category="cam_chem"
+       group="camexp" valid_values="" >
+Below-cloud solubility factor used in NH4NO3 wet removal
+Default: set by build-namelist.
+</entry>
+<entry id="CB2_sol_facti" type="real" category="cam_chem"
+       group="camexp" valid_values="" >
+In-cloud solubility factor used in CB2 wet removal
+Default: set by build-namelist.
+</entry>
+<entry id="CB2_sol_factb" type="real" category="cam_chem"
+       group="camexp" valid_values="" >
+Below-cloud solubility factor used in CB2 wet removal
+Default: set by build-namelist.
+</entry>
+<entry id="OC2_sol_facti" type="real" category="cam_chem"
+       group="camexp" valid_values="" >
+In-cloud solubility factor used in OC2 wet removal
+Default: set by build-namelist.
+</entry>
+<entry id="OC2_sol_factb" type="real" category="cam_chem"
+       group="camexp" valid_values="" >
+Below-cloud solubility factor used in OC2 wet removal
+Default: set by build-namelist.
+</entry>
+<entry id="dust_sol_facti" type="real" category="cam_chem"
+       group="camexp" valid_values="" >
+In-cloud solubility factor used in wet removal of BULK dust
+Default: set by build-namelist.
+</entry>
+<entry id="dust_sol_factb" type="real" category="cam_chem"
+       group="camexp" valid_values="" >
+Below-cloud solubility factor used in wet removal of BULK dust
+Default: set by build-namelist.
+</entry>
+<entry id="sslt_sol_facti" type="real" category="cam_chem"
+       group="camexp" valid_values="" >
+In-cloud solubility factor used in wet removal of BULK sea salt
+Default: set by build-namelist.
+</entry>
+<entry id="sslt_sol_factb" type="real" category="cam_chem"
+       group="camexp" valid_values="" >
+Below-cloud solubility factor used in wet removal of BULK sea salt
+Default: set by build-namelist.
+</entry>
+
+<entry id="aer_drydep_list" type="char*16(1000)" category="cam_chem"
+       group="aerosol_nl" valid_values="" >
+List of aerosol species that undergo sediment (dry deposition).
+Default: set by build-namelist.
+</entry>
+
+<entry id="sol_factb_interstitial" type="real" category="cam_chem"
+       group="aero_wetdep_nl" valid_values="" >
+Tuning for below cloud scavenging of interstitial modal aerosols.
+Default: set by build-namelist.
+</entry>
+
+<entry id="sol_factic_interstitial" type="real" category="cam_chem"
+       group="aero_wetdep_nl" valid_values="" >
+Tuning for in-cloud scavenging of interstitial modal aerosols.
+Default: set by build-namelist.
+</entry>
+
+<entry id="sol_facti_cloud_borne" type="real" category="cam_chem"
+       group="aero_wetdep_nl" valid_values="" >
+Tuning for in-cloud scavenging of cloud-borne modal aerosols.
+Default: set by build-namelist.
+</entry>
+
+<entry id="seasalt_emis_scale" type="real" category="cam_chem"
+       group="aerosol_nl" valid_values="" >
+Tuning for seasalt_emis
+Default: set by build-namelist.
+</entry>
+
+<entry id="aer_sol_facti" type="real(1000)" category="cam_chem"
+       group="aerosol_nl" valid_values="" >
+In-cloud solubility factor used in BULK aerosol wet removal
+Default: set by build-namelist.
+</entry>
+
+<entry id="aer_sol_factb" type="real(1000)" category="cam_chem"
+       group="aerosol_nl" valid_values="" >
+Below-cloud solubility factor used in BULK aerosol wet removal
+Default: set by build-namelist.
+</entry>
+
+<entry id="aer_scav_coef" type="real(1000)" category="cam_chem"
+       group="aerosol_nl" valid_values="" >
+Scavenging coefficient used in BULK aerosol wet removal
+Default: set by build-namelist.
+</entry>
+
+<entry id="SO4_scav_coef" type="real(1000)" category="cam_chem"
+       group="camexp" valid_values="" >
+Scavenging coefficient used in the wet removal of SO4
+Default: set by build-namelist.
+</entry>
+
+<entry id="NH4_scav_coef" type="real(1000)" category="cam_chem"
+       group="camexp" valid_values="" >
+Scavenging coefficient used in the wet removal of NH4
+Default: set by build-namelist.
+</entry>
+
+<entry id="CB2_scav_coef" type="real(1000)" category="cam_chem"
+       group="camexp" valid_values="" >
+Scavenging coefficient used in the wet removal of CB2
+Default: set by build-namelist.
+</entry>
+
+<entry id="OC2_scav_coef" type="real(1000)" category="cam_chem"
+       group="camexp" valid_values="" >
+Scavenging coefficient used in the wet removal of OC2
+Default: set by build-namelist.
+</entry>
+
+<entry id="DST01_scav_coef" type="real(1000)" category="cam_chem"
+       group="camexp" valid_values="" >
+Scavenging coefficient used in the wet removal of DST01
+Default: set by build-namelist.
+</entry>
+
+<entry id="DST02_scav_coef" type="real(1000)" category="cam_chem"
+       group="camexp" valid_values="" >
+Scavenging coefficient used in the wet removal of DST02
+Default: set by build-namelist.
+</entry>
+
+<entry id="DST03_scav_coef" type="real(1000)" category="cam_chem"
+       group="camexp" valid_values="" >
+Scavenging coefficient used in the wet removal of DST03
+Default: set by build-namelist.
+</entry>
+
+<entry id="DST04_scav_coef" type="real(1000)" category="cam_chem"
+       group="camexp" valid_values="" >
+Scavenging coefficient used in the wet removal of DST04
+Default: set by build-namelist.
+</entry>
+
+<entry id="SSLT01_scav_coef" type="real(1000)" category="cam_chem"
+       group="camexp" valid_values="" >
+Scavenging coefficient used in the wet removal of SSLT01
+Default: set by build-namelist.
+</entry>
+
+<entry id="SSLT02_scav_coef" type="real(1000)" category="cam_chem"
+       group="camexp" valid_values="" >
+Scavenging coefficient used in the wet removal of SSLT02
+Default: set by build-namelist.
+</entry>
+
+<entry id="SSLT03_scav_coef" type="real(1000)" category="cam_chem"
+       group="camexp" valid_values="" >
+Scavenging coefficient used in the wet removal of SSLT03
+Default: set by build-namelist.
+</entry>
+
+<entry id="SSLT04_scav_coef" type="real(1000)" category="cam_chem"
+       group="camexp" valid_values="" >
+Scavenging coefficient used in the wet removal of SSLT04
+Default: set by build-namelist.
+</entry>
+
+<entry id="airpl_emis_file" type="char*256" input_pathname="abs" category="cam_chem"
+       group="chem_inparm" valid_values="" >
+Full pathname of boundary dataset for airplane emissions.
+Default: set by build-namelist.
+</entry>
+
+<entry id="depvel_lnd_file" type="char*256" input_pathname="abs" category="cam_chem"
+       group="chem_inparm" valid_values="" >
+Full pathname of dataset which contains land vegetation information used in modal aerosol deposition.
+Default: set by build-namelist.
+</entry>
+
+<entry id="dust_emis_fact" type="real" category="cam_chem"
+       group="dust_nl" valid_values="" >
+Tuning parameter for dust emissions.
+Default: set by build-namelist.
+</entry>
+
+<entry id="steady_state_ion_elec_temp" type="logical" category="waccmx"
+       group="ion_electron_temp_nl" valid_values="" >
+If TRUE a steady state solution is used to calculate electron and
+ion temperature.
+Default: TRUE
+</entry>
+
+<entry id="efield_hflux_file" type="char*256" input_pathname="abs" category="waccm_phys"
+       group="iondrag_nl" valid_values="" >
+Full pathname of dataset for coefficient data used in WACCM to calculate ion drag
+for high solar fluxes from the Scherliess low latitude electric potential model.
+Default: set by build-namelist.
+</entry>
+
+<entry id="efield_lflux_file" type="char*256" input_pathname="abs" category="waccm_phys"
+       group="iondrag_nl" valid_values="" >
+Full pathname of dataset for coefficient data used in WACCM to calculate ion drag
+for low solar fluxes from the Scherliess low latitude electric potential model.
+Default: set by build-namelist.
+</entry>
+
+<entry id="efield_potential_max" type="real" category="waccm_phys"
+       group="iondrag_nl" valid_values="" >
+Maximum cross cap electric potential used in Heelis high-latitude potential
+empirical model for WACCM ion drag and joule heating.
+Default: set by build-namelist (120 kV).
+</entry>
+
+<entry id="empirical_ion_velocities" type="logical" category="waccm_phys"
+       group="iondrag_nl" valid_values="" >
+Switch to turn on empirical ExB ion drift velocities model for use in ion drag
+parameterizations.  If this is false then it is assumed ion drift velocities are
+supplied by an active ionosphere model.
+Default: set by build-namelist.
+</entry>
+
+<entry id="electron_file" type="char*256" input_pathname="abs" category="waccm"
+       group="chem_inparm" valid_values="" >
+Full pathname of dataset for the neutral species absorption cross sections for EUV
+photo reactions producing electrons.
+Default: set by build-namelist.
+</entry>
+
+<entry id="srf_emis_type" type="char*32" category="cam_chem"
+       group="chem_inparm" valid_values="CYCLICAL,SERIAL,INTERP_MISSING_MONTHS,FIXED" >
+Type of time interpolation of emission datasets specified.
+Can be set to 'CYCLICAL', 'SERIAL', 'INTERP_MISSING_MONTHS', or 'FIXED'.
+by {{ hilight }}srf_emis_specifier{{ closehilight }}.
+Default: 'CYCLICAL'
+</entry>
+
+<entry id="srf_emis_cycle_yr" type="integer" category="cam_chem"
+       group="chem_inparm" valid_values="" >
+The  cycle year of the surface emissions data
+if {{ hilight }}srf_emis_type{{ closehilight }}  is 'CYCLICAL'.
+Format: YYYY
+Default: 0
+</entry>
+
+<entry id="srf_emis_fixed_ymd" type="integer" category="cam_chem"
+       group="chem_inparm" valid_values="" >
+The date at which the surface emissions are fixed
+if {{ hilight }}srf_emis_type{{ closehilight }} is 'FIXED'.
+Format: YYYYMMDD
+Default: 0
+</entry>
+
+<entry id="srf_emis_fixed_tod" type="integer" category="cam_chem"
+       group="chem_inparm" valid_values="" >
+The time of day (seconds) corresponding to {{ hilight }}srf_emis_fixed_ymd{{ closehilight }}
+at which the surface emissions are fixed
+if {{ hilight }}srf_emis_type{{ closehilight }} is 'FIXED'.
+Default: 0 seconds
+</entry>
+
+<entry id="euvac_file" type="char*256" input_pathname="abs" category="waccm"
+       group="chem_inparm" valid_values="" >
+Full pathname of dataset for EUVAC solar EUV model (0.05-121nm).
+Default: set by build-namelist.
+</entry>
+
+<entry id="ext_frc_cycle_yr" type="integer" category="cam_chem"
+       group="chem_inparm" valid_values="" >
+The  cycle year of the external forcings (3D emissions) data
+if {{ hilight }}ext_frc_type{{ closehilight }}  is 'CYCLICAL'.
+Format: YYYY
+Default: 0
+</entry>
+
+<entry id="ext_frc_fixed_ymd" type="integer" category="cam_chem"
+       group="chem_inparm" valid_values="" >
+Default: current model date
+The date at which the external forcings are fixed
+if {{ hilight }}ext_frc_type{{ closehilight }} is 'FIXED'.
+Format: YYYYMMDD
+Default: 0
+</entry>
+
+<entry id="ext_frc_fixed_tod" type="integer" category="cam_chem"
+       group="chem_inparm" valid_values="" >
+The time of day (seconds) corresponding to {{ hilight }}ext_frc_fixed_ymd{{ closehilight }}
+at which the external forcings are fixed
+if {{ hilight }}ext_frc_type{{ closehilight }} is 'FIXED'.
+Default: 0 seconds
+</entry>
+
+<entry id="ext_frc_specifier" type="char*256(1000)" category="cam_chem"
+       group="chem_inparm" valid_values="" >
+List of full pathnames of elevated emission (or external chemical forcings) datasets.
+
+The chemistry package reads in elevated emission data from a set of netcdf files in
+units of "molecules/cm3/s".  Each tracer species emissions is read from its
+own file as directed by the namelist variable {{ hilight }}ext_frc_specifier{{ closehilight }}.  The
+{{ hilight }}ext_frc_specifier{{ closehilight }} variable tells the model which species have elevated
+emissions and the file path for the corresponding species.  That is, the
+{{ hilight }}ext_frc_specifier{{ closehilight }} variable is set something like:
+
+ ext_frc_specifier = 'SO2 -> /path/vrt.emis.so2.nc',
+                     'SO4 -> /path/vrt.emis.so4.nc', etc...
+
+Each emission file can have more than one source.  When the emission are
+read in the sources are summed to give a total emission field for the
+corresponding species.  The emission can be read in as time series of data,
+cycle over a given year, or be fixed to a given date.
+
+The vertical coordinate in these emissions files should be 'altitude' (km) so that the
+vertical redistribution to the model layers is done using a mass conserving method.
+If the vertical coordinate is altitude then data needs to be ordered from the
+surface to the top (increasing altitude).
+
+Default: set by build-namelist.
+</entry>
+
+<entry id="ext_frc_type" type="char*32" category="cam_chem"
+       group="chem_inparm" valid_values="CYCLICAL,SERIAL,INTERP_MISSING_MONTHS,FIXED" >
+Type of time interpolation for fixed lower boundary data.
+Can be set to 'CYCLICAL', 'SERIAL', 'INTERP_MISSING_MONTHS', or 'FIXED'.
+Default: 'CYCLICAL'
+</entry>
+
+<entry id="flbc_cycle_yr" type="integer" category="cam_chem"
+       group="chem_surfvals_nl" valid_values="" >
+The cycle year of the fixed lower boundary data
+if {{ hilight }}flbc_type{{ closehilight }}  is 'CYCLICAL'.
+Format: YYYY
+Default: 0
+</entry>
+<entry id="flbc_fixed_ymd" type="integer" category="cam_chem"
+       group="chem_surfvals_nl" valid_values="" >
+The date at which the fixed lower boundary data is fixed
+if {{ hilight }}flbc_type{{ closehilight }} is 'FIXED'..
+Format: YYYYMMDD
+Default: 0
+</entry>
+<entry id="flbc_fixed_tod" type="integer" category="cam_chem"
+       group="chem_surfvals_nl" valid_values="" >
+The time of day (seconds) corresponding to {{ hilight }}flbc_fixed_ymd{{ closehilight }}
+at which the fixed lower boundary data is fixed
+if {{ hilight }}flbc_type{{ closehilight }} is 'FIXED'.
+Default: 0 seconds
+</entry>
+
+<entry id="flbc_file" type="char*256" input_pathname="abs" category="cam_chem"
+       group="chem_surfvals_nl" valid_values="" >
+Full pathname of dataset for fixed lower boundary conditions.
+Default: set by build-namelist.
+</entry>
+
+<entry id="flbc_list" type="char*16(1000)" category="cam_chem"
+       group="chem_surfvals_nl" valid_values="" >
+List of species that are fixed at the lower boundary.
+Default: set by build-namelist.
+</entry>
+
+<entry id="flbc_type" type="char*8" category="cam_chem"
+       group="chem_surfvals_nl" valid_values="CYCLICAL,SERIAL,FIXED" >
+Type of time interpolation for fixed lower boundary data.
+Default: 'CYCLICAL'
+</entry>
+
+<entry id="fstrat_file" type="char*256" input_pathname="abs" category="cam_chem"
+       group="chem_inparm" valid_values="" >
+Full pathname of dataset for chemical tracers constrained  in the stratosphere
+Default: set by build-namelist.
+</entry>
+
+<entry id="fstrat_list" type="char*16(1000)" category="cam_chem"
+       group="chem_inparm" valid_values="" >
+List of species that are constrained in the stratosphere.
+Default: set by build-namelist.
+</entry>
+
+<entry id="lght_no_prd_factor" type="real" category="cam_chem"
+       group="lightning_nl" valid_values="" >
+Multiplication factor  applied to the lighting NOx production
+Default: 1.0.
+</entry>
+
+<entry id="no_xfac_ubc" type="real" category="waccm"
+       group="upper_bc_opts" valid_values="" >
+Multiplication factor applied to the upper boundary NO mass mixing ratio.
+Default: 1.0
+</entry>
+
+<entry id="photon_file" type="char*256" input_pathname="abs" category="waccm"
+       group="chem_inparm" valid_values="" >
+Full pathname of dataset for the neutral species absorption cross sections.
+Default: set by build-namelist.
+</entry>
+
+<entry id="exo_coldens_file" type="char*256" input_pathname="abs" category="cam_chem"
+       group="chem_inparm" valid_values="" >
+Full pathname of dataset of O2 and 03 column densities above the model for look-up-table photolysis
+Default: set by build-namelist.
+</entry>
+
+<entry id="aircraft_specifier" type="char*256(100)" category="cam_chem"
+       group="aircraft_emit_nl" valid_values="" >
+Filename of file that contains aircraft input file lists. The filenames in the files are relative
+to the directory specified by {{ hilight }}aircraft_datapath{{ closehilight }}.
+Default: set by build-namelist.
+</entry>
+
+<entry id="aircraft_datapath" type="char*256" input_pathname="abs" category="cam_chem"
+       group="aircraft_emit_nl" valid_values="" >
+Full pathname of the directory that contains the files specified in
+{{ hilight }}aircraft_specifier{{ closehilight }}.
+Default: set by build-namelist.
+</entry>
+
+<entry id="aircraft_type" type="char*32" category="cam_chem"
+       group="aircraft_emit_nl" valid_values="CYCLICAL_LIST,SERIAL" >
+Type of time interpolation for data in aircraft aerosol files.
+Default: 'CYCLICAL_LIST'
+</entry>
+
+<entry id="aircraft_co2_file" type="char*256" input_pathname="abs" category="cam_chem"
+       group="camexp" valid_values="" >
+Full pathname of the ac_CO2 file specified in the filelist in
+{{ hilight }}aircraft_specifier{{ closehilight }}.  This is only to
+get this name into the cam.input_data_list for the CESM scripts.
+Default: set by build-namelist.
+</entry>
+
+
+
+<entry id="gcr_ionization_datapath" type="char*256" input_pathname="abs" category="cam_chem"
+       group="gcr_ionization_nl" valid_values="" >
+Full pathname of the directory that contains the files specified in
+{{ hilight }}gcr_ionization_filelist{{ closehilight }}.
+Default: set by build-namelist.
+</entry>
+
+<entry id="gcr_ionization_filename" type="char*256" input_pathname="rel:gcr_ionization_datapath" category="cam_chem"
+       group="gcr_ionization_nl" valid_values="" >
+Filename of dataset for ionization rates by galactic cosmic rays.
+Default: set by build-namelist.
+</entry>
+
+<entry id="gcr_ionization_filelist" type="char*256" input_pathname="rel:gcr_ionization_datapath" category="cam_chem"
+       group="gcr_ionization_nl" valid_values="" >
+Filename of file that contains a sequence of filenames for ionization
+rates by galactic cosmic rays.  The filenames in this file are relative
+to the directory specified by {{ hilight }}gcr_ionization_datapath{{ closehilight }}.
+Default: set by build-namelist.
+</entry>
+
+<entry id="gcr_ionization_fldname" type="char*16" category="cam_chem"
+       group="gcr_ionization_nl" valid_values="" >
+Names of variables containing ionization rates (/cm3/sec) in the cosmic rays datasets.
+Default: none
+</entry>
+
+<entry id="gcr_ionization_datatype" type="char*32" category="cam_chem"
+       group="gcr_ionization_nl" valid_values="CYCLICAL,SERIAL,INTERP_MISSING_MONTHS,FIXED" >
+Type of time interpolation for data in gcr_ionization files.
+Can be set to 'CYCLICAL', 'SERIAL', 'INTERP_MISSING_MONTHS', or 'FIXED'.
+Default: 'SERIAL'
+</entry>
+
+<entry id="gcr_ionization_cycle_yr" type="integer" category="cam_chem"
+       group="gcr_ionization_nl" valid_values="" >
+The  cycle year of the prescribed green house gas data
+if {{ hilight }}gcr_ionization_type{{ closehilight }}  is 'CYCLICAL'.
+Format: YYYY
+Default: 0
+</entry>
+
+<entry id="gcr_ionization_fixed_ymd" type="integer" category="cam_chem"
+       group="gcr_ionization_nl" valid_values="" >
+The date at which the prescribed green house gas data  is fixed
+if {{ hilight }}gcr_ionization_type{{ closehilight }} is 'FIXED'.
+Format: YYYYMMDD
+Default: 0
+</entry>
+
+<entry id="gcr_ionization_fixed_tod" type="integer" category="cam_chem"
+       group="gcr_ionization_nl" valid_values="" >
+The time of day (seconds) corresponding to {{ hilight }}gcr_ionization_fixed_ymd{{ closehilight }}
+at which the prescribed green house gas data is fixed
+if {{ hilight }}gcr_ionization_type{{ closehilight }} is 'FIXED'.
+Default: 0 seconds
+</entry>
+
+
+
+<entry id="prescribed_aero_datapath" type="char*256" input_pathname="abs" category="cam_chem"
+       group="prescribed_aero_nl" valid_values="" >
+Full pathname of the directory that contains the files specified in
+{{ hilight }}prescribed_aero_filelist{{ closehilight }}.
+Default: set by build-namelist.
+</entry>
+
+<entry id="prescribed_aero_model" type="char*5" category="cam_chem"
+       group="camexp" valid_values="bulk,modal" >
+Switch used to indicate which type of aerosols are prescribed -- bulk or modal.
+This is used to set the default {{ hilight }}prescribed_aero_specifier{{ closehilight }} and
+{{ hilight }}aerodep_flx_specifier{{ closehilight }} namelist variables.
+Default: set by build-namelist
+</entry>
+
+<entry id="prescribed_aero_file" type="char*256" input_pathname="rel:prescribed_aero_datapath" category="cam_chem"
+       group="prescribed_aero_nl" valid_values="" >
+Filename of dataset for prescribed aerosols.
+Default: set by build-namelist.
+</entry>
+
+<entry id="prescribed_aero_filelist" type="char*256" input_pathname="rel:prescribed_aero_datapath" category="cam_chem"
+       group="prescribed_aero_nl" valid_values="" >
+Filename of file that contains a sequence of filenames for prescribed
+aerosols.  The filenames in this file are relative to the directory specified
+by {{ hilight }}prescribed_aero_datapath{{ closehilight }}.
+Default: set by build-namelist.
+</entry>
+
+<entry id="prescribed_aero_rmfile" type="logical" category="cam_chem"
+       group="prescribed_aero_nl" valid_values="" >
+Remove the file containing prescribed aerosol concentrations from local disk when no longer needed.
+Default: FALSE
+</entry>
+
+<entry id="prescribed_aero_specifier" type="char*32(50)" category="cam_chem"
+       group="prescribed_aero_nl" valid_values="" >
+A list of variable names of the concentration fields in the prescribed aerosol datasets
+and corresponding names used in the physics buffer seperated by colons.  For example:
+
+ prescribed_aero_specifier = 'pbuf_name1:ncdf_fld_name1','pbuf_name2:ncdf_fld_name2', ...
+
+If there is no colon seperater then the specified name is used as both the pbuf_name and ncdf_fld_name,
+
+Default: none
+</entry>
+
+<entry id="prescribed_aero_type" type="char*32" category="cam_chem"
+       group="prescribed_aero_nl" valid_values="CYCLICAL,SERIAL,INTERP_MISSING_MONTHS,FIXED" >
+Type of time interpolation for data in prescribed_aero files.
+Can be set to 'CYCLICAL', 'SERIAL', 'INTERP_MISSING_MONTHS', or 'FIXED'.
+Default: 'SERIAL'
+</entry>
+
+<entry id="prescribed_aero_cycle_yr" type="integer" category="cam_chem"
+       group="prescribed_aero_nl" valid_values="" >
+The  cycle year of the prescribed aerosol data
+if {{ hilight }}prescribed_aero_type{{ closehilight }}  is 'CYCLICAL'.
+Format: YYYY
+Default: 0
+</entry>
+
+<entry id="prescribed_aero_fixed_ymd" type="integer" category="cam_chem"
+       group="prescribed_aero_nl" valid_values="" >
+The date at which the prescribed aerosol data is fixed
+if {{ hilight }}prescribed_aero_type{{ closehilight }} is 'FIXED'.
+Format: YYYYMMDD
+Default: 0
+</entry>
+
+<entry id="prescribed_aero_fixed_tod" type="integer" category="cam_chem"
+       group="prescribed_aero_nl" valid_values="" >
+The time of day (seconds) corresponding to {{ hilight }}prescribed_aero_fixed_ymd{{ closehilight }}
+at which the prescribed aerosol data is fixed
+if {{ hilight }}prescribed_aero_type{{ closehilight }} is 'FIXED'.
+Default: 0 seconds
+</entry>
+
+<entry id="aerodep_flx_datapath" type="char*256" input_pathname="abs" category="cam_chem"
+       group="aerodep_flx_nl" valid_values="" >
+Full pathname of the directory that contains the files specified in
+{{ hilight }}aerodep_flx_filelist{{ closehilight }}.
+Default: set by build-namelist.
+</entry>
+
+<entry id="aerodep_flx_file" type="char*256" input_pathname="rel:aerodep_flx_datapath" category="cam_chem"
+       group="aerodep_flx_nl" valid_values="" >
+Filename of dataset for prescribed aerosols.
+Default: set by build-namelist.
+</entry>
+
+<entry id="aerodep_flx_filelist" type="char*256" input_pathname="rel:aerodep_flx_datapath" category="cam_chem"
+       group="aerodep_flx_nl" valid_values="" >
+Filename of file that contains a sequence of filenames for prescribed
+aerosols.  The filenames in this file are relative to the directory specified
+by {{ hilight }}aerodep_flx_datapath{{ closehilight }}.
+Default: set by build-namelist.
+</entry>
+
+<entry id="aerodep_flx_rmfile" type="logical" category="cam_chem"
+       group="aerodep_flx_nl" valid_values="" >
+Remove the file containing prescribed aerosol deposition fluxes from local disk when no longer needed.
+Default: FALSE
+</entry>
+
+<entry id="aerodep_flx_specifier" type="char*32(22)" category="cam_chem"
+       group="aerodep_flx_nl" valid_values="" >
+Names of variables containing aerosol data in the prescribed aerosol datasets.
+Default: none
+</entry>
+
+<entry id="aerodep_flx_type" type="char*32" category="cam_chem"
+       group="aerodep_flx_nl" valid_values="CYCLICAL,SERIAL,INTERP_MISSING_MONTHS,FIXED" >
+Type of time interpolation for data in aerodep_flx files.
+Can be set to 'CYCLICAL', 'SERIAL', 'INTERP_MISSING_MONTHS', or 'FIXED'.
+Default: 'SERIAL'
+</entry>
+
+<entry id="aerodep_flx_cycle_yr" type="integer" category="cam_chem"
+       group="aerodep_flx_nl" valid_values="" >
+The  cycle year of the prescribed aerosol flux data
+if {{ hilight }}aerodep_flx_type{{ closehilight }}  is 'CYCLICAL'.
+Format: YYYY
+Default: 0
+</entry>
+
+<entry id="aerodep_flx_fixed_ymd" type="integer" category="cam_chem"
+       group="aerodep_flx_nl" valid_values="" >
+The date at which the prescribed aerosol flux data is fixed
+if {{ hilight }}aerodep_flx_type{{ closehilight }} is 'FIXED'.
+Format: YYYYMMDD
+Default: 0
+</entry>
+
+<entry id="aerodep_flx_fixed_tod" type="integer" category="cam_chem"
+       group="aerodep_flx_nl" valid_values="" >
+The time of day (seconds) corresponding to {{ hilight }}ssaerodep_flx_fixed_ymd{{ closehilight }}
+at which the prescribed aerosol flux data is fixed
+if {{ hilight }}saerodep_flx_type{{ closehilight }} is 'FIXED'.
+Default: 0 seconds
+</entry>
+
+<entry id="prescribed_ghg_datapath" type="char*256" input_pathname="abs" category="cam_chem"
+       group="prescribed_ghg_nl" valid_values="" >
+Full pathname of the directory that contains the files specified in
+{{ hilight }}prescribed_ghg_filelist{{ closehilight }}.
+Default: set by build-namelist.
+</entry>
+
+<entry id="prescribed_ghg_file" type="char*256" input_pathname="rel:prescribed_ghg_datapath" category="cam_chem"
+       group="prescribed_ghg_nl" valid_values="" >
+Filename of dataset for prescribed GHGs.
+Default: set by build-namelist.
+</entry>
+
+<entry id="prescribed_ghg_filelist" type="char*256" input_pathname="rel:prescribed_ghg_datapath" category="cam_chem"
+       group="prescribed_ghg_nl" valid_values="" >
+Filename of file that contains a sequence of filenames for prescribed
+GHGs.  The filenames in this file are relative to the directory specified
+by {{ hilight }}prescribed_ghg_datapath{{ closehilight }}.
+Default: set by build-namelist.
+</entry>
+
+<entry id="prescribed_ghg_rmfile" type="logical" category="cam_chem"
+       group="prescribed_ghg_nl" valid_values="" >
+Remove the file containing prescribed green house gas concentrations from local disk when no longer needed.
+Default: FALSE
+</entry>
+
+<entry id="prescribed_ghg_specifier" type="char*16(100)" category="cam_chem"
+       group="prescribed_ghg_nl" valid_values="" >
+Names of variables containing GHG data in the prescribed GHG datasets.
+Default: none
+</entry>
+
+<entry id="prescribed_ghg_type" type="char*32" category="cam_chem"
+       group="prescribed_ghg_nl" valid_values="CYCLICAL,SERIAL,INTERP_MISSING_MONTHS,FIXED" >
+Type of time interpolation for data in prescribed_ghg files.
+Can be set to 'CYCLICAL', 'SERIAL', 'INTERP_MISSING_MONTHS', or 'FIXED'.
+Default: 'SERIAL'
+</entry>
+
+<entry id="prescribed_ghg_cycle_yr" type="integer" category="cam_chem"
+       group="prescribed_ghg_nl" valid_values="" >
+The  cycle year of the prescribed green house gas data
+if {{ hilight }}prescribed_ghg_type{{ closehilight }}  is 'CYCLICAL'.
+Format: YYYY
+Default: 0
+</entry>
+
+<entry id="prescribed_ghg_fixed_ymd" type="integer" category="cam_chem"
+       group="prescribed_ghg_nl" valid_values="" >
+The date at which the prescribed green house gas data  is fixed
+if {{ hilight }}prescribed_ghg_type{{ closehilight }} is 'FIXED'.
+Format: YYYYMMDD
+Default: 0
+</entry>
+
+<entry id="prescribed_ghg_fixed_tod" type="integer" category="cam_chem"
+       group="prescribed_ghg_nl" valid_values="" >
+The time of day (seconds) corresponding to {{ hilight }}prescribed_ghg_fixed_ymd{{ closehilight }}
+at which the prescribed green house gas data is fixed
+if {{ hilight }}prescribed_ghg_type{{ closehilight }} is 'FIXED'.
+Default: 0 seconds
+</entry>
+
+<entry id="prescribed_ozone_datapath" type="char*256" input_pathname="abs" category="cam_chem"
+       group="prescribed_ozone_nl" valid_values="" >
+Full pathname of the directory that contains the files specified in
+{{ hilight }}prescribed_ozone_filelist{{ closehilight }}.
+Default: set by build-namelist.
+</entry>
+
+<entry id="prescribed_ozone_file" type="char*256" input_pathname="rel:prescribed_ozone_datapath" category="cam_chem"
+       group="prescribed_ozone_nl" valid_values="" >
+Filename of dataset for prescribed ozone.
+Default: set by build-namelist.
+</entry>
+
+<entry id="prescribed_ozone_filelist" type="char*256" input_pathname="rel:prescribed_ozone_datapath" category="cam_chem"
+       group="prescribed_ozone_nl" valid_values="" >
+Filename of file that contains a sequence of filenames for prescribed
+ozone.  The filenames in this file are relative to the directory specified
+by {{ hilight }}prescribed_ozone_datapath{{ closehilight }}.
+Default: set by build-namelist.
+</entry>
+
+<entry id="prescribed_ozone_name" type="char*16" category="cam_chem"
+       group="prescribed_ozone_nl" valid_values="" >
+Name of variable containing ozone data in the prescribed ozone datasets.
+Default: 'ozone'
+</entry>
+
+<entry id="prescribed_ozone_rmfile" type="logical" category="cam_chem"
+       group="prescribed_ozone_nl" valid_values="" >
+Remove the file containing prescribed ozone concentrations from local disk when no longer needed.
+Default: FALSE
+</entry>
+
+<entry id="prescribed_ozone_type" type="char*32" category="cam_chem"
+       group="prescribed_ozone_nl" valid_values="CYCLICAL,SERIAL,INTERP_MISSING_MONTHS,FIXED" >
+Type of time interpolation for data in prescribed_ozone files.
+Can be set to 'CYCLICAL', 'SERIAL', 'INTERP_MISSING_MONTHS', or 'FIXED'.
+Default: 'SERIAL'
+</entry>
+
+<entry id="prescribed_ozone_cycle_yr" type="integer" category="cam_chem"
+       group="prescribed_ozone_nl" valid_values="" >
+The  cycle year of the prescribed ozone data
+if {{ hilight }}prescribed_ozone_type{{ closehilight }}  is 'CYCLICAL'.
+Format: YYYY
+Default: 0
+</entry>
+
+<entry id="prescribed_ozone_fixed_ymd" type="integer" category="cam_chem"
+       group="prescribed_ozone_nl" valid_values="" >
+The date at which the prescribed ozone data is fixed
+if {{ hilight }}prescribed_ozone_type{{ closehilight }} is 'FIXED'.
+Format: YYYYMMDD
+Default: 0
+</entry>
+
+<entry id="prescribed_ozone_fixed_tod" type="integer" category="cam_chem"
+       group="prescribed_ozone_nl" valid_values="" >
+The time of day (seconds) corresponding to {{ hilight }}prescribed_ozone_fixed_ymd{{ closehilight }}
+at which the prescribed ozone data is fixed
+if {{ hilight }}prescribed_ozone_type{{ closehilight }} is 'FIXED'.
+Default: 0 seconds
+</entry>
+
+<entry id="prescribed_volcaero_datapath" type="char*256" input_pathname="abs" category="cam_chem"
+       group="prescribed_volcaero_nl" valid_values="" >
+Full pathname of the directory that contains the files specified in
+{{ hilight }}prescribed_volcaero_filelist{{ closehilight }}.
+Default: set by build-namelist.
+</entry>
+
+<entry id="prescribed_volcaero_file" type="char*256" input_pathname="rel:prescribed_volcaero_datapath" category="cam_chem"
+       group="prescribed_volcaero_nl" valid_values="" >
+Filename of dataset for prescribed volcaero.
+Default: set by build-namelist.
+</entry>
+
+<entry id="prescribed_volcaero_filelist" type="char*256" input_pathname="rel:prescribed_volcaero_datapath" category="cam_chem"
+       group="prescribed_volcaero_nl" valid_values="" >
+Filename of file that contains a sequence of filenames for prescribed
+volcanic aerosols.  The filenames in this file are relative to the directory specified
+by {{ hilight }}prescribed_volcaero_datapath{{ closehilight }}.
+Default: set by build-namelist.
+</entry>
+
+<entry id="prescribed_volcaero_name" type="char*16" category="cam_chem"
+       group="prescribed_volcaero_nl" valid_values="" >
+Name of variable containing volcaero data in the prescribed volcaero datasets.
+Default: 'MMRVOLC'
+</entry>
+
+<entry id="prescribed_volcaero_rmfile" type="logical" category="cam_chem"
+       group="prescribed_volcaero_nl" valid_values="" >
+Remove the file containing prescribed volcanic aerosol concentrations from local disk when no longer needed.
+Default: FALSE
+</entry>
+
+<entry id="prescribed_volcaero_type" type="char*32" category="cam_chem"
+       group="prescribed_volcaero_nl" valid_values="CYCLICAL,SERIAL,INTERP_MISSING_MONTHS,FIXED" >
+Type of time interpolation for data in prescribed_volcaero files.
+Can be set to 'CYCLICAL', 'SERIAL', 'INTERP_MISSING_MONTHS', or 'FIXED'.
+Default: 'SERIAL'
+</entry>
+
+<entry id="prescribed_volcaero_cycle_yr" type="integer" category="cam_chem"
+       group="prescribed_volcaero_nl" valid_values="" >
+The  cycle year of the prescribed volcanic aerosol data
+if {{ hilight }}prescribed_volcaero_type{{ closehilight }}  is 'CYCLICAL'.
+Format: YYYY
+Default: 0
+</entry>
+
+<entry id="prescribed_volcaero_fixed_ymd" type="integer" category="cam_chem"
+       group="prescribed_volcaero_nl" valid_values="" >
+The date at which the prescribed volcanic aerosol data  is fixed
+if {{ hilight }}prescribed_volcaero_type{{ closehilight }} is 'FIXED'.
+Format: YYYYMMDD
+Default: 0
+</entry>
+
+<entry id="prescribed_volcaero_fixed_tod" type="integer" category="cam_chem"
+       group="prescribed_volcaero_nl" valid_values="" >
+The time of day (seconds) corresponding to {{ hilight }}prescribed_volcaero_fixed_ymd{{ closehilight }}
+at which the prescribed volcanic aerosol data is fixed
+if {{ hilight }}prescribed_volcaero_type{{ closehilight }} is 'FIXED'.
+Default: 0 seconds
+</entry>
+
+
+<entry id="prescribed_strataero_datapath" type="char*256" input_pathname="abs" category="cam_chem"
+       group="prescribed_strataero_nl" valid_values="" >
+Full pathname of the directory that contains the files specified in
+{{ hilight }}prescribed_strataero_filelist{{ closehilight }}.
+Default: set by build-namelist.
+</entry>
+
+<entry id="prescribed_strataero_file" type="char*256" input_pathname="rel:prescribed_strataero_datapath" category="cam_chem"
+       group="prescribed_strataero_nl" valid_values="" >
+Filename of dataset for prescribed volcaero.
+Default: set by build-namelist.
+</entry>
+
+<entry id="prescribed_strataero_filelist" type="char*256" input_pathname="rel:prescribed_strataero_datapath" category="cam_chem"
+       group="prescribed_strataero_nl" valid_values="" >
+Filename of file that contains a sequence of filenames for prescribed
+stratospheric aerosols.  The filenames in this file are relative to the directory specified
+by {{ hilight }}prescribed_strataero_datapath{{ closehilight }}.
+Default: set by build-namelist.
+</entry>
+
+<entry id="prescribed_strataero_specifier" type="char*16" category="cam_chem"
+       group="prescribed_strataero_nl" valid_values="" >
+Name of variable containing prescribed stratospheric aerosol specifiers
+Default: set by the CAM program
+</entry>
+
+<entry id="prescribed_strataero_rmfile" type="logical" category="cam_chem"
+       group="prescribed_strataero_nl" valid_values="" >
+Remove the file containing prescribed volcanic aerosol concentrations from local disk when no longer needed.
+Default: FALSE
+</entry>
+
+<entry id="prescribed_strataero_type" type="char*32" category="cam_chem"
+       group="prescribed_strataero_nl" valid_values="CYCLICAL,SERIAL,INTERP_MISSING_MONTHS,FIXED" >
+Type of time interpolation for data in prescribed_strataero files.
+Can be set to 'CYCLICAL', 'SERIAL', 'INTERP_MISSING_MONTHS', or 'FIXED'.
+Default: 'SERIAL'
+</entry>
+
+<entry id="prescribed_strataero_cycle_yr" type="integer" category="cam_chem"
+       group="prescribed_strataero_nl" valid_values="" >
+The  cycle year of the prescribed volcanic aerosol data
+if {{ hilight }}prescribed_strataero_type{{ closehilight }}  is 'CYCLICAL'.
+Format: YYYY
+Default: 0
+</entry>
+
+<entry id="prescribed_strataero_fixed_ymd" type="integer" category="cam_chem"
+       group="prescribed_strataero_nl" valid_values="" >
+The date at which the prescribed volcanic aerosol data  is fixed
+if {{ hilight }}prescribed_strataero_type{{ closehilight }} is 'FIXED'.
+Format: YYYYMMDD
+Default: 0
+</entry>
+
+<entry id="prescribed_strataero_fixed_tod" type="integer" category="cam_chem"
+       group="prescribed_strataero_nl" valid_values="" >
+The time of day (seconds) corresponding to {{ hilight }}prescribed_strataero_fixed_ymd{{ closehilight }}
+at which the prescribed volcanic aerosol data is fixed
+if {{ hilight }}prescribed_strataero_type{{ closehilight }} is 'FIXED'.
+Default: 0 seconds
+</entry>
+
+<entry id="prescribed_strataero_feedback" type="logical" category="cam_chem"
+       group="camexp" valid_values="" >
+Switch to turn on climate feed backs due to prescribed stratospheric aerosols via
+the rad_climate namelist variable.
+Default: false
+</entry>
+
+<entry id="prescribed_strataero_3modes" type="logical" category="cam_chem"
+       group="camexp" valid_values="" >
+If true the prescribed stratospheric aerosols have three distribution modes.
+Default: true for CAM6, otherwise false
+</entry>
+
+<entry id="prescribed_strataero_use_chemtrop" type="logical" category="aerosol"
+       group="prescribed_strataero_nl" valid_values="" >
+Indicates whether to use the unified chemistry tropopause method to set prescribed
+stratospheric aerosols below the tropopause to zero.  This has a maximum altitude
+level corresponding to 300 hPa for latitudes poleward of 50 degrees.
+Default: set by build-namelist
+</entry>
+
+<entry id="rsf_file" type="char*256" input_pathname="abs" category="cam_chem"
+       group="chem_inparm" valid_values="" >
+Full pathname of dataset for radiative source function used in look up table photloysis
+Default: set by build-namelist.
+</entry>
+
+<entry id="snoe_ubc_file" type="char*256" input_pathname="abs" category="waccm"
+       group="upper_bc_opts" valid_values="" >
+Full pathname of dataset for the coefficients of the NOEM nitric oxide model used
+to calculate its upper boundary concentration.
+Default: set by build-namelist.
+</entry>
+
+<entry id="soil_erod_file" type="char*256" input_pathname="abs" category="cam_chem"
+       group="dust_nl" valid_values="" >
+Full pathname of boundary dataset for soil erodibility factors.
+Default: set by build-namelist.
+</entry>
+
+<entry id="srf_emis_specifier" type="char*256(1000)" category="cam_chem"
+       group="chem_inparm" valid_values="" >
+List of full pathnames of surface emission datasets.
+
+The chemistry package reads in emission data from a set of netcdf files in
+units of "molecules/cm2/s".  Each tracer species emissions is read from its
+own file as directed by the namelist variable {{ hilight }}srf_emis_specifier{{ closehilight }}.  The
+{{ hilight }}srf_emis_specifier{{ closehilight }} variable tells the model which species have emissions
+and the file path for the corresponding species.  That is, the
+{{ hilight }}srf_emis_specifier{{ closehilight }} variable is set something like:
+
+ srf_emis_specifier = 'CH4 -> /path/emis.ch4.nc',
+                      'CO  -> /path/emis.co.nc', etc...
+
+Each emission file can have more than one source.  When the emission are
+read in the sources are summed to give a total emission field for the
+corresponding species.  The emission can be read in as time series of data,
+cycle over a given year, or be fixed to a given date.
+
+Default: set by build-namelist.
+</entry>
+
+<entry id="emissions_specifier" type="char*256(50)" category="cam_chem"
+       group="surface_emissions_opts" valid_values="" >
+List of full pathnames of surface emission datasets.
+
+Surface emission data added to physcis buffer read from a set of netcdf file.
+Each tracer species emissions is read from its own file as directed by the
+namelist variable {{ hilight }}emissions_specifier{{ closehilight }}.  The
+{{ hilight }}emissions_specifier{{ closehilight }} variable tells the model
+which species have emissions and the file path for the corresponding species.
+That is, the {{ hilight }}emissions_specifier{{ closehilight }} variable is
+set something like:
+
+ emissions_specifier = 'BC -> /path/emis.BC.nc',
+                       'OC -> /path/emis.OC.nc', etc...
+
+Each emission file can have more than one source.  When the emission are
+read in the sources are summed to give a total emission field for the
+corresponding species.  The emission can be read in as time series of data,
+cycle over a given year, or be fixed to a given date.
+
+Default: set by build-namelist.
+</entry>
+
+<entry id="emissions_type" type="char*32" category="cam_chem"
+       group="surface_emissions_opts" valid_values="CYCLICAL,SERIAL,INTERP_MISSING_MONTHS,FIXED" >
+Type of time interpolation of emission datasets specified.
+Can be set to 'CYCLICAL', 'SERIAL', 'INTERP_MISSING_MONTHS', or 'FIXED'.
+by {{ hilight }}emissions_specifier{{ closehilight }}.
+Default: 'CYCLICAL'
+</entry>
+
+<entry id="emissions_cycle_yr" type="integer" category="cam_chem"
+       group="surface_emissions_opts" valid_values="" >
+The  cycle year of the surface emissions data
+if {{ hilight }}emissions_type{{ closehilight }}  is 'CYCLICAL'.
+Format: YYYY
+Default: 0
+</entry>
+
+<entry id="emissions_fixed_ymd" type="integer" category="cam_chem"
+       group="surface_emissions_opts" valid_values="" >
+The date at which the surface emissions are fixed
+if {{ hilight }}emissions_type{{ closehilight }} is 'FIXED'.
+Format: YYYYMMDD
+Default: 0
+</entry>
+
+<entry id="emissions_fixed_tod" type="integer" category="cam_chem"
+       group="surface_emissions_opts" valid_values="" >
+The time of day (seconds) corresponding to {{ hilight }}emissions_fixed_ymd{{ closehilight }}
+at which the surface emissions are fixed
+if {{ hilight }}emissions_type{{ closehilight }} is 'FIXED'.
+Default: 0 seconds
+</entry>
+
+<entry id="sulf_file" type="char*256" input_pathname="abs" category="cam_chem"
+       group="sulf_nl" valid_values="" >
+Full pathname of dataset containing tropopheric sulfate aerosols
+Default: set by build-namelist.
+</entry>
+
+<entry id="sulf_datapath" type="char*256" input_pathname="abs" category="cam_chem"
+       group="sulf_nl" valid_values="" >
+Full pathname of the directory that contains the files specified in
+{{ hilight }}sulf_filelist{{ closehilight }}.
+Default: set by build-namelist.
+</entry>
+
+<entry id="sulf_filelist" type="char*256" input_pathname="rel:sulf_datapath" category="cam_chem"
+       group="sulf_nl" valid_values="" >
+Filename of file that contains a sequence of filenames for prescribed
+sulfate.  The filenames in this file are relative to the directory specified
+by {{ hilight }}sulf_datapath{{ closehilight }}.
+Default: set by build-namelist.
+</entry>
+
+<entry id="sulf_name" type="char*16" category="cam_chem"
+       group="sulf_nl" valid_values="" >
+Name of variable containing sulfate data in the prescribed sulfate datasets.
+Default: 'SULFATE'
+</entry>
+
+<entry id="sulf_rmfile" type="logical" category="cam_chem"
+       group="sulf_nl" valid_values="" >
+Remove the file containing prescribed sulfate concentrations from local disk when no longer needed.
+Default: FALSE
+</entry>
+
+<entry id="sulf_type" type="char*32" category="cam_chem"
+       group="sulf_nl" valid_values="CYCLICAL,SERIAL,INTERP_MISSING_MONTHS,FIXED" >
+Type of time interpolation for data in prescribed sulfate files.
+Can be set to 'CYCLICAL', 'SERIAL', 'INTERP_MISSING_MONTHS', or 'FIXED'.
+Default: 'CYCLICAL'
+</entry>
+
+<entry id="sulf_cycle_yr" type="integer" category="cam_chem"
+       group="sulf_nl" valid_values="" >
+The  cycle year of the prescribed sulfate data
+if {{ hilight }}sulf_type{{ closehilight }}  is 'CYCLICAL'.
+Format: YYYY
+Default: 0
+</entry>
+
+<entry id="sulf_fixed_ymd" type="integer" category="cam_chem"
+       group="sulf_nl" valid_values="" >
+The date at which the prescribed sulfate data is fixed
+if {{ hilight }}sulf_type{{ closehilight }} is 'FIXED'.
+Format: YYYYMMDD
+Default: 0
+</entry>
+
+<entry id="sulf_fixed_tod" type="integer" category="cam_chem"
+       group="sulf_nl" valid_values="" >
+The time of day (seconds) corresponding to {{ hilight }}sulf_fixed_ymd{{ closehilight }}
+at which the prescribed sulfate data is fixed
+if {{ hilight }}sulf_type{{ closehilight }} is 'FIXED'.
+Default: 0 seconds
+</entry>
+
+<entry id="tgcm_ubc_file" type="char*256" input_pathname="abs" category="waccm"
+       group="upper_bc_opts" valid_values="" >
+Full pathname of dataset for TGCM upper boundary
+Default: set by build-namelist.
+</entry>
+<entry id="tgcm_ubc_data_type" type="char*32" category="waccm"
+       group="upper_bc_opts" valid_values="CYCLICAL,SERIAL,INTERP_MISSING_MONTHS,FIXED" >
+Type of time interpolation for data in TGCM upper boundary file.
+Can be set to 'CYCLICAL', 'SERIAL', 'INTERP_MISSING_MONTHS', or 'FIXED'.
+Default: 'SERIAL'
+</entry>
+
+<entry id="tgcm_ubc_cycle_yr" type="integer" category="waccm"
+       group="upper_bc_opts" valid_values="" >
+The cycle year of the TGCM upper boundary data
+if {{ hilight }}tgcm_ubc_type{{ closehilight }}  is 'CYCLICAL'.
+Format: YYYY
+Default: 0
+</entry>
+
+<entry id="tgcm_ubc_fixed_ymd" type="integer" category="waccm"
+       group="upper_bc_opts" valid_values="" >
+The date at which the TGCM upper boundary data is fixed
+if {{ hilight }}tgcm_ubc_type{{ closehilight }} is 'FIXED'.
+Format: YYYY
+Default: 0
+</entry>
+
+<entry id="tgcm_ubc_fixed_tod" type="integer" category="waccm"
+       group="upper_bc_opts" valid_values="" >
+The time of day (seconds) corresponding to {{ hilight }}tgcm_ubc_fixed_ymd{{ closehilight }}
+at which the TGCM upper boundary data is fixed
+if {{ hilight }}tgcm_ubc_type{{ closehilight }} is 'FIXED'.
+Default: 0 seconds
+</entry>
+
+<entry id="t_pert_ubc" type="real" category="waccm"
+       group="upper_bc_opts" valid_values="" >
+Perturbation applied to the upper boundary temperature.
+Default: 0.0
+</entry>
+
+<entry id="ubc_specifier" type="char*64(pcnst)"  category="upper_boundary"
+       group="upper_bc_opts" valid_values="" >
+
+List of fields that have fixed upper boundary conditions (temperature and mass mixing ratios)
+and corresponding data sources. Each entry in this list is of the form:
+  FLD->source
+where source may be of the following:
+  MSIS - NRL neutral atmosphere empirical model (Mass Spectrometer Incoherent Scatter radar)
+  TGCM - Input file generated by Thermospheric General Circulation Model
+  SNOE - Input file generated from Student Nitric Oxide Explorer satellite observations
+  UBC_FILE - Generalized input file which spans the upper boundary altitude
+  value (mmr|vmr) - Set to a constant value (e.g., 1.2e-6 mmr)
+
+These fields can be set to constant values with units of "mmr" (mass mixing ratio)
+or "vmr" (volume mixing ratio).  The upper boundary values of source UBC_FILE are prescribed
+in the UBC_FILE_path file. Fields of source UBC_FILE may include a CAM constituent name
+and a file field name separated by ":".
+
+Note: Constituents not included in ubc_specifier default to zero flux through the upper boundary.
+
+Example:
+  ubc_specifier = 'Q:H2O->UBC_FILE', 'CH4->2.D-10vmr', 'F->1.0D-15mmr', 'HF->1.0D-15mmr',
+                  'T->MSIS', 'H->MSIS', 'N->MSIS','O->MSIS', 'O2->MSIS', 'H2->TGCM', 'NO->SNOE'
+
+Default: set by build-namelist
+</entry>
+
+<entry id="ubc_file_path" type="char*512" input_pathname="abs" category="upper_boundary"
+       group="upper_bc_file_opts" valid_values="" >
+Full path of the file containing prescribed upper boundary conditions.
+Default: NONE
+</entry>
+
+<entry id="ubc_file_input_type" type="char*32" category="upper_boundary"
+       group="upper_bc_file_opts" valid_values="CYCLICAL,SERIAL,INTERP_MISSING_MONTHS,FIXED" >
+Type of time interpolation for data in {{ hilight }}ubc_file_path file{{ closehilight }}.
+Can be set to 'CYCLICAL', 'SERIAL', 'INTERP_MISSING_MONTHS', or 'FIXED'.
+Default: NONE
+</entry>
+
+<entry id="ubc_file_cycle_yr" type="integer" category="upper_boundary"
+       group="upper_bc_file_opts" valid_values="" >
+The cycle year of the prescribed upper boundary data
+if {{ hilight }}ubc_file_input_type{{ closehilight }} is 'CYCLICAL'.
+Format: YYYY
+Default: 0
+</entry>
+
+<entry id="ubc_file_fixed_ymd" type="integer" category="upper_boundary"
+       group="upper_bc_file_opts" valid_values="" >
+The date at which the upper boundary data is fixed
+if {{ hilight }}ubc_file_input_type{{ closehilight }} is 'FIXED'.
+Format: YYYYMMDD
+Default: 0
+</entry>
+
+<entry id="ubc_file_fixed_tod" type="integer" category="upper_boundary"
+       group="upper_bc_file_opts" valid_values="" >
+The time of day (seconds) corresponding to {{ hilight }}ubc_file_fixed_ymd{{ closehilight }}
+at which the upper boundary data is fixed
+if {{ hilight }}ubc_file_input_type{{ closehilight }} is 'FIXED'.
+Default: 0 seconds
+</entry>
+
+<entry id="chem_freq" type="integer" category="cam_chem"
+       group="chem_inparm" valid_values="" >
+Frequency in time steps at which the chemical equations are solved.
+Default: 1
+</entry>
+
+<entry id="tracer_cnst_datapath" type="char*256" input_pathname="abs" category="cam_chem"
+       group="chem_inparm" valid_values="" >
+Full pathname of the directory that contains the files specified in
+{{ hilight }}tracer_cnst_filelist{{ closehilight }}.
+Default: set by build-namelist.
+</entry>
+
+<entry id="tracer_cnst_file" type="char*256" input_pathname="rel:tracer_cnst_datapath" category="cam_chem"
+       group="chem_inparm" valid_values="" >
+Filename of dataset for the prescribed chemical constituents.
+Default: set by build-namelist.
+</entry>
+
+<entry id="tracer_cnst_filelist" type="char*256" input_pathname="rel:tracer_cnst_datapath" category="cam_chem"
+       group="chem_inparm" valid_values="" >
+Filename of file that contains a sequence of filenames for the prescribed chemical constituents.
+The filenames in this file are relative to the directory specified
+by {{ hilight }}tracer_cnst_datapath{{ closehilight }}.
+Default: set by build-namelist.
+</entry>
+
+<entry id="tracer_cnst_rmfile" type="logical" category="cam_chem"
+       group="chem_inparm" valid_values="" >
+Remove the file containing prescribed chemical constituents from local disk when no longer needed.
+Default: FALSE
+</entry>
+
+<entry id="tracer_cnst_specifier" type="char*256(100)" category="cam_chem"
+       group="chem_inparm" valid_values="" >
+List of prescribed chemical constituents.
+Default: set by build-namelist.
+</entry>
+
+<entry id="tracer_cnst_type" type="char*24" category="cam_chem"
+       group="chem_inparm" valid_values="CYCLICAL,SERIAL,INTERP_MISSING_MONTHS,FIXED" >
+Type of time interpolation for data in tracer_cnst files.
+Default: 'SERIAL'
+</entry>
+
+<entry id="tracer_cnst_cycle_yr" type="integer" category="cam_chem"
+       group="chem_inparm" valid_values="" >
+The  cycle year of the prescribed chemical constituents data
+if {{ hilight }}tracer_cnst_type{{ closehilight }}  is 'CYCLICAL'.
+Format: YYYY
+Default: 0
+</entry>
+
+<entry id="tracer_cnst_fixed_ymd" type="integer" category="cam_chem"
+       group="chem_inparm" valid_values="" >
+The date at which the chemical constituents data is fixed
+if {{ hilight }}tracer_cnst_type{{ closehilight }} is 'FIXED'.
+Format: YYYYMMDD
+Default: 0
+</entry>
+
+<entry id="tracer_cnst_fixed_tod" type="integer" category="cam_chem"
+       group="chem_inparm" valid_values="" >
+The time of day (seconds) corresponding to {{ hilight }}tracer_cnst_fixed_ymd{{ closehilight }}
+at which the chemical constituents data is fixed
+if {{ hilight }}tracer_cnst_type{{ closehilight }} is 'FIXED'.
+Default: 0 seconds
+</entry>
+
+<entry id="tracer_srcs_datapath" type="char*256" input_pathname="abs" category="cam_chem"
+       group="chem_inparm" valid_values="" >
+Full pathname of the directory that contains the files specified in
+{{ hilight }}tracer_srcs_filelist{{ closehilight }}.
+Default: set by build-namelist.
+</entry>
+
+<entry id="tracer_srcs_file" type="char*256" input_pathname="rel:tracer_srcs_datapath" category="cam_chem"
+       group="chem_inparm" valid_values="" >
+Filename of dataset for the prescribed chemical sources.
+Default: set by build-namelist.
+</entry>
+
+<entry id="tracer_srcs_filelist" type="char*256" input_pathname="rel:tracer_srcs_datapath" category="cam_chem"
+       group="chem_inparm" valid_values="" >
+Filename of file that contains a sequence of datasets for the prescribed chemical sources.
+The filenames in this file are relative to the directory specified
+by {{ hilight }}tracer_srcs_datapath{{ closehilight }}.
+Default: set by build-namelist.
+</entry>
+
+<entry id="tracer_srcs_rmfile" type="logical" category="cam_chem"
+       group="chem_inparm" valid_values="" >
+Remove the file containing prescribed chemical sources from local disk when no longer needed.
+Default: FALSE
+</entry>
+
+<entry id="tracer_srcs_specifier" type="char*256(100)" category="cam_chem"
+       group="chem_inparm" valid_values="" >
+List of prescribed chemical sources
+Default: set by build-namelist.
+</entry>
+
+<entry id="tracer_srcs_type" type="char*24" category="cam_chem"
+       group="chem_inparm" valid_values="" >
+Type of time interpolation for data in tracer_srcs files.
+Default: 'SERIAL'
+</entry>
+
+<entry id="tracer_srcs_cycle_yr" type="integer" category="cam_chem"
+       group="chem_inparm" valid_values="" >
+The  cycle year of the prescribed chemical sources data
+if {{ hilight }}tracer_srcs_type{{ closehilight }}  is 'CYCLICAL'.
+Format: YYYY
+Default: 0
+</entry>
+
+<entry id="tracer_srcs_fixed_ymd" type="integer" category="cam_chem"
+       group="chem_inparm" valid_values="" >
+The date at which the chemical sources data is fixed
+if {{ hilight }}tracer_srcs_type{{ closehilight }} is 'FIXED'.
+Format: YYYYMMDD
+Default: 0
+</entry>
+
+<entry id="tracer_srcs_fixed_tod" type="integer" category="cam_chem"
+       group="chem_inparm" valid_values="" >
+The time of day (seconds) corresponding to {{ hilight }}tracer_srcs_fixed_ymd{{ closehilight }}
+at which the chemical sources data is fixed
+if {{ hilight }}tracer_srcs_type{{ closehilight }} is 'FIXED'.
+Default: 0 seconds
+</entry>
+
+<entry id="xs_coef_file" type="char*256" input_pathname="abs" category="cam_chem"
+       group="chem_inparm" valid_values="" >
+Full pathname of dataset for  Chebyshev polynomial Coeff data used for photolysis
+cross sections.
+Default: set by build-namelist.
+</entry>
+
+<entry id="xs_long_file" type="char*256" input_pathname="abs" category="cam_chem"
+       group="chem_inparm" valid_values="" >
+Full pathname of cross section dataset for long wavelengh photolysis
+Default: set by build-namelist.
+</entry>
+
+<entry id="xs_short_file" type="char*256" input_pathname="abs" category="cam_chem"
+       group="chem_inparm" valid_values="" >
+Full pathname of cross section dataset for short wavelengh photolysis
+Default: set by build-namelist.
+</entry>
+
+<entry id="photo_max_zen" type="real" category="cam_chem"
+       group="chem_inparm" valid_values="" >
+Maximum zenith angle (degrees) used for photolysis.
+Default: set by build-namelist.
+</entry>
+
+<entry id="tuvx_config_path" type="char*256" input_pathname="abs" category="chemistry"
+       group="tuvx_opts" valid_values="" >
+Filepath of TUV-X configuration specification.
+Default: NONE
+</entry>
+
+<entry id="tuvx_active" type="logical" category="chemistry"
+       group="tuvx_opts" valid_values="" >
+Switch to turn on TUV-X photolysis.
+Default: FALSE
+</entry>
+
+<!-- Namelist read by seq_drydep_mod and shared by CAM and CLM -->
+
+<entry id="drydep_list" type="char*16(1000)" category="dry_deposition"
+       group="drydep_inparm" valid_values="" >
+List of species that undergo dry deposition.
+Default: set by build-namelist.
+</entry>
+
+<entry id="dep_data_file" type="char*500" input_pathname="abs" category="dry_deposition"
+       group="drydep_inparm" valid_values="" >
+Full pathname of file containing gas phase deposition data including effective
+Henry's law coefficients.
+Default: set by build-namelist.
+</entry>
+
+<entry id="rxn_rate_sums" type="char*256(200)" category="cam_chem"
+       group="rxn_rate_diags_nl" valid_values="" >
+Give the user the ability to specify rate families (or groupings) diagnostics based
+on reaction tag names. These group names can be added to history fincl variables.
+A "+" character at the end of a string indicates that the summation will continue with the next string.
+Example:
+ rate_sums =
+   'OX_P = NO_HO2 + CH3O2_NO + 2*jo2_b ... ',
+   'OX_L = NO2_O_M + HO2_O3 + CLO_O ...',
+   'RO2_RO2_sum = CH3O2_CH3O2a + CH3O2_CH3O2b + C2H5O2_CH3O2 + C2H5O2_C2H5O2 + CH3CO3_CH3O2 +',
+               'CH3CO3_CH3CO3 + CH3H7O2_CH3O2 + RO2_CH3O2 + MACRO2_CH3O2 ...',
+ fincl1 = 'OX_P','OX_L', 'RO2_RO2_sum', ...
+Default: none
+</entry>
+
+<entry id="vmr_sums" type="char*256(200)" category="cam_chem"
+       group="species_sums_nl" valid_values="" >
+Give the user the ability to specify species families (or groupings) diagnostics in volume mixing ratio.
+These group names can be added to history fincl variables.  The units are mole/mole.
+A "+" character at the end of a string indicates that the summation will continue with the next string.
+Example:
+ vmr_sums =
+   'SOAG = SOAG0 + SOAG1 + SOAG2 + SOAG3 + SOAG4',
+   'NOy = N + NO + NO2 + NO3 + 2*N2O5 + HNO3 + HO2NO2 + CLONO2 +',
+       'BRONO2 + PAN + MPAN + ISOPNO3 + ONITR +',
+       'HONITR + ALKNIT + ISOPNITA + ISOPNITB + ISOPNOOH + NC4CH2OH +',
+       'NC4CHO + NOA + NTERPOOH + PBZNIT + TERPNIT'
+ fincl1 = 'NOy','SOAG', ...
+Default: none
+</entry>
+
+<entry id="mmr_sums" type="char*256(200)" category="cam_chem"
+       group="species_sums_nl" valid_values="" >
+Give the user the ability to specify species families (or groupings) diagnostics in mass mixing ratio.
+These group names can be added to history fincl variables. The units are kg/kg.
+A "+" character at the end of a string indicates that the summation will continue with the next string.
+Example:
+ mmr_sums =
+    'soa_a1 = soa1_a1 + soa2_a1 + soa3_a1 + soa4_a1 + soa5_a1',
+    'soa_a2 = soa1_a2 + soa2_a2 + soa3_a2 + soa4_a2 + soa5_a2'
+ fincl1 = 'soa_a1','soa_a2', ...
+Default: none
+</entry>
+
+<entry id="chem_use_chemtrop" type="logical" category="chemistry"
+       group="chem_inparm" valid_values="" >
+Indicates whether to use the unified chemistry tropopause method to set the
+tropopause used in gas phase and aerosol chemical processes.  This has a maximum altitude
+level corresponding to 300 hPa for latitudes poleward of 50 degrees.
+Default: set by build-namelist
+</entry>
+
+<entry id="fire_emis_factors_file" type="char*256" input_pathname="abs" category="Fire_emissions"
+       group="fire_emis_nl" valid_values="" >
+File containing fire emissions factors.
+Default: none
+</entry>
+
+<entry id="fire_emis_specifier" type="char*1024(100)" category="Fire_emissions"
+       group="fire_emis_nl" valid_values="" >
+Fire emissions specifier.
+Default: none
+</entry>
+
+<entry id="fire_emis_elevated" type="logical" category="Fire_emissions"
+       group="fire_emis_nl" valid_values="" >
+If true fire emissions are input into atmosphere as elevated forcings.
+Otherwise they are treated as surface emissions.
+Default: TRUE
+</entry>
+
+<entry id="ocean_salinity_file" type="char*256" input_pathname="abs" category="ocean_emissions"
+       group="ocean_emis_nl" valid_values="" >
+File containing ocean salinity
+Default: none
+</entry>
+
+<entry id="csw_specifier" type="char*256(1000)" category="ocean_emissions"
+       group="ocean_emis_nl" valid_values="" >
+Specifies a list of chemical species and corresponding seawater concentration files.
+Each tracer species seawater concentration is read from its own file as directed by the
+namelist variable {{ hilight }}csw_specifier{{ closehilight }}.  The
+{{ hilight }}csw_specifier{{ closehilight }} variable tells the model which species have seawater
+concentration and the file path for the corresponding species.  Each file path may be
+proceeded by a scaling factor.
+Example:
+
+csw_specifier = 'DMS      -> /path/Csw_DMS_HiResML_f09f09_1990_2019_20190616a.nc',
+                'CH3COCH3 -> 0.75*/path/Csw_Acetone_HiResML_f09f09_1990_2019_20190814a.nc'
+
+These can be read in as a time series of data, cyle over a given year, or be fixed to a given date
+as directed by {{ hilight }}csw_time_type{{ closehilight }}.
+
+Default: none
+</entry>
+
+<entry id="csw_time_type" type="char*32" category="ocean_emissions"
+       group="ocean_emis_nl" valid_values="CYCLICAL,SERIAL,INTERP_MISSING_MONTHS,FIXED" >
+Type of time interpolation of seawater concentration datasets specified.
+Can be set to 'CYCLICAL', 'SERIAL', 'INTERP_MISSING_MONTHS', or 'FIXED'.
+by {{ hilight }}csw_specifier{{ closehilight }}.
+Default: 'CYCLICAL'
+</entry>
+
+<entry id="csw_cycle_yr" type="integer" category="ocean_emissions"
+       group="ocean_emis_nl" valid_values="" >
+The cycle year of the seawater concentration data
+if {{ hilight }}csw_time_type{{ closehilight }}  is 'CYCLICAL'.
+Format: YYYY
+Default: 0
+</entry>
+
+<entry id="bubble_mediated_transfer" type="logical" category="ocean_emissions"
+       group="ocean_emis_nl" valid_values="" >
+Bubble-mediated sea-air transfer. See ocean_emis.F90 for details.
+Default: FALSE
+</entry>
+
+<entry id="stream_ndep_year_first" type="integer" category="Nitrogen Deposition"
+       group="ndep_stream_nl" valid_values="" >
+Year first to use in nitrogen deposition stream data.
+</entry>
+
+<entry id="stream_ndep_year_last" type="integer" category="Nitrogen Deposition"
+       group="ndep_stream_nl" valid_values="" >
+Year last to use in nitrogen deposition stream data.
+</entry>
+
+<entry id="stream_ndep_year_align" type="integer" category="Nitrogen Deposition"
+       group="ndep_stream_nl" valid_values="" >
+Model year to align with stream_ndep_year_first.
+</entry>
+
+<entry id="stream_ndep_data_filename" type="char*256" input_pathname="abs" category="Nitrogen Deposition"
+       group="ndep_stream_nl" valid_values="" >
+Nitrogen deposition stream data filename.
+</entry>
+
+<entry id="stream_ndep_mesh_filename" type="char*256" input_pathname="abs" category="Nitrogen Deposition"
+       group="ndep_stream_nl" valid_values="" >
+Grid mesh file corresponding to stream_ndep_data_filename.
+</entry>
+
+<entry id="megan_factors_file" type="char*256" input_pathname="abs" category="VOC_emissions"
+       group="megan_emis_nl" valid_values="" >
+File containing MEGAN emissions factors.
+Default: set by build-namelist.
+</entry>
+
+<entry id="megan_specifier" type="char*512(200)" category="VOC_emissions"
+       group="megan_emis_nl" valid_values="" >
+MEGAN specifier.
+Default: set by build-namelist.
+</entry>
+
+<entry id="megan_mapped_emisfctrs" type="logical" category="VOC_emissions"
+       group="megan_emis_nl" valid_values=".true.,.false." >
+MEGAN mapped isoprene emissions facters switch
+If true then use mapped MEGAN emissions facters for isoprene.
+Default: .false.
+</entry>
+
+<entry id="carma_fields" type="char*256" category="carma"
+       group="carma_inparm" valid_values="" >
+List of fluxes needed by the CARMA model, from CLM to CAM.
+Default: set by build-namelist.
+</entry>
+
+<entry id="dust_emis_method" type="char*80" category="dust_emissions"
+       group="dust_emis_inparm" valid_values="Zender_2003,Leung_2023" >
+Which dust emission method is going to be used.
+Either the Zender 2003 scheme or the Leung 2023 scheme.
+Default: Zender_2003
+</entry>
+
+<entry id="zender_soil_erod_source" type="char*80" category="dust_emissions"
+       group="dust_emis_inparm" valid_values="none,lnd,atm" >
+Option only applying for the Zender_2003 method for whether the soil erodibility
+file is handled in the active LAND model or in the ATM model.
+(only used when dust_emis_method is Zender_2003)
+Default: atm
+</entry>
+
+<!-- Ozone namelist variables shared between CAM and driver -->
+
+<entry id="atm_ozone_frequency" type="char*64" category="ozone_coupling"
+       group="ozone_coupling_nl" valid_values="subdaily,multiday_average">
+Frequency of surface ozone field passed from CAM to surface components.
+Surface ozone is passed every coupling interval, but this namelist flag
+indicates whether the timestep-level values are interpolated from a
+coarser temporal resolution.
+Default: set by build-namelist.
+</entry>
+
+<entry id="atm_provides_lightning" type="logical" category="lightning_coupling"
+       group="lightning_coupling_nl" valid_values="">
+If TRUE atmosphere model will provide prognosed lightning flash frequency.
+Default: FALSE
+</entry>
+
+<!-- WACCM_GHG Chemistry -->
+
+<entry id="waccm_forcing_file" type="char*256" input_pathname="rel:waccm_forcing_datapath" category="waccm_sc"
+       group="waccm_forcing_nl" valid_values="" >
+Filename of the prescribed waccm forcing data used with waccm_sc chemistry.
+This contains prescribed constituents for non-LTE calculations and heating rates
+for wavelengths less than 200 nm.
+Default: set by build-namelist.
+</entry>
+
+<entry id="waccm_forcing_datapath" type="char*256" input_pathname="abs" category="waccm_sc"
+       group="waccm_forcing_nl" valid_values="" >
+Full pathname of the directory that contains the files specified in
+{{ hilight }}waccm_forcing_filelist{{ closehilight }}.
+Default: set by build-namelist.
+</entry>
+
+<entry id="waccm_forcing_filelist" type="char*256" input_pathname="rel:waccm_forcing_datapath" category="waccm_sc"
+       group="waccm_forcing_nl" valid_values="" >
+A file that contains a sequence of filenames for prescribed waccm forcing data.
+The filenames in this file are relative to the directory specified
+by {{ hilight }}waccm_forcing_datapath{{ closehilight }}.
+Default: set by build-namelist.
+</entry>
+
+<entry id="waccm_forcing_rmfile" type="logical" category="waccm_sc"
+       group="waccm_forcing_nl" valid_values="" >
+Remove the file containing prescribed waccm forcing data from local disk when no longer needed.
+Default: FALSE
+</entry>
+
+<entry id="waccm_forcing_specifier" type="char*16(100)" category="waccm_sc"
+       group="waccm_forcing_nl" valid_values="" >
+Names of variables containing concentrations and heating rate in the prescribed waccm forcing datasets.
+Default: none
+</entry>
+
+<entry id="waccm_forcing_type" type="char*32" category="waccm_sc"
+       group="waccm_forcing_nl" valid_values="CYCLICAL,SERIAL,INTERP_MISSING_MONTHS,FIXED" >
+Type of time interpolation for data in waccm_forcing files.
+Can be set to 'CYCLICAL', 'SERIAL', 'INTERP_MISSING_MONTHS', or 'FIXED'.
+Default: 'CYCLICAL'
+</entry>
+
+<entry id="waccm_forcing_cycle_yr" type="integer" category="waccm_sc"
+       group="waccm_forcing_nl" valid_values="" >
+The  cycle year of the prescribed waccm forcing data
+if {{ hilight }}waccm_forcing_type{{ closehilight }}  is 'CYCLICAL'.
+Format: YYYY
+Default: 0
+</entry>
+
+<entry id="waccm_forcing_fixed_ymd" type="integer" category="waccm_sc"
+       group="waccm_forcing_nl" valid_values="" >
+The date at which the prescribed waccm forcing data is fixed
+if {{ hilight }}waccm_forcing_type{{ closehilight }} is 'FIXED'.
+Format: YYYYMMDD
+Default: 0
+</entry>
+
+<entry id="waccm_forcing_fixed_tod" type="integer" category="waccm_sc"
+       group="waccm_forcing_nl" valid_values="" >
+The time of day (seconds) corresponding to {{ hilight }}waccm_forcing_fixed_ymd{{ closehilight }}
+at which the prescribed waccm forcing data is fixed
+if {{ hilight }}waccm_forcing_type{{ closehilight }} is 'FIXED'.
+Default: 0 seconds
+</entry>
+
+<entry id="h2orates" type="char*256" input_pathname="abs" category="waccm_sc"
+       group="chem_inparm" valid_values="" >
+Full pathname of time-variant boundary dataset for H2O production/loss rates.
+Default: set by build-namelist.
+</entry>
+
+<!-- WACCM -->
+
+<entry id="nlte_use_mo" type="logical" category="waccm_phys"
+       group="radheat_nl" valid_values="" >
+Determines which constituents are used from non-LTE calculations.
+TRUE implies use prognostic constituents.
+FALSE implies use constituents from dataset specified by {{ hilight }}waccm_forcing_file{{ closehilight }}.
+Default: TRUE for full chemistry WACCM; FALSE for WACCM_SC.
+</entry>
+
+<entry id="nlte_limit_co2" type="logical" category="waccm_phys"
+       group="radheat_nl" valid_values="" >
+If TRUE apply upper limit to CO2 concentrations passed to the Formichev non-LTE cooling calculation
+(code not intended for values greater than 720 ppmv).  Running with flag set to TRUE could lead to
+incorrect cooling rates if model CO2 exceeds 720 ppmv.  If FALSE simulation will abort if CO2 levels
+exceed this value at altitudes above 1 mbar.  The 720 ppmv CO2 limiter in the Formichev non-LTE cooling
+scheme is applied to all vertical levels regardless of this setting.
+Default: FALSE
+</entry>
+
+<entry id="nlte_use_aliarms" type="logical" category="waccm_phys"
+       group="radheat_nl" valid_values="" >
+If TRUE, then use the ALI-ARMS scheme (an alternative method of computing non-LTE heating rates in the upper atmosphere)
+Default: FALSE
+</entry>
+
+<entry id="nlte_aliarms_every_x" type="integer" category="waccm_phys"
+       group="radheat_nl" valid_values="" >
+Call ALI-ARMS every X timesteps
+Default: 1
+</entry>
+
+<entry id="nlte_use_extco2" type="logical" category="waccm_phys"
+       group="radheat_nl" valid_values="" >
+If TRUE, then use the extended CO2 scheme of Lopez-Puertas et al. 2024 as an alernative method of computing non-LTE
+CO2 cooling rates in the upper atmosphere. (DOI:10.5194/gmd-17-4401-2024)
+Default: FALSE
+</entry>
+
+<entry id="qbo_cyclic" type="logical" category="waccm_phys"
+       group="qbo_nl" valid_values="" >
+TRUE implies assume cyclic qbo data.
+Default: FALSE
+</entry>
+
+<entry id="qbo_forcing_file" type="char*256" input_pathname="abs" category="waccm_phys"
+       group="qbo_nl" valid_values="" >
+Filepath for qbo forcing dataset.
+Default: Set by build-namelist.
+</entry>
+
+<entry id="qbo_use_forcing" type="logical" category="waccm_phys"
+       group="qbo_nl" valid_values="" >
+TRUE implies qbo package is active.
+Default: FALSE
+</entry>
+
+<entry id="fixed_geomag_year" type="integer" category="waccm"
+       group="geomag_nl" valid_values="" >
+If set this year is used for setting geomagnetic coordinates through out the
+simulation.  If not set the model simulation year is used.
+Default: none
+</entry>
+
+<entry id="igrf_geomag_coefs_file" type="char*256" input_pathname="abs" category="waccm"
+       group="geomag_nl" valid_values="" >
+International Geomagnetic Reference Field (IGRF) coefficients.
+Default: None.
+</entry>
+
+<entry id="epp_all_filepath" type="char*256" input_pathname="abs" category="waccm"
+       group="epp_ionization_nl" valid_values="" >
+Filepath input dataset for ionization due to energetic particle precipitation.
+Default: None.
+</entry>
+<entry id="epp_all_varname" type="char*80" category="waccm"
+       group="epp_ionization_nl" valid_values="" >
+Variable name in netCDF file {{ hilight }}epp_all_filepath{{ closehilight }} which contains
+ion pairs production rates.
+Default: None.
+</entry>
+
+<entry id="epp_spe_filepath" type="char*256" input_pathname="abs" category="waccm"
+       group="epp_ionization_nl" valid_values="" >
+Filepath input dataset for ionization due to solar proton events.
+Default: None.
+</entry>
+<entry id="epp_spe_varname" type="char*80" category="waccm"
+       group="epp_ionization_nl" valid_values="" >
+Variable name in netCDF file {{ hilight }}epp_spe_filepath{{ closehilight }} which contains
+ion pairs production rates.
+Default: None.
+</entry>
+
+<entry id="epp_mee_filepath" type="char*256" input_pathname="abs" category="waccm"
+       group="epp_ionization_nl" valid_values="" >
+Filepath input dataset for ionization due to medium energy electrons.
+Default: None.
+</entry>
+<entry id="epp_mee_varname" type="char*80" category="waccm"
+       group="epp_ionization_nl" valid_values="" >
+Variable name in netCDF file {{ hilight }}epp_mee_filepath{{ closehilight }} which contains
+ion pairs production rates.
+Default: None.
+</entry>
+
+<entry id="epp_gcr_filepath" type="char*256" input_pathname="abs" category="waccm"
+       group="epp_ionization_nl" valid_values="" >
+Filepath input dataset for ionization due to galactic cosmic rays.
+Default: None.
+</entry>
+<entry id="epp_gcr_varname" type="char*80" category="waccm"
+       group="epp_ionization_nl" valid_values="" >
+Variable name in netCDF file {{ hilight }}epp_gcr_filepath{{ closehilight }} which contains
+ion pairs production rates.
+Default: None.
+</entry>
+
+<entry id="mee_ion_inline" type="logical" category="waccm"
+       group="mee_ion_nl" valid_values="" >
+Switch to turn on medium energy electron ionization chemical forcings
+computed inline using Ap geomagnetic activity index input data.
+Default: FALSE
+</entry>
+
+<entry id="mee_ion_blc" type="real" category="waccm"
+       group="mee_ion_nl" valid_values="" >
+Bounce cone loss angle (degrees) for medium energy electrons in radiation belts.
+Must range from 0 to 90 degrees.
+Default: 80 degrees
+</entry>
+
+<entry id="mee_ion_diagonly" type="logical" category="waccm"
+       group="mee_ion_nl" valid_values="" >
+If TRUE, compute medium energy electron ionization rates only for output to history stream.
+Otherwise,  apply the ionization rates as forcings to the chemistry.
+Default: FALSE
+</entry>
+
+<entry id="mee_fluxes_filepath" type="char*256" input_pathname="abs" category="waccm"
+       group="mee_fluxes_opts" valid_values="" >
+Filepath input dataset for radiation belt medium energy electrons fluxes incident
+on upper atmosphere.
+Default: None.
+</entry>
+
+<entry id="mee_fluxes_fillin" type="logical" category="waccm"
+       group="mee_fluxes_opts" valid_values="" >
+If TRUE, fill in missing fluxes with computed fluxes based in Ap index using van de Kamp
+method.
+Default: FALSE
+</entry>
+
+<entry id="apply_lunar_tides" type="logical" category="waccm_phys"
+       group="lunar_tides_opts" valid_values="" >
+Switch to apply lunar tidal tendencies to neutral winds.
+Default: FALSE
+</entry>
+
+<!-- Dry air major species -->
+
+<entry id="dry_air_species" type="char*6(20)"  category="physconst"
+       group="air_composition_nl" valid_values="" >
+List of major species of dry air.  If not set then the composition of dry
+air is considered fixed at tropospheric conditions and the properties of
+dry air are constant.  If set then the list of major species is assumed to
+have 'N2' listed last.  This information is currently used only for
+computing the variable properties of air in WACCM-X configurations.
+Default: Set by build-namelist.
+</entry>
+
+<!-- Water species in moist air -->
+
+<entry id="water_species_in_air" type="char*6(20)"  category="physconst"
+       group="air_composition_nl" valid_values="" >
+List of water species that are included in "moist" air.  This is currently
+used only by the SE dycore to generalize the computation of the moist air
+mass and thermodynamic properties.
+Default: Set by build-namelist.
+</entry>
+
+<!-- SE dycore -->
+
+<entry id="se_fine_ne" type="integer" category="se"
+       group="dyn_se_inparm" valid_values="" >
+Set for refined exodus meshes (variable viscosity).
+Viscosity in namelist specified for regions with a resolution equivilant
+to a uniform grid with se_ne = se_fine_ne.
+Default: -1 (not used)
+</entry>
+
+<entry id="se_ftype" type="integer" category="se"
+       group="dyn_se_inparm" valid_values="0,1,2" >
+CAM physics forcing option:
+0: tendencies
+1: adjustments
+2: hybrid
+Default: Set by build-namelist.
+</entry>
+
+<entry id="se_hypervis_power" type="real" category="se"
+       group="dyn_se_inparm" valid_values="" >
+Scalar viscosity with variable coefficient.
+Use variable hyperviscosity based on element area limited by
+se_max_hypervis_courant.
+Default: 0
+</entry>
+
+<entry id="se_hypervis_scaling" type="real" category="se"
+       group="dyn_se_inparm" valid_values="" >
+Use tensor hyperviscosity.
+Citation: Guba, O., Taylor, M. A., Ullrich, P. A., Overfelt, J. R., and
+Levy, M. N.: The spectral element method (SEM) on variable-resolution
+grids: evaluating grid sensitivity and resolution-aware numerical
+viscosity, Geosci. Model Dev., 7, 2803-2816,
+doi:10.5194/gmd-7-2803-2014, 2014.
+Default: 0 (i.e., not used)
+</entry>
+
+<entry id="se_hypervis_subcycle" type="integer" category="se"
+       group="dyn_se_inparm" valid_values="" >
+Number of hyperviscosity subcycles per dynamics timestep.
+Default: Set by build-namelist
+</entry>
+
+<entry id="se_hypervis_subcycle_sponge" type="integer" category="se"
+       group="dyn_se_inparm" valid_values="" >
+Number of hyperviscosity subcycles per dynamics timestep in sponge del2 diffusion.
+Default: Set by build-namelist
+</entry>
+
+<entry id="se_molecular_diff" type="real" category="se"
+       group="dyn_se_inparm" valid_values="" >
+Used by SE dycore to apply sponge layer diffusion to u, v, and T for
+stability of WACCM configurations. The diffusion is modeled on 3D molecular
+diffusion and thermal conductivity by using actual molecular diffusion and
+thermal conductivity coefficients multiplied by the value of
+se_molecular_diff.
+
+If set &lt;= 0.0 then the code is not activated.  If set &gt; 0.0 then
+the molecular diffusion and thermal conductivity coefficients will be
+multiplied by a factor of se_molecular_diff.
+
+Default: 0.
+</entry>
+
+<entry id="se_min_temperature" type="real" category="se"
+       group="dyn_se_inparm" valid_values="" >
+Used by spectral element dynamical core to apply floor to temperature.
+If set to a value greater than zero the floor is applied.
+Otherwise, no floor is applied.
+Default: 0.
+</entry>
+
+<entry id="se_hypervis_subcycle_q" type="integer" category="se"
+       group="dyn_se_inparm" valid_values="" >
+Number of hyperviscosity subcycles done in tracer advection code.
+Default: Set by build-namelist.
+</entry>
+
+<entry id="se_limiter_option" type="integer" category="se"
+       group="dyn_se_inparm" valid_values="0,4,8" >
+Limiter used for horizontal tracer advection:
+0: None
+4: Sign-preserving limiter.
+8: Monotone limiter.
+Default: 8
+</entry>
+
+<entry id="se_max_hypervis_courant" type="real" category="se"
+       group="dyn_se_inparm" valid_values="" >
+Upper bound for Courant number, used to limit se_hypervis_power.
+Default: 1.0e99 (i.e., not used) unless se_refined_mesh=TRUE
+</entry>
+
+<entry id="se_mesh_file" type="char*256" input_pathname="abs" category="se"
+       group="dyn_se_inparm" valid_values="" >
+Filename of exodus file to read grid from (generated by CUBIT or SQuadGen).
+Default: ""
+</entry>
+
+<entry id="se_ne" type="integer" category="se"
+       group="dyn_se_inparm" valid_values="" >
+Number of elements along a cube edge.
+Must match value of grid. Set this to zero to use a refined mesh.
+Default: Set by build-namelist.
+</entry>
+
+<entry id="se_npes" type="integer" category="se"
+       group="dyn_se_inparm" valid_values="" >
+Number of PEs to be used by SE dycore.
+Default: Number of PEs used by CAM.
+</entry>
+
+<entry id="se_nsplit" type="integer" category="se"
+       group="dyn_se_inparm" valid_values="" >
+Number of dynamics steps per physics timestep.
+Default: Set by build-namelist.
+</entry>
+
+<entry id="se_nu" type="real" category="se"
+       group="dyn_se_inparm" valid_values="" >
+Hyperviscosity coefficient for u,v, T [m^4/s].
+If &lt; 0, se_nu is automatically set.
+Default: Set by build-namelist.
+</entry>
+
+<entry id="se_nu_div" type="real" category="se"
+       group="dyn_se_inparm" valid_values="" >
+Hyperviscosity applied to divergence component of winds [m^4/s].
+If &lt; 0, uses se_nu_p.
+Default: Set by build-namelist.
+</entry>
+
+<entry id="se_nu_p" type="real" category="se"
+       group="dyn_se_inparm" valid_values="" >
+Hyperviscosity coefficient applied to pressure-level thickness [m^4/s].
+If &lt; 0, se_nu_p is automatically set.
+Default: Set by build-namelist.
+</entry>
+
+<entry id="se_nu_top" type="real" category="se"
+       group="dyn_se_inparm" valid_values="" >
+Second-order viscosity applied only near the model top [m^2/s].
+Default: Set by build-namelist.
+</entry>
+
+<entry id="se_sponge_del4_nu_fac" type="real" category="se"
+       group="dyn_se_inparm" valid_values="" >
+Hyperviscosity coefficient se_nu [m^4/s] for u,v, T is increased to
+se_nu_p*se_sponge_del4_nu_fac following a hyperbolic tangent function
+centered around pressure at vertical index se_sponge_del4_lev:
+
+ 0.5_r8*(1.0_r8+tanh(2.0_r8*log(pmid(se_sponge_del4_lev)/press)))
+
+where press is pressure
+
+If &lt; 0, se_sponge_del4_nu_fac is automatically set based on model top location.
+Default: Set by build-namelist.
+</entry>
+
+<entry id="se_sponge_del4_nu_div_fac" type="real" category="se"
+       group="dyn_se_inparm" valid_values="" >
+Divergence damping hyperviscosity coefficient se_nu_div [m^4/s] for u,v is increased to
+se_nu_p*se_sponge_del4_nu_div_fac following a hyperbolic tangent function
+centered around pressure at vertical index se_sponge_del4_lev:
+
+ 0.5_r8*(1.0_r8+tanh(2.0_r8*log(pmid(se_sponge_del4_lev)/press)))
+
+where press is pressure
+
+If &lt; 0, se_sponge_del4_nu_div_fac is automatically set based on model top location.
+Default: Set by build-namelist.
+</entry>
+
+<entry id="se_sponge_del4_lev" type="integer" category="se"
+       group="dyn_se_inparm" valid_values="" >
+Level index around which increased del4 damping is centered.
+
+See se_sponge_del4_nu_fac and se_sponge_del4_nu_div_fac
+
+If &lt; 0, se_sponge_del4_lev is automatically set based on model top location.
+Default: Set by build-namelist.
+</entry>
+
+<entry id="se_large_Courant_incr" type="logical" category="se"
+       group="dyn_se_inparm" valid_values="" >
+  If TRUE the CSLAM algorithm will work for Courant number larger than 1 with
+  a low-order increment for tracer mass more than one grid cell width away
+</entry>
+
+<entry id="se_fvm_supercycling" type="integer" category="se"
+       group="dyn_se_inparm" valid_values="" >
+Number of SE rsplit time-steps CSLAM supercycles
+rsplit/se_fvm_supercycling must be an integer
+</entry>
+
+<entry id="se_fvm_supercycling_jet" type="integer" category="se"
+       group="dyn_se_inparm" valid_values="" >
+Number of SE rsplit time-steps CSLAM supercycles in the jet region
+(which is specified by kmin_jet and kmax_jet)
+rsplit/se_fvm_supercycling_jet must be an integer
+se_fvm_supercycling_jet/se_fvm_supercyling must be an integer
+</entry>
+
+<entry id="se_kmin_jet" type="integer" category="se"
+       group="dyn_se_inparm" valid_values="" >
+  Min level index where CSLAM runs with se_fvm_supercycling_jet
+  (if se_fvm_supercycling_jet.ne.se_fvm_supercycling) or
+  min index where are Courant number increment is active
+  (se_large_Courant_incr=.true.)
+</entry>
+
+<entry id="se_kmax_jet" type="integer" category="se"
+       group="dyn_se_inparm" valid_values="" >
+  Max level index where CSLAM runs with se_fvm_supercycling_jet
+  (if se_fvm_supercycling_jet.ne.se_fvm_supercycling) or
+  max index where are Courant number increment is active
+  (se_large_Courant_incr=.true.)
+</entry>
+
+
+<entry id="se_qsplit" type="integer" category="se"
+       group="dyn_se_inparm" valid_values="" >
+Tracer advection is done every qsplit dynamics timesteps.
+Default: Set by build-namelist.
+</entry>
+
+<entry id="se_refined_mesh" type="logical" category="se"
+       group="dyn_se_inparm" valid_values="" >
+TRUE specified use of a refined grid (mesh) for this run.
+Default: FALSE
+</entry>
+
+<entry id="se_rsplit" type="integer" category="se"
+       group="dyn_se_inparm" valid_values="" >
+Vertically lagrangian code vertically remaps every rsplit tracer timesteps.
+Default: Set by build-namelist.
+</entry>
+
+<entry id="se_statefreq" type="integer" category="se"
+       group="dyn_se_inparm" valid_values="" >
+Frequency with which diagnostic output is written to log (output every
+statefreq dynamics timesteps).
+Default: Set by build-namelist.
+</entry>
+
+<entry id="se_tstep_type" type="integer" category="se"
+       group="dyn_se_inparm" valid_values="" >
+Time stepping method for SE dycore
+se_tstep_type=1  RK2 followed by qsplit-1 Leapfrog steps; second-order accurate in time (CESM1.2.0 setting)
+se_tstep_type=2  RK2-SSP 3 stage (as used by tracers)
+se_tstep_type=3  classic Runga-Kutta (RK) 3 stage
+se_tstep_type=4  Kinnmark&amp;Gray Runga-Kutta (RK) 4 stage
+Default: 4
+</entry>
+
+<entry id="se_statediag_numtrac" type="integer" category="se"
+       group="dyn_se_inparm" valid_values="" >
+Number of tracers to include in logfile diagnostics for SE dycore
+Default: 3
+</entry>
+
+<entry id="se_vert_remap_T" type="char*32" category="se"
+       group="dyn_se_inparm" valid_values="thermal_energy_over_P,Tv_over_logP">
+CAM-SE vertical remapping of temperature:
+"thermal_energy_over_P": Map cp*T (thermal energy conserving) using a
+                         pressure coordinate.
+"Tv_over_logP"         : Map virtual temperature using a log pressure coordinate.
+
+Default: Set by build-namelist.
+</entry>
+
+<entry id="se_vert_remap_uvTq_alg" type="char*32" category="se"
+       group="dyn_se_inparm" valid_values="PPM_bc_mirror,PPM_bc_PCoM,PPM_bc_linear_extrapolation,FV3_PPM,FV3_CS,FV3_CS_2dz_filter,FV3_non_monotone_CS_2dz_filter">
+CAM-SE vertical remap algorithm for u,v,T, and water species.
+PPM_bc_mirror: PPM vertical remap with mirroring at the boundaries
+     (solid wall boundary conditions, high-order throughout)
+PPM_bc_PCoM: PPM vertical remap without mirroring at the boundaries
+     (no boundary conditions enforced, first-order at two cells bordering top and bottom
+     boundaries)
+PPM_bc_linear_extrapolation: PPM with linear extrapolation in ghost cells (code from A. Bradley, DOE)
+
+The following options use the FV3 vertical remapping algorithm.
+
+FV3_PPM: Monotone PPM
+FV3_CS: Monotonic cubic spline with 2*delta_z oscillations removed
+FV3_CS_2dz_filter: Selectively monotonic cubic spline, where local extrema are retained,
+     with 2*delta_z oscillations removed
+FV3_non_monotone_CS_2dz_filter: Non-monotonic (linear) cubic spline with 2*delta_z oscillations removed;
+
+Default: Set by build-namelist.
+</entry>
+
+<entry id="se_vert_remap_tracer_alg" type="char*32" category="se"
+       group="dyn_se_inparm" valid_values="PPM_bc_mirror,PPM_bc_PCoM,PPM_bc_linear_extrapolation,FV3_PPM,FV3_CS,FV3_non_monotone_CS_2dz_filter">
+CAM-SE vertical remap algorithm for non-water tracers
+PPM_bc_mirror: PPM vertical remap with mirroring at the boundaries
+     (solid wall boundary conditions, high-order throughout)
+PPM_bc_PCoM: PPM vertical remap without mirroring at the boundaries
+     (no boundary conditions enforced, first-order at two cells bordering top and bottom
+     boundaries)
+PPM_bc_linear_extrapolation: PPM with linear extrapolation in ghost cells (code from A. Bradley, DOE)
+
+The following options use the FV3 vertical remapping algorithm.
+
+FV3_PPM: Monotone PPM
+FV3_CS: Monotonic cubic spline with 2*delta_z oscillations removed
+FV3_non_monotone_CS_2dz_filter: Non-monotonic (linear) cubic spline with 2*delta_z oscillations removed;
+
+Default: Set by build-namelist.
+</entry>
+
+<entry id="se_write_restart_unstruct" type="logical" category="se"
+       group="dyn_se_inparm" valid_values="" >
+Set .true. to allow writing SE dynamics fields to the restart file using the
+unstructured grid format.  This allows the restart file to be used as an
+initial file, but its use as a restart file will introduce roundoff size
+differences into the simulation.
+Default: .false.
+</entry>
+
+<!-- Nudging -->
+<entry id="se_met_nudge_u" type="real" category="se"
+       group="dyn_se_inparm" valid_values="" >
+Nudging factor for prescribed winds in SE dycore
+Units: 1/sec
+Default: 2e-5
+</entry>
+
+<entry id="se_met_nudge_t" type="real" category="se"
+       group="dyn_se_inparm" valid_values="" >
+Nudging factor for prescribed temperature in SE dycore
+Units: 1/sec
+Default: 2e-5
+</entry>
+
+<entry id="se_met_nudge_p" type="real" category="se"
+       group="dyn_se_inparm" valid_values="" >
+Nudging factor for prescribed surface pressure in SE dycore
+Units: 1/sec
+Default: 0.0
+</entry>
+
+<entry id="se_met_tevolve" type="integer" category="se"
+       group="dyn_se_inparm" valid_values="0,1" >
+Switch to turn on/off time evolution of dynamics nudging
+Default: 0
+</entry>
+
+<!-- Physics grid entries -->
+<entry id="se_fv_nphys" type="integer" category="se"
+       group="dyn_se_inparm" valid_values="" >
+Number of equally-spaced horizontal physics points per spectral
+element. A number greater than zero will define [se_fv_nphys] equally
+spaced physics points in each direction (e.g., se_fv_nphys = 3 will
+result in 9 equally-spaced physics points per element).
+Default: 0 = feature disabled, use dynamics GLL points.
+</entry>
+
+<!-- Option to write SCRIP grid file -->
+<entry id="se_write_grid_file" type="char*16" category="se"
+       group="dyn_se_inparm" valid_values="no,SCRIP" >
+If 'SCRIP', write a NetCDF file with the grid in SCRIP format.
+If using a finite-volume physics grid, write the FVM grid, otherwise
+write the native GLL grid.
+Note that if this option is used, the simulation will exit after writing.
+Default: 'no'
+</entry>
+
+<entry id="se_grid_filename" type="char*256" category="se"
+       group="dyn_se_inparm" valid_values="" >
+Name of grid file to write if se_write_grid_file is set.
+Default: Set according to active grid
+</entry>
+
+<entry id="se_write_gll_corners" type="logical" category="se"
+       group="dyn_se_inparm" valid_values="" >
+Set to true to write the SEMapping.nc file.
+Default: .false.
+</entry>
+
+<entry id="native_mapping_outgrids" type="char*256(5)" category="se"
+       group="native_mapping_nl" valid_values="" >
+List of SCRIP grid filenames each representing a destination grid. If provided during a CAM simulation running the spectral element dycore, mapping files will be created from the native cubed-sphere grid to each destination grid. Both native mapping (using the internal spectral element basis functions) and bilinear maps are created.
+Default: none
+</entry>
+
+<!-- SE performance (threading) entries -->
+<entry id="se_horz_num_threads" type="integer" category="se"
+       group="dyn_se_inparm" valid_values="" >
+Number of threads to use for loops over elements.
+Default: Set by build-namelist.
+</entry>
+
+<entry id="se_vert_num_threads" type="integer" category="se"
+       group="dyn_se_inparm" valid_values="" >
+Number of threads to use when processing vertical loops. Normally
+equal to se_tracer_num_threads.
+Default: Set by build-namelist.
+</entry>
+
+<entry id="se_tracer_num_threads" type="integer" category="se"
+       group="dyn_se_inparm" valid_values="" >
+Number of threads to use when processing loops over threads.
+Normally equal to se_vert_num_threads.
+Default: Set by build-namelist.
+</entry>
+
+<entry id="se_pgf_formulation" type="integer" category="se"
+       group="dyn_se_inparm" valid_values="1,2,3" >
+
+  1: Exner version of pressure gradient force (PGF)
+  see Appendix A in https://agupubs.onlinelibrary.wiley.com/doi/epdf/10.1029/2022MS003192
+
+  2: Traditional pressure gradient formulation (grad p)
+
+  3: Hybrid (formulation 1 where hybm>0 else formulation 2)
+     Use hybrid PGF option for WACCM-x to make WACCM-x consistent with PGF
+     used in CAM in the troposphere and traditional PGF formulation above
+
+  Default: Set by build-namelist.
+</entry>
+
+<entry id="se_dribble_in_rsplit_loop" type="integer" category="se"
+       group="dyn_se_inparm" valid_values="0,1" >
+
+  0: physics tendencies will be added every vertical remapping time-step (dt_phys/se_nsplit)
+     for se_ftype=0,2
+
+  1: physics tendencies will be added every dynamics time-step (dt_phys/se_nsplit*se_rsplit)
+     for se_ftype=0,2
+
+     If se_ftype=1 then se_dribble_in_rsplit_loop has no effect since physics tendencies are added as an adjustment
+
+  Default: Set by build-namelist.
+</entry>
+
+
+<!-- MPAS dycore -->
+
+<entry id="mpas_time_integration" type="char*512" category="mpas"
+       group="nhyd_model" valid_values="SRK3">
+Time integration scheme in MPAS dycore.
+Default: SRK3
+</entry>
+
+<entry id="mpas_time_integration_order" type="integer" category="mpas"
+       group="nhyd_model" valid_values="2,3">
+Order for RK time integration in MPAS dycore.
+Default: 2
+</entry>
+
+<entry id="mpas_dt" type="real" category="mpas"
+       group="nhyd_model" valid_values="">
+Time step (seconds) in MPAS dycore
+Default: Set by build-namelist.
+</entry>
+
+<entry id="mpas_split_dynamics_transport" type="logical" category="mpas"
+       group="nhyd_model" valid_values="">
+Whether to super-cycle scalar transport in MPAS dycore.
+Default: TRUE
+</entry>
+
+<entry id="mpas_number_of_sub_steps" type="integer" category="mpas"
+       group="nhyd_model" valid_values="">
+Number of acoustic steps per full RK step in MPAS dycore.
+Default: 2
+</entry>
+
+<entry id="mpas_dynamics_split_steps" type="integer" category="mpas"
+       group="nhyd_model" valid_values="">
+When {{ hilight }}mpas_split_dynamics_transport{{ closehilight }} = .true., the
+number of RK steps per transport step in MPAS dycore.
+Default: 3
+</entry>
+
+<entry id="mpas_h_mom_eddy_visc2" type="real" category="mpas"
+       group="nhyd_model" valid_values="">
+Del^2 eddy viscosity for horizontal diffusion of momentum in MPAS dycore.
+Default: 0.0
+</entry>
+
+<entry id="mpas_h_mom_eddy_visc4" type="real" category="mpas"
+       group="nhyd_model" valid_values="">
+Del^4 eddy hyper-viscosity for horizontal diffusion of momentum in MPAS dycore.
+Default: 0.0
+</entry>
+
+<entry id="mpas_v_mom_eddy_visc2" type="real" category="mpas"
+       group="nhyd_model" valid_values="">
+Del^2 eddy viscosity for vertical diffusion of momentum in MPAS dycore.
+Default: 0.0
+</entry>
+
+<entry id="mpas_h_theta_eddy_visc2" type="real" category="mpas"
+       group="nhyd_model" valid_values="">
+Del^2 eddy viscosity for horizontal diffusion of theta in MPAS dycore.
+Default: 0.0
+</entry>
+
+<entry id="mpas_h_theta_eddy_visc4" type="real" category="mpas"
+       group="nhyd_model" valid_values="">
+Del^4 eddy hyper-viscosity for horizontal diffusion of theta in MPAS dycore.
+Default: 0.0
+</entry>
+
+<entry id="mpas_v_theta_eddy_visc2" type="real" category="mpas"
+       group="nhyd_model" valid_values="">
+Del^2 eddy viscosity for vertical diffusion of theta in MPAS dycore.
+Default: 0.0
+</entry>
+
+<entry id="mpas_horiz_mixing" type="char*512" category="mpas"
+       group="nhyd_model" valid_values="2d_fixed,2d_smagorinsky">
+Formulation of horizontal mixing in MPAS dycore.
+Default: 2d_smagorinsky
+</entry>
+
+<entry id="mpas_len_disp" type="real" category="mpas"
+       group="nhyd_model" valid_values="">
+Horizontal length scale, used by the Smagorinsky formulation of horizontal
+diffusion and by 3-d divergence damping in MPAS dycore.
+Default: 120000.0
+</entry>
+
+<entry id="mpas_visc4_2dsmag" type="real" category="mpas"
+       group="nhyd_model" valid_values="">
+Coefficient multiplied by delta x^3 to obtain Del^4 physical hyperviscosity
+in MPAS dycore.
+Default: 0.05
+</entry>
+
+<entry id="mpas_del4u_div_factor" type="real" category="mpas"
+       group="nhyd_model" valid_values="">
+Scaling factor for the divergent component of Del^4 u calculation in MPAS
+dycore.
+Default: 10.0
+</entry>
+
+<entry id="mpas_w_adv_order" type="integer" category="mpas"
+       group="nhyd_model" valid_values="2,3,4">
+Horizontal advection order for w in MPAS dycore.
+Default: 3
+</entry>
+
+<entry id="mpas_theta_adv_order" type="integer" category="mpas"
+       group="nhyd_model" valid_values="2,3,4">
+Horizontal advection order for theta in MPAS dycore.
+Default: 3
+</entry>
+
+<entry id="mpas_scalar_adv_order" type="integer" category="mpas"
+       group="nhyd_model" valid_values="2,3,4">
+Horizontal advection order for scalars in MPAS dycore.
+Default: 3
+</entry>
+
+<entry id="mpas_u_vadv_order" type="integer" category="mpas"
+       group="nhyd_model" valid_values="2,3,4">
+Vertical advection order for normal velocities (u) in MPAS dycore
+Default: 3
+</entry>
+
+<entry id="mpas_w_vadv_order" type="integer" category="mpas"
+       group="nhyd_model" valid_values="2,3,4">
+Vertical advection order for w in MPAS dycore.
+Default: 3
+</entry>
+
+<entry id="mpas_theta_vadv_order" type="integer" category="mpas"
+       group="nhyd_model" valid_values="2,3,4">
+Vertical advection order for theta in MPAS dycore.
+Default: 3
+</entry>
+
+<entry id="mpas_scalar_vadv_order" type="integer" category="mpas"
+       group="nhyd_model" valid_values="2,3,4">
+Vertical advection order for scalars in MPAS dycore.
+Default: 3
+</entry>
+
+<entry id="mpas_scalar_advection" type="logical" category="mpas"
+       group="nhyd_model" valid_values="">
+Whether to advect scalar fields in MPAS dycore
+Default: TRUE
+</entry>
+
+<entry id="mpas_positive_definite" type="logical" category="mpas"
+       group="nhyd_model" valid_values="">
+Whether to enable positive-definite advection of scalars in MPAS dycore.
+Default: FALSE
+</entry>
+
+<entry id="mpas_monotonic" type="logical" category="mpas"
+       group="nhyd_model" valid_values="">
+Whether to enable monotonic limiter in scalar advection in MPAS dycore.
+Default: TRUE
+</entry>
+
+<entry id="mpas_coef_3rd_order" type="real" category="mpas"
+       group="nhyd_model" valid_values="">
+Upwinding coefficient in the 3rd order advection scheme in MPAS dycore.
+Default: 1.0
+</entry>
+
+<entry id="mpas_smagorinsky_coef" type="real" category="mpas"
+       group="nhyd_model" valid_values="">
+Dimensionless empirical parameter relating the strain tensor to the eddy
+viscosity in the Smagorinsky turbulence model in MPAS dycore.
+Default: 0.125
+</entry>
+
+<entry id="mpas_mix_full" type="logical" category="mpas"
+       group="nhyd_model" valid_values="">
+Mix full theta and u fields, or mix perturbation from intitial state in
+MPAS dycore.
+Default: TRUE
+</entry>
+
+<entry id="mpas_smdiv" type="real" category="mpas"
+       group="nhyd_model" valid_values="">
+3-d divergence damping coefficient in MPAS dycore.
+Default: 0.1
+</entry>
+
+<entry id="mpas_apvm_upwinding" type="real" category="mpas"
+       group="nhyd_model" valid_values="">
+Amount of upwinding in APVM in MPAS dycore.
+Default: 0.5
+</entry>
+
+<entry id="mpas_h_ScaleWithMesh" type="logical" category="mpas"
+       group="nhyd_model" valid_values="">
+Scale eddy viscosities with mesh-density function for horizontal diffusion
+in MPAS dycore.
+Default: TRUE
+</entry>
+
+<entry id="mpas_zd" type="real" category="mpas"
+       group="damping" valid_values="">
+Height in meters above MSL to begin w-damping profile in MPAS dycore.
+Default: 22000.0
+</entry>
+
+<entry id="mpas_xnutr" type="real" category="mpas"
+       group="damping" valid_values="">
+Maximum w-damping coefficient at model top in MPAS dycore.
+Default: 0.2
+</entry>
+
+<entry id="mpas_cam_coef" type="real" category="mpas"
+       group="damping" valid_values="">
+Coefficient for scaling the 2nd-order horizontal diffusion in the mpas_cam absorbing
+layer. The absorbing layer depth is controlled with mpas_cam_damping_levels. The damping
+coefficients scale linearly with mpas_cam_coef. A value of 0.0 (or
+mpas_cam_damping_levels=0) disables the 2nd-order diffusion in the absorbing layer. Sponge
+layer absorption can also be provided by Rayleigh damping.
+
+E.g. a value of 1.0 with mpas_cam_damping_levels=3 will result in damping coefficients of
+2E6 m^2/s, 6E5, 2E5 in the top-most three layers on the dynamics variables u, w, and
+theta.
+Default: 0.0
+</entry>
+
+<entry id="mpas_cam_damping_levels" type="integer" category="mpas"
+       group="damping" valid_values="">
+Number mpas_cam absorbing layers in which to apply 2nd-order horizontal diffusion.
+Viscocity linearly ramps to zero by layer number from the top. mpas_cam_damping_levels and
+mpas_cam_coef must both be greater than 0 for the diffusion to be enabled.
+Default: 0
+</entry>
+
+<entry id="mpas_rayleigh_damp_u" type="logical" category="mpas"
+       group="damping" valid_values="">
+Whether to apply Rayleigh damping on horizontal velocity in the top-most model levels.
+The number of levels is specified by the config_number_rayleigh_damp_u_levels option,
+and the damping timescale is specified by the config_rayleigh_damp_u_timescale_days option.
+Default: TRUE
+</entry>
+
+<entry id="mpas_rayleigh_damp_u_timescale_days" type="real" category="mpas"
+       group="damping" valid_values="">
+Timescale, in days (86400 s), for the Rayleigh damping on horizontal velocity in
+the top-most model levels.
+Default: 5.0
+</entry>
+
+<entry id="mpas_number_rayleigh_damp_u_levels" type="integer" category="mpas"
+       group="damping" valid_values="">
+Number layers in which to apply Rayleigh damping on horizontal velocity at top of model;
+damping linearly ramps to zero by layer number from the top
+Default: 3
+</entry>
+
+<entry id="mpas_epssm_minimum" type="real" category="mpas"
+       group="damping" valid_values="real values between 0 and 1">
+Value of epssm, the off-centering parameter for the vertically implicit acoustic integration,
+below transition zone.
+Default: 0.1
+</entry>
+
+<entry id="mpas_epssm_maximum" type="real" category="mpas"
+       group="damping" valid_values="real values between 0 and 1">
+Value of epssm, the off-centering parameter for the vertically implicit acoustic integration,
+above transition zone.
+Default: 0.5
+</entry>
+
+<entry id="mpas_epssm_transition_bottom_z" type="real" category="mpas"
+       group="damping" valid_values="positive real values">
+Height (in meters) above MSL for the bottom of transition zone for epssm.
+Default: 30000.0
+</entry>
+
+<entry id="mpas_epssm_transition_top_z" type="real" category="mpas"
+       group="damping" valid_values="positive real values">
+Height (in meters) above MSL for the top of transition zone for epssm.
+Default: 50000.0
+</entry>
+
+<entry id="mpas_apply_lbcs" type="logical" category="mpas"
+       group="limited_area" valid_values="">
+Whether to apply lateral boundary conditions
+Default: FALSE
+</entry>
+
+<entry id="mpas_jedi_da" type="logical" category="mpas"
+       group="assimilation" valid_values="">
+Whether this run is within the JEDI data assimilation framework; used to add
+temperature and specific humidity as diagnostics
+Default: FALSE
+</entry>
+
+<entry id="mpas_block_decomp_file_prefix" type="char*512" input_pathname="abs" category="mpas"
+       group="decomposition" valid_values="">
+Prefix of the MPAS graph decomposition file, to be suffixed with the MPI
+task count.  The prefix includes the full pathname of the directory
+containing the file.
+Default: Set by build-namelist.
+</entry>
+
+<entry id="mpas_do_restart" type="logical" category="mpas"
+       group="restart" valid_values="">
+Whether this run with the MPAS dycore is to restart from a previous restart
+file or not.
+Default: Set by build-namelist.
+</entry>
+
+<entry id="mpas_print_global_minmax_vel" type="logical" category="mpas"
+       group="printout" valid_values="">
+Whether to print the global min/max of horizontal normal velocity and
+vertical velocity each timestep in MPAS dycore.
+Default: TRUE
+</entry>
+
+<entry id="mpas_print_detailed_minmax_vel" type="logical" category="mpas"
+       group="printout" valid_values="">
+Whether to print the global min/max of horizontal normal velocity and
+vertical velocity each timestep, along with the location in the domain
+where those extrema occurred in MPAS dycore.
+Default: FALSE
+</entry>
+
+<entry id="mpas_print_global_minmax_sca" type="logical" category="mpas"
+       group="printout" valid_values="">
+Whether to print the global min/max of scalar fields each timestep in MPAS
+dycore.
+Default: FALSE
+</entry>
+
+<entry id="mpas_halo_exch_method" type="char*512" category="mpas"
+       group="development" valid_values="mpas_dmpar,mpas_halo">
+Method to use for exchanging halos in MPAS dycore.
+Default: mpas_halo
+</entry>
+
+<entry id="mpas_gpu_aware_mpi" type="logical" category="mpas"
+       group="development" valid_values=".false.,.true.">
+Whether to use GPU-aware MPI for halo exchanges in MPAS dycore. GPU-aware MPI
+is only implemented for mpas_halo_exch_method = mpas_halo.
+Default: FALSE
+</entry>
+
+<!-- Dycore testing  -->
+
+<entry id="analytic_ic_type" type="char*80" category="dyn_test"
+       group="analytic_ic_nl"
+       valid_values="none,held_suarez_1994,moist_baroclinic_wave_dcmip2016,dry_baroclinic_wave_dcmip2016,dry_baroclinic_wave_jw2006,us_standard_atmosphere" >
+Specify the type of analytic initial conditions for an initial run.
+held_suarez_1994: Initial conditions specified in Held and Suarez (1994)
+moist_baroclinic_wave_dcmip2016: Moist baroclinic wave as used in the DCMIP 2016 experiments
+dry_baroclinic_wave_dcmip2016: Dry baroclinic wave as used in the DCMIP 2016 experiments
+dry_baroclinic_wave_jw2006: Dry baroclinic wave as specified in Jablonowski and Williamson (2006)
+us_standard_atmosphere: static atmospheric state (u,v)=0, standard lapse rate for T, PS is hydrostatic equilibrium with topography
+(this ic is recommended for spinning up new initial condition files when changing horizontal or vertical resolution)
+Default: 'none'
+</entry>
+
+<!-- ========================================================================================  -->
+<!-- Rename component log files.  shr_file_mod::shr_file_setIO reads
+     namelist /modelio/.  These variables in group camexp are treated
+     specially in build-namelist, where they are put into the modelio
+     namelist group in files with specific names that are read by each
+     component.  -->
+
+<entry id="atm_logfile" type="char*256" category="driver"
+       group="camexp" valid_values="">
+Name of file that the atmosphere component log messages will be written to.  By
+default all log messages are written to stdout.
+Default: ""
+</entry>
+
+<entry id="atm_logfile_diro" type="char*256" category="driver"
+       group="camexp" valid_values="">
+Absolute pathname of directory that the file specified by {{ hilight }}atm_logfile{{ closehilight }}
+will be written to.
+Default: "."
+</entry>
+
+<entry id="cpl_logfile" type="char*256" category="driver"
+       group="camexp" valid_values="">
+Name of file that the driver component log messages will be written to.  By
+default all log messages are written to stdout.
+Default: ""
+</entry>
+
+<entry id="cpl_logfile_diro" type="char*256" category="driver"
+       group="camexp" valid_values="">
+Absolute pathname of directory that the file specified by {{ hilight }}cpl_logfile{{ closehilight }}
+will be written to.
+Default: "."
+</entry>
+
+<entry id="lnd_logfile" type="char*256" category="driver"
+       group="camexp" valid_values="">
+Name of file that the land component log messages will be written to.  By
+default all log messages are written to stdout.
+Default: ""
+</entry>
+
+<entry id="lnd_logfile_diro" type="char*256" category="driver"
+       group="camexp" valid_values="">
+Absolute pathname of directory that the file specified by {{ hilight }}lnd_logfile{{ closehilight }}
+will be written to.
+Default: "."
+</entry>
+
+<entry id="rof_logfile" type="char*256" category="driver"
+       group="camexp" valid_values="">
+Name of file that the runoff component log messages will be written to.  By
+default all log messages are written to stdout.
+Default: ""
+</entry>
+
+<entry id="rof_logfile_diro" type="char*256" category="driver"
+       group="camexp" valid_values="">
+Absolute pathname of directory that the file specified by {{ hilight }}rof_logfile{{ closehilight }}
+will be written to.
+Default: "."
+</entry>
+
+<entry id="sim_year" type="char*9" category="cam"
+       group="camexp" valid_values="1850,2000,2010,1850-2000,1850-2015">
+This varible is only used internally by build-namelist to determine
+appropriate defaults for climatological or transient forcing datasets.
+Default: set by build-namelist.
+</entry>
+
+<!-- ========================================================================================  -->
+<!-- physical constants: -->
+
+<entry id="sday" type="real" category="physconst"
+       group="physconst_nl" valid_values="" >
+Length of siderial day [seconds].
+Default: set to shr_const value
+</entry>
+
+<entry id="rearth" type="real" category="physconst"
+       group="physconst_nl" valid_values="" >
+Radius of Earth [m].
+Default: set to shr_const value
+</entry>
+
+<entry id="gravit" type="real" category="physconst"
+       group="physconst_nl" valid_values="" >
+Acceleration of gravity [m/s**2].
+Default: set to shr_const value
+</entry>
+
+<entry id="mwdry" type="real" category="physconst"
+       group="physconst_nl" valid_values="" >
+Molecular weight of dry air [g/mol]
+Default: set to shr_const value
+</entry>
+
+<entry id="cpair" type="real" category="physconst"
+       group="physconst_nl" valid_values="" >
+Heat capacity of dry air at constant pressure [J/kg/K].
+Default: set to shr_const value
+</entry>
+
+<entry id="mwh2o" type="real" category="physconst"
+       group="physconst_nl" valid_values="" >
+Molecular weight of water [g/mol].
+Default: set to shr_const value
+</entry>
+
+<entry id="cpwv" type="real" category="physconst"
+       group="physconst_nl" valid_values="" >
+Heat capacity of water vapor at constant pressure [J/kg/K].
+Default: set to shr_const value
+</entry>
+
+<entry id="tmelt" type="real" category="physconst"
+       group="physconst_nl" valid_values="" >
+Freezing point of water [K].
+Default: set to shr_const value
+</entry>
+
+<entry id="omega" type="real" category="physconst"
+       group="physconst_nl" valid_values="" >
+Planetary rotation rate (radians/second). Value set here is ONLY used in the atmosphere.
+Default: set to shr_const value
+</entry>
+
+<!-- for offine unit drivers -->
+
+<entry id="offline_driver_infile" type="char*256" input_pathname="abs" category="offline_unit_driver"
+       group="offline_driver_nl" valid_values="" >
+Filepath for dataset for offline unit driver.
+Default: none
+</entry>
+
+<entry id="offline_driver_fileslist" type="char*256" input_pathname="abs" category="offline_unit_driver"
+       group="offline_driver_nl" valid_values="" >
+List of filepaths for dataset for offline unit driver.
+Default: none
+</entry>
+
+<!-- for fv3 dynamical core -->
+
+<entry id="fv3_clock_grain" type="char*256" category="dyn_fv3"
+       group="fms_nml" valid_values="" >
+The level of clock granularity used for performance timing sections
+of code. Possible values in order of increasing detail are:
+NONE, COMPONENT, SUBCOMPONENT, MODULE_DRIVER, MODULE, ROUTINE,
+LOOP, and INFRA.
+Default: none
+</entry>
+
+<entry id="fv3_domains_stack_size" type="integer" category="dyn_fv3"
+       group="fms_nml" valid_values="" >
+Integer: The size in words of the MPP_DOMAINS user stack. If
+fv3_domains_stack_size &gt; 0, the following MPP_DOMAINS routine is called:
+call mpp_domains_set_stack_size (fv3_domains_stack_size). If
+fv3_domains_stack_size = 0 then the size set by
+mpp_domains_mod is used.
+Default: 6000000
+</entry>
+
+<entry id="fv3_stack_size" type="integer" category="dyn_fv3"
+       group="fms_nml" valid_values="" >
+Integer: The size in words of the MPP user stack. If fv3_stack_size &gt; 0, the following
+MPP routine is called: call mpp_set_stack_size (fv3_stack_size). If fv3_stack_size = 0
+then the defaults set by mpp_mod is used.
+Default: 6000000
+</entry>
+
+<entry id="fv3_print_memory_usage" type="logical" category="dyn_fv3"
+       group="fms_nml" valid_values="" >
+Logical: If set to .TRUE., memory usage statistics will be printed at various
+points in the code. It is used to study memory usage, e.g to detect
+memory leaks.
+Default: FALSE
+</entry>
+
+<entry id="fv3_adjust_dry_mass" type="logical" category="dyn_fv3"
+       group="fv_core_nml" valid_values="" >
+Logical: whether to adjust the global dry-air mass to
+the value set by fv3_adjust_dry_mass. This is only done in an initialization
+step, particularly when using an initial condition from an external
+dataset, interpolated from another resolution (either horizontal or
+vertical), or when changing the topography, so that the global mass
+of the atmosphere matches some estimate of observed value. It is
+recommended to only set this to True when initializing the model.
+Default: FALSE
+</entry>
+
+<entry id="fv3_beta" type="real" category="dyn_fv3"
+       group="fv_core_nml" valid_values="" >
+Real: Parameter specifying fraction of time-off-centering for
+backwards evaluation of the pressure gradient force. The default value
+of 0.0 indicates a fully backwards evaluation of the pressure gradient
+force using the updated (time n+1) dynamical fields. A value of 0.5
+will equally weight the PGF determined at times n and n+1, but may not
+be stable; values larger than 0.45 are not recommended. A value of 0.4
+is recommended for most hydrostatic simulations, which allows an
+improved representation of inertia-gravity waves in the tropics. In
+non-hydrostatic simulations using the semi-implicit solver (a_imp &gt; 0.5)
+the values of a_imp and fv3_beta should add to 1, so that the
+time-centering is consistent between the PGF and the nonhydrostatic
+solver. Proper range is 0 to 0.45.
+Default: 0.
+</entry>
+
+<entry id="fv3_consv_am" type="logical" category="dyn_fv3"
+       group="fv_core_nml" valid_values="" >
+Logical: whether to enable Angular momentum fixer.
+Default: FALSE
+</entry>
+
+<entry id="fv3_consv_te" type="integer" category="dyn_fv3"
+       group="fv_core_nml" valid_values="" >
+Real: fraction of total energy lost during the adiabatic integration
+between calls of the physics, to be added back globally as heat;
+essentially the strength of the energy fixer in the physics. Note that
+this is a global energy fixer and cannot add back energy locally.
+The default algorithm increments the potential temperature so the
+pressure gradients are unchanged. Proper range is 0
+to 1. 1 will restore the energy completely to its original value before
+entering the physics; a value of 0.7 roughly causes the energy fixer
+to compensate for the amount of energy changed by the physics in
+GFDL HiRAM or AM3.
+Default: 0
+</entry>
+
+<entry id="fv3_dddmp" type="real" category="dyn_fv3"
+       group="fv_core_nml" valid_values="" >
+Real: Dimensionless coefficient for the second-order Smagorinsky type
+divergence damping. 0.0 is the default but 0.2 (the Smagorinsky
+constant) is recommended if ICs are noisy
+Default: 0.0
+</entry>
+
+<entry id="fv3_delt_max" type="real" category="dyn_fv3"
+       group="fv_core_nml" valid_values="" >
+Real: maximum allowed magnitude of the dissipative heating
+rate, K/s; larger magnitudes are clipped to this amount. This can
+help avoid instability that can occur due to strong heating when d_con &gt; 0.
+A value of 0.008 (a rate equivalent to about 800K per day) is sufficient
+to stabilize the model at 3 km resolution.
+Default: 0.0
+</entry>
+
+<entry id="fv3_dnats" type="integer" category="dyn_fv3"
+       group="fv_core_nml" valid_values="" >
+Integer: The number of tracers which are not to be advected by
+the dynamical core, but still passed into the dynamical core; the last
+dnats+pnats tracers in field_table are not advected.
+Default: 0
+</entry>
+
+<entry id="fv3_do_sat_adj" type="logical" category="dyn_fv3"
+       group="fv_core_nml" valid_values="" >
+Logical: If true activate Fast Saturation Adjustment Module. It adjusts
+cloud water evaporation (cloud water change to water vapor), cloud water freezing
+(cloud water change to cloud ice), and cloud ice deposition
+(water vapor change to cloud ice).
+Default: FALSE
+</entry>
+
+<entry id="fv3_do_vort_damp" type="logical" category="dyn_fv3"
+       group="fv_core_nml" valid_values="" >
+Logical: whether to apply flux damping (of strength governed by fv3_vtdm4)
+to the fluxes of vorticity, air mass, and nonhydrostatic vertical
+velocity (there is no dynamically correct way to
+add explicit diffusion to the tracer fluxes). The form is the same
+as is used for the divergence damping, including the same order
+(from fv3_nord) damping, unless fv3_nord = 0, in which case this damping
+is fourth-order, or if fv3_nord = 3, in which case this damping is
+sixth-order (instead of eighth-order). We recommend enabling this
+damping when the linear or non-monotonic horizontal advection
+schemes are enabled, but is unnecessary and not recommended
+when using monotonic advection.
+Default: FALSE
+</entry>
+
+<entry id="fv3_dwind_2d" type="logical" category="dyn_fv3"
+       group="fv_core_nml" valid_values="" >
+Logical: whether to use a simpler and faster algorithm for interpolating the A-grid (cell-centered) wind tendencies computed from
+the physics to the D-grid. Typically, the A-grid wind tendencies are
+first converted in 3D cartesian coordinates and then interpolated
+before converting back to 2D local coordinates. When this option
+enabled, a much simpler but less accurate 2D interpolation is used.
+Default: FALSE
+</entry>
+
+<entry id="fv3_d_con" type="real" category="dyn_fv3"
+       group="fv_core_nml" valid_values="" >
+Real: Fraction of kinetic energy lost to net damping (divergence
+and vorticity) to be converted to heat. Acts as a dissipative heating
+mechanism in the dynamical core. Proper range is 0
+to 1. Note that this is a local, physically correct, energy fixer.
+Default: 0
+</entry>
+
+<entry id="fv3_d_ext" type="real" category="dyn_fv3"
+       group="fv_core_nml" valid_values="" >
+Real: coefficient for external (barotropic) mode damping.
+Proper range is 0 to 0.02. A value of 0.01 or 0.02 may help
+improve the models maximum stable time step in low-resolution
+(2-degree or poorer) simulations; otherwise a value of 0 is recommended.
+Default: 0
+</entry>
+
+<entry id="fv3_d2_bg" type="real" category="dyn_fv3"
+       group="fv_core_nml" valid_values="" >
+Real: coefficient for background second-order divergence damping.
+This option remains active even if fv3_nord is nonzero.
+Proper range is 0 to 0.02.
+Default: 0.0
+</entry>
+
+<entry id="fv3_d2_bg_k1" type="real" category="dyn_fv3"
+       group="fv_core_nml" valid_values="" >
+Real: strength of second-order diffusion in the top sponge
+layer. This value, and fv3_d2_bg_k2, will be changed
+appropriately in the model (depending on the height of model top),
+so the actual damping may be very reduced. See atmos_cubed_sphere/model/dyn_core
+for details. Recommended range is 0. to 0.2. Note that since diffusion is
+converted to heat if fv3_d_con &gt; 0 larger amounts of spongelayer diffusion may be less stable.
+Default: 0.15
+</entry>
+
+<entry id="fv3_d2_bg_k2" type="real" category="dyn_fv3"
+       group="fv_core_nml" valid_values="" >
+Real: strength of second-order diffusion in the second sponge
+layer from the model top. This value should be
+lower than fv3_d2_bg_k1.
+Default: 0.02
+</entry>
+
+<entry id="fv3_d4_bg" type="real" category="dyn_fv3"
+       group="fv_core_nml" valid_values="" >
+Real: Dimensionless coefficient for background higher-order
+divergence damping. If no second-order divergence
+damping is used, then values between 0.1 and 0.16 are recommended.
+Requires fv3_nord &gt; 0. Note that the scaling for fv3_d4_bg differs from that
+of fv3_d2_bg; fv3_nord ge 1 and fv3_d4_bg = 0.16 will be less diffusive than
+fv3_nord = 0 and fv3_d2_bg = 0.02.
+Default: 0.15
+</entry>
+
+<entry id="fv3_fill" type="logical" category="dyn_fv3"
+       group="fv_core_nml" valid_values="" >
+Logical: Fills in negative tracer values by taking positive tracers from
+the cells above and below. This option is useful when the physical
+parameterizations produced negatives.
+Default: TRUE
+</entry>
+
+<entry id="fv3_fv_debug" type="logical"  category="dyn_fv3"
+       group="fv_core_nml" valid_values="" >
+true for debug print
+Default: FALSE
+</entry>
+
+<entry id="fv3_fv_diag" type="logical"  category="dyn_fv3"
+       group="fv_core_nml" valid_values="" >
+true to print diagnostics
+Default: FALSE
+</entry>
+
+<entry id="fv3_lcp_moist" type="logical" category="dyn_fv3"
+       group="dyn_fv3_inparm" valid_values="" >
+If TRUE the continuous equations the dynamical core is based on will conserve a
+comprehensive moist total energy based on cp for dry air and all condensates.
+If FALSE the continuous equations the dynamical core is based on will conserve
+a total energy based on cp for dry air only (same total energy as CAM physics uses).
+For more details see Lauritzen et al., (2018;DOI:10.1029/2017MS001257)
+Default: TRUE
+</entry>
+
+<entry id="fv3_lcv_moist" type="logical" category="dyn_fv3"
+       group="dyn_fv3_inparm" valid_values="" >
+If TRUE the continuous equations the dynamical core is based on will conserve a
+comprehensive moist total energy based on cv for dry air and all condensates.
+If FALSE the continuous equations the dynamical core is based on will conserve
+a total energy based on cp for dry air only (same total energy as CAM physics uses).
+For more details see Lauritzen et al., (2018;DOI:10.1029/2017MS001257)
+Default: FALSE
+</entry>
+
+<entry id="fv3_fv_sg_adj" type="integer" category="dyn_fv3"
+       group="fv_core_nml" valid_values="" >
+Integer: timescale (in seconds) at which to remove two-delta-z
+instability when the local (between two adjacent levels) Richardson
+number is less than 1. This is achieved by local mixing, which conserves
+mass, momentum, and total energy. Values of 0 or smaller
+disable this feature. If fv3_n_sponge &lt; 0 then the mixing is applied
+only to the top fv3_n_sponge layers of the domain. Proper range is 0 to 3600.
+Default: 0
+</entry>
+
+<entry id="fv3_grid_type" type="integer" category="dyn_fv3"
+       group="fv_core_nml" valid_values="" >
+Integer: which type of grid to use. If 0, the equidistant gnomonic
+cubed-sphere will be used. If 4, a doubly-periodic f-plane cartesian
+grid will be used. If -1, the grid is read from INPUT/grid_spec.nc.
+Other FV3 grid type values (2, 3, 5, 6, and 7) are not supported
+and will likely not run.
+Default: 0
+</entry>
+
+<entry id="fv3_hord_dp" type="integer" category="dyn_fv3"
+       group="fv_core_nml" valid_values="" >
+Integer: horizontal advection scheme for mass. A positivity
+constraint may be warranted for fv3_hord_dp but not strictly necessary.
+
+Hord horizontal advection method
+================================
+5     Unlimited fifth-order scheme with 2 delta x filter; fastest and
+      least diffusive
+6     Intermediate-strength monotonicity constraint. Gives best
+      ACC but weaker TCs
+7     #6 with a positive-definite constraint
+8     Lin 2004 monotone PPM constraint; overall best for tracers?
+9     Hunyh constraint: more expensive but less diffusive than #8
+10    9, with a 2 delta x filter, and the Huynh constraint applied only if a
+      certain condition is met; otherwise unlimited
+-5    #5 with a positive-definite constraint
+-10   #10 with a positive-definite constraint
+Default: -10 (hydrostatic) or -5 (non-hydrostatic)
+</entry>
+
+<entry id="fv3_hord_mt" type="integer" category="dyn_fv3"
+       group="fv_core_nml" valid_values="" >
+Integer: horizontal advection scheme for momentum fluxes. A
+complete list of kord options is given in the table below.
+10 is the default for hydrostatic simulations, using a
+limited form of the monotonicity constraint
+of Huynh, which is less diffusive than other constraints.
+5 is the default for non-hydrostatic simulations which uses the
+completely unlimited (linear or non-monotone) PPM scheme.
+If no monotonicity constraint is applied, enabling
+the flux damping (fv3_do_vort_damp = .true.) is highly recommended
+to control grid-scale noise. It is also recommended that fv3_hord_mt,
+fv3_hord_vt, fv3_hord_tm, and fv3_hord_dp use the same value, to ensure consistent
+transport of all dynamical fields, unless a positivity constraint
+on mass advection (fv3_hord_dp) is desired.
+
+Hord horizontal advection method
+================================
+5     Unlimited fifth-order scheme with 2 delta x filter; fastest and
+      least diffusive
+6     Intermediate-strength monotonicity constraint. Gives best
+      ACC but weaker TCs
+7     #6 with a positive-definite constraint
+8     Lin 2004 monotone PPM constraint; overall best for tracers?
+9     Hunyh constraint: more expensive but less diffusive than #8
+10    9, with a 2 delta x filter, and the Huynh constraint applied only if a
+      certain condition is met; otherwise unlimited
+-5    #5 with a positive-definite constraint
+-10   #10 with a positive-definite constraint
+Default: 10 (hydrostatic) or 5 (non-hydrostatic)
+
+</entry>
+
+<entry id="fv3_hord_tm" type="integer" category="dyn_fv3"
+       group="fv_core_nml" valid_values="" >
+Integer: horizontal advection scheme for potential temperature
+and layer thickness in nonhydrostatic simulations.
+10 is the default for hydrostatic simulations, using a
+limited form of the monotonicity constraint
+of Huynh, which is less diffusive than other constraints.
+5 is the default for non-hydrostatic simulations which uses the
+completely unlimited (linear or non-monotone) PPM scheme.
+
+Hord horizontal advection method
+================================
+5     Unlimited fifth-order scheme with 2 delta x filter; fastest and
+      least diffusive
+6     Intermediate-strength monotonicity constraint. Gives best
+      ACC but weaker TCs
+7     #6 with a positive-definite constraint
+8     Lin 2004 monotone PPM constraint; overall best for tracers?
+9     Hunyh constraint: more expensive but less diffusive than #8
+10    9, with a 2 delta x filter, and the Huynh constraint applied only if a
+      certain condition is met; otherwise unlimited
+-5    #5 with a positive-definite constraint
+-10   #10 with a positive-definite constraint
+Default: 10 (hydrostatic) or 5 (non-hydrostatic)
+</entry>
+
+<entry id="fv3_hord_tr" type="integer" category="dyn_fv3"
+       group="fv_core_nml" valid_values="" >
+Integer: horizontal advection scheme for tracers. 8 by default.
+This value can differ from the other hord options since tracers are
+sub-cycled and require positive-definite
+advection to control the appearance of non-physical negative masses.
+8 (fastest) or 10 (least diffusive) are typically recommended.
+
+Hord horizontal advection method
+================================
+5     Unlimited fifth-order scheme with 2 delta x filter; fastest and
+      least diffusive
+6     Intermediate-strength monotonicity constraint. Gives best
+      ACC but weaker TCs
+7     #6 with a positive-definite constraint
+8     Lin 2004 monotone PPM constraint; overall best for tracers?
+9     Hunyh constraint: more expensive but less diffusive than #8
+10    9, with a 2 delta x filter, and the Huynh constraint applied only if a
+      certain condition is met; otherwise unlimited
+-5    #5 with a positive-definite constraint
+-10   #10 with a positive-definite constraint
+Default:8
+</entry>
+
+<entry id="fv3_hord_vt" type="integer" category="dyn_fv3"
+       group="fv_core_nml" valid_values="" >
+Integer: horizontal advection scheme for absolute vorticity and
+for vertical velocity in nonhydrostatic simulations.
+10 is the default for hydrostatic simulations, using a
+limited form of the monotonicity constraint
+of Huynh, which is less diffusive than other constraints.
+5 is the default for non-hydrostatic simulations which uses the
+completely unlimited (linear or non-monotone) PPM scheme.
+
+Hord horizontal advection method
+================================
+5     Unlimited fifth-order scheme with 2 delta x filter; fastest and
+      least diffusive
+6     Intermediate-strength monotonicity constraint. Gives best
+      ACC but weaker TCs
+7     #6 with a positive-definite constraint
+8     Lin 2004 monotone PPM constraint; overall best for tracers?
+9     Hunyh constraint: more expensive but less diffusive than #8
+10    9, with a 2 delta x filter, and the Huynh constraint applied only if a
+      certain condition is met; otherwise unlimited
+-5    #5 with a positive-definite constraint
+-10   #10 with a positive-definite constraint
+Default: 10 (hydrostatic) or 5 (non-hydrostatic)
+</entry>
+
+<entry id="fv3_hydrostatic" type="logical" category="dyn_fv3"
+       group="fv_core_nml" valid_values="" >
+Logical: whether to use the hydrostatic or nonhydrostatic
+solver.
+Default: TRUE
+</entry>
+
+<entry id="fv3_ke_bg" type="real" category="dyn_fv3"
+       group="fv_core_nml" valid_values="" >
+Real: background KE production (m^2/s^3) over a small step
+Use this to conserve total energy if fv3_consv_te=0
+Default: 0
+</entry>
+
+<entry id="fv3_kord_mt" type="integer" category="dyn_fv3"
+       group="fv_core_nml" valid_values="" >
+Integer: vertical remapping scheme for the winds.
+9 is recommended as the safest option, although 10, and 11 can also
+be useful.
+
+kord table
+==========
+4    Monotone PPM
+6    Vanilla PPM
+7    PPM with Hyunh monotonicity constraint(more expensive but less diffusive)
+9    Monotonic Cubic Spline
+10   Selectively (local extrema retained) monotonic Cubic Spline with 2 delta z
+     oscillations removed
+11   Non-monotonic cubic spline with 2 delta z oscillations removed
+Default: 9
+
+</entry>
+
+<entry id="fv3_kord_tm" type="integer" category="dyn_fv3"
+       group="fv_core_nml" valid_values="" >
+Integer: vertical remapping scheme for temperature. If positive (not
+recommended), then vertical remapping is performed on
+total energy instead of temperature (see remap_t below).
+kord table
+==========
+4    Monotone PPM
+6    Vanilla PPM
+7    PPM with Hyunh monotonicity constraint(more expensive but less diffusive)
+9    Monotonic Cubic Spline
+10   Selectively (local extrema retained) monotonic Cubic Spline with 2 delta z
+     oscillations removed
+11   Non-monotonic cubic spline with 2 delta z oscillations removed
+-9   Monotonic Cubic Spline with a positive-definite constraint
+Default: -9
+</entry>
+
+<entry id="fv3_kord_tr" type="integer" category="dyn_fv3"
+       group="fv_core_nml" valid_values="" >
+Integer: vertical remapping scheme for tracers.
+9 or 11 recommended.  It is recommended that the value
+of fv3_kord_tr should match fv3_kord_tm.
+
+kord table
+==========
+4    Monotone PPM
+6    Vanilla PPM
+7    PPM with Hyunh monotonicity constraint(more expensive but less diffusive)
+9    Monotonic Cubic Spline
+10   Selectively (local extrema retained) monotonic Cubic Spline with 2 delta z
+     oscillations removed
+11   Non-monotonic cubic spline with 2 delta z oscillations removed
+Default: 9
+</entry>
+
+<entry id="fv3_kord_wz" type="integer" category="dyn_fv3"
+       group="fv_core_nml" valid_values="" >
+Integer: vertical remapping scheme for vertical velocity in
+nonhydrostatic simulations. It is recommended that the value
+of fv3_kord_wz should match fv3_kord_mt.
+
+kord table
+==========
+4    Monotone PPM
+6    Vanilla PPM
+7    PPM with Hyunh monotonicity constraint(more expensive but less diffusive)
+9    Monotonic Cubic Spline
+10   Selectively (local extrema retained) monotonic Cubic Spline with 2 delta z
+     oscillations removed
+11   Non-monotonic cubic spline with 2 delta z oscillations removed
+Default: 9
+</entry>
+
+<entry id="fv3_k_split" type="integer" category="dyn_fv3"
+       group="fv_core_nml" valid_values="" >
+Integer: number of vertical remappings per dt_atmos (physics
+time step).
+Default: 2
+</entry>
+
+<entry id="fv3_layout" type="integer(2)" category="dyn_fv3"
+       group="fv_core_nml" valid_values="" >
+Integer(2): Processor layout on each tile. The number of PEs
+assigned to a domain must equal fv3_layout(1)*fv3_layout(2)*ntiles. Must be
+set.
+Default: none
+</entry>
+
+<entry id="fv3_make_nh" type="logical" category="dyn_fv3"
+       group="fv_core_nml" valid_values="" >
+Logical: Whether to re-initialize the nonhydrostatic state, by
+re-computing dz from hydrostatic balance and setting w to 0.
+Default: FALSE
+</entry>
+
+<entry id="fv3_na_init" type="integer" category="dyn_fv3"
+       group="fv_core_nml" valid_values="" >
+Integer: Number of forward-backward dynamics steps used to
+initialize adiabatic solver. Not recommended if not
+cold-starting the model.
+Default: 0
+</entry>
+
+<entry id="fv3_ncnst" type="integer" category="dyn_fv3"
+       group="fv_core_nml" valid_values="" >
+Integer: Number of tracer species advected by fv_tracer in the dynamical core.
+Typically this is set automatically by reading in values from field_table,
+but fv3_ncnst can be set to a smaller value so only the first ncnst tracers
+listed in field_table are not advected.
+Default: none
+</entry>
+
+<entry id="fv3_nord" type="integer" category="dyn_fv3"
+       group="fv_core_nml" valid_values="" >
+Integer: order of divergence damping: 0 for second-order; 1 for
+fourth-order; 2 for sixth-order; 3 for eighth-order.
+Sixth-order may yield a better solution for low resolutions (one degree or
+coarser) by virtue of it being more scale-selective and will not damp
+moderately-well-resolved disturbances as much as does lower-order
+damping.
+Default: 3
+</entry>
+
+<entry id="fv3_no_dycore" type="logical" category="dyn_fv3"
+       group="fv_core_nml" valid_values="" >
+Logical: disables execution of the dynamical core, only running
+the initialization, diagnostic, and I/O routines, and any physics
+that may be enabled.
+Default: FALSE
+</entry>
+
+<entry id="fv3_npx" type="integer" category="dyn_fv3"
+       group="fv_core_nml" valid_values="" >
+Integer: Number of grid corners in the x-direction on one tile of the
+domain; so one more than the number of grid cells across a tile. On
+the cubed sphere this is one more than the number of cells across a
+cube face. Must be set.
+Default: none
+</entry>
+
+<entry id="fv3_npy" type="integer" category="dyn_fv3"
+       group="fv_core_nml" valid_values="" >
+Integer: Number of grid corners in the y-direction on one tile of the
+domain. This value should be identical to fv3_npx on a cubed-sphere
+grid; doubly periodic or nested grids do not have this restriction.
+Must be set.
+Default: none
+</entry>
+
+<entry id="fv3_npz" type="integer" category="dyn_fv3"
+       group="fv_core_nml" valid_values="" >
+z Integer: Number of vertical levels. Each choice of fv3_npz comes with a
+pre-defined set of hybrid sigma-pressure levels and model top (see
+fv_eta.F90). Must be set.
+Default: none
+</entry>
+
+<entry id="fv3_ntiles" type="integer" category="dyn_fv3"
+       group="fv_core_nml" valid_values="" >
+Integer: Number of tiles on the domain. For the cubed sphere, this
+should be 6, one tile for each face of the cubed sphere; normally for
+most other domains (including nested grids) this should be set to 1.
+Must be set.
+Default: 6
+</entry>
+
+<entry id="fv3_nwat" type="integer" category="dyn_fv3"
+       group="fv_core_nml" valid_values="" >
+Integer: Number of water species to be included in condensate and
+water vapor loading. The masses of the first nwat tracer species
+will be added to the dry air mass, so that p is the mass of dry air,
+water vapor, and the included condensate species. The value used
+depends on the microphysics in the physics package you are using.
+This value is set by namelist defaults.
+Default: None
+</entry>
+
+<entry id="fv3_n_split" type="integer" category="dyn_fv3"
+       group="fv_core_nml" valid_values="" >
+Integer: number of small dynamics (acoustic) time steps between
+vertical remapping. A setting of 0 allows the model to choose a value
+by examining the resolution, dt_atmos, and fv3_k_split.
+Default: 6
+</entry>
+
+<entry id="fv3_n_sponge" type="integer" category="dyn_fv3"
+       group="fv_core_nml" valid_values="" >
+Integer: controls the number of layers at the upper boundary
+on which the 2 delta x filter is applied.
+Default: 0
+</entry>
+
+<entry id="fv3_print_freq" type="integer" category="dyn_fv3"
+       group="fv_core_nml" valid_values="" >
+Integer: number of hours between print out of max/min and
+air/tracer mass diagnostics to standard output. 0
+never prints out any output; set to -1 to see output after every
+dt_atmos. Computing these diagnostics requires some computational overhead.
+Default: 0
+</entry>
+
+<entry id="fv3_range_warn" type="logical" category="dyn_fv3"
+       group="fv_core_nml" valid_values="" >
+Logical: checks whether the values of the prognostic variables
+are within a reasonable range at the end of a dynamics time
+step, and prints a warning if not. Adds computational overhead,
+so we only recommend using this when debugging.
+Default: FALSE
+</entry>
+
+<entry id="fv3_rf_cutoff" type="real" category="dyn_fv3"
+       group="fv_core_nml" valid_values="" >
+Real: pressure below which no Rayleigh damping is applied if
+tau &gt; 0.
+Default: 750
+</entry>
+
+<entry id="fv3_tau" type="real" category="dyn_fv3"
+       group="fv_core_nml" valid_values="" >
+Real: time scale (in days) for Rayleigh friction applied to horizontal
+and vertical winds; lost kinetic energy is converted to heat, except
+on nested grids. 0.0 disables damping. Larger values yield less damping.
+For models with tops at 1 mb or lower
+values between 10 and 30 are useful for preventing overly-strong
+polar night jets; for higher-top hydrostatic models values between
+5 and 15 should be considered; and for non-hydrostatic models
+values of 10 or less should be considered, with smaller values for
+higher-resolution.
+Default: 10
+</entry>
+
+<entry id="fv3_vtdm4" type="real" category="dyn_fv3"
+       group="fv_core_nml" valid_values="" >
+Real: coefficient for background other-variable damping. The
+value of fv3_vtdm4 should be less than that of fv3_d4_bg. A good first guess
+for fv3_vtdm4 is about one-third the value of fv3_d4_bg.
+Requires fv3_do_vort_damp to be .true. Disabled for values less than
+1.e-3. Other-variable damping should not be used if a monotonic
+horizontal advection scheme is used.
+Default: 0.0
+</entry>
+
+<entry id="fv3_scale_ttend" type="logical" category="dyn_fv3"
+       group="dyn_fv3_inparm" valid_values="" >
+If TRUE perform temp tendency scaling before send to fv3 dynamics
+Default: FALSE
+</entry>
+
+</namelist_definition>

--- a/TAU_ML_microphysics/docs/build_instructions.md
+++ b/TAU_ML_microphysics/docs/build_instructions.md
@@ -1,0 +1,53 @@
+# Build Instructions (Summary)
+
+Tested against `cesm3_0_alpha09e` (CAM `cam6_4_186`, PUMAS
+`pumas_cam-release_v1.39`) on Derecho.
+
+**Requires CAM7 physics.** See the README warning — `micro_mg_warm_rain`
+only exists in the CAM7 physics driver. Use a CAM7-native compset (e.g.
+`F2000dev`), not a CAM6 one (e.g. `F2000climo`).
+
+1. Clone/checkout CESM3 (with submodules, e.g. via `git-fleximod update`).
+   PUMAS in this CESM tag lives at
+   `components/cam/src/atmos_phys/schemes/pumas/pumas` (a submodule nested
+   inside the `atmos_phys` submodule).
+2. Copy the files under `src/` in this folder into that PUMAS directory:
+   - New: `tester.F90` (not present upstream)
+   - Modified: `module_neural_net.F90`, `tau_neural_net_quantile.F90`,
+     `micro_pumas_v1.F90`, `micro_pumas_utils.F90`
+   - Unmodified, included for reference: `ML_fixer_check.F90`
+3. Copy `bld/namelist_files/{namelist_defaults_cam.xml,namelist_definition.xml}`
+   from this folder into `components/cam/bld/namelist_files/` (or confirm
+   your tag's files already have the `stochastic_emulated_nl` namelist group
+   — these files are unchanged from upstream aside from whatever else
+   differs between CAM tags).
+4. Create a case with a **CAM7** compset, e.g.:
+   ```
+   ./create_newcase --case <casedir> --compset F2000dev --res f09_f09_mg17 \
+       --project <project> --run-unsupported
+   ```
+   (`--run-unsupported` needed if this compset/resolution combo isn't yet a
+   validated pairing in your CESM tag.)
+5. Build as usual — no `USE_FTORCH` or other special `xmlchange` needed,
+   this scheme has no FTorch/PyTorch dependency:
+   ```
+   ./case.setup
+   ./case.build
+   ```
+6. In `user_nl_cam`:
+   ```
+   micro_mg_warm_rain = 'emulated'
+   stochastic_emulated_filename_quantile     = '/path/to/quantile_neural_net_fortran.nc'
+   stochastic_emulated_filename_input_scale  = '/path/to/input_quantile_scaler.nc'
+   stochastic_emulated_filename_output_scale = '/path/to/output_quantile_scaler.nc'
+   ```
+7. Before submitting, sanity-check the weight file matches this 9-input
+   model (see README "Required Input Files") — a mismatched file will
+   either crash or silently produce garbage.
+
+## Symptom → cause reference
+
+| Symptom | Cause |
+|---|---|
+| `micro_pumas_cam_readnl:: ERROR reading namelist` at startup | Built with `-phys cam6` instead of `-phys cam7`. Rebuild with a CAM7 compset. |
+| Crash/NaN in warm-rain tendencies | Check the NN weight file's `dense_00_in` dimension is 9, and the input/output scaler files' `column` dimension matches. |

--- a/TAU_ML_microphysics/src/ML_fixer_check.F90
+++ b/TAU_ML_microphysics/src/ML_fixer_check.F90
@@ -1,0 +1,83 @@
+module ML_fixer_check
+
+
+contains
+subroutine ML_fixer_calc(mgncol,dt,qc,nc,qr,nr,qctend,nctend,qrtend,nrtend,fixer,qc_fixer, nc_fixer, qr_fixer, nr_fixer)
+
+use pumas_kinds,       only: r8=>kind_r8
+use micro_pumas_utils, only: pi, rhow
+
+integer, intent(in) :: mgncol
+real(r8), intent(in) :: dt
+real(r8), intent(in) :: qc(mgncol)
+real(r8), intent(in) :: nc(mgncol)
+real(r8), intent(in) :: qr(mgncol)
+real(r8), intent(in) :: nr(mgncol)
+real(r8), intent(inout) :: qctend(mgncol)
+real(r8), intent(inout) :: nctend(mgncol)
+real(r8), intent(inout) :: qrtend(mgncol)
+real(r8), intent(inout) :: nrtend(mgncol)
+
+real(r8), intent(out) :: qc_fixer(mgncol)
+real(r8), intent(out) :: nc_fixer(mgncol)
+real(r8), intent(out) :: qr_fixer(mgncol)
+real(r8), intent(out) :: nr_fixer(mgncol)
+
+real(r8), intent(out) :: fixer(mgncol)
+
+real(r8) :: qc_tmp, nc_tmp, qr_tmp, nr_tmp
+integer :: i
+
+fixer = 0._r8
+
+qc_fixer = 0._r8
+qr_fixer = 0._r8
+nc_fixer = 0._r8
+nr_fixer = 0._r8
+
+do i = 1,mgncol
+   qc_tmp = qc(i)+qctend(i)*dt
+   nc_tmp = nc(i)+nctend(i)*dt
+   qr_tmp = qr(i)+qrtend(i)*dt
+   nr_tmp = nr(i)+nrtend(i)*dt
+
+   if( qc_tmp.lt.0._r8 ) then
+      fixer(i) = 1._r8
+      qctend(i) = -qc(i)/dt
+      qrtend(i) = qc(i)/dt
+      nctend(i) = -nc(i)/dt
+   end if
+   if( qr_tmp.lt.0._r8 ) then
+      fixer(i) = 1._r8
+      qrtend(i) = -qr(i)/dt
+      qctend(i) = qr(i)/dt
+      nrtend(i) = -nr(i)/dt
+   end if
+   if( nc_tmp.lt.0._r8 ) then
+      fixer(i) = 1._r8
+      if( qc_tmp.gt.0._r8 ) then
+         nc_tmp = qc_tmp/(4._r8/3._r8*pi*(5.e-5_r8)**3._r8*rhow)
+         nctend(i) = (nc_tmp-nc(i))/dt
+      else
+         nctend(i) = -nc(i)/dt
+      end if
+   end if
+   if( nr_tmp.lt.0._r8 ) then
+      fixer(i) = 1._r8
+      if(qr_tmp.gt.0._r8) then
+         nr_tmp = qr_tmp/(4._r8/3._r8*pi*(5.e-5_r8)**3._r8*rhow)
+         nrtend(i) = (nr_tmp-nr(i))/dt
+      else
+         nrtend(i) = -nr(i)/dt
+      end if
+   end if
+
+   qc_fixer(i) = qc(i)+qctend(i)*dt-qc_tmp
+   qr_fixer(i) = qr(i)+qrtend(i)*dt-qr_tmp
+   nc_fixer(i) = nc(i)+nctend(i)*dt-nc_tmp
+   nr_fixer(i) = nr(i)+nrtend(i)*dt-nr_tmp
+end do
+
+end subroutine ML_fixer_calc
+
+end module ML_fixer_check

--- a/TAU_ML_microphysics/src/micro_pumas_utils.F90
+++ b/TAU_ML_microphysics/src/micro_pumas_utils.F90
@@ -1,0 +1,3448 @@
+module micro_pumas_utils
+
+!--------------------------------------------------------------------------
+!
+! This module contains process rates and utility functions used by the MG
+! microphysics.
+!
+! Original MG authors: Andrew Gettelman, Hugh Morrison
+! Contributions from: Peter Caldwell, Xiaohong Liu and Steve Ghan
+!
+! Separated from MG 1.5 by B. Eaton.
+! Separated module switched to MG 2.0 and further changes by S. Santos.
+!
+! for questions contact Hugh Morrison, Andrew Gettelman
+! e-mail: morrison@ucar.edu, andrew@ucar.edu
+!
+!--------------------------------------------------------------------------
+!
+! List of required external functions that must be supplied:
+!   gamma --> standard mathematical gamma function (if gamma is an
+!       intrinsic, define HAVE_GAMMA_INTRINSICS)
+!
+!--------------------------------------------------------------------------
+!
+! Constants that must be specified in the "init" method (module variables):
+!
+! kind            kind of reals (to verify correct linkage only) -
+! gravit          acceleration due to gravity                    m s-2
+! rair            dry air gas constant for air                   J kg-1 K-1
+! rh2o            gas constant for water vapor                   J kg-1 K-1
+! cpair           specific heat at constant pressure for dry air J kg-1 K-1
+! tmelt           temperature of melting point for water         K
+! latvap          latent heat of vaporization                    J kg-1
+! latice          latent heat of fusion                          J kg-1
+!
+!--------------------------------------------------------------------------
+
+use pumas_kinds, only: r8=>kind_r8, i8=>kind_i8
+
+#ifndef HAVE_GAMMA_INTRINSICS
+use pumas_gamma_function, only: gamma=>pumas_gamma
+#endif
+
+implicit none
+private
+save
+
+public :: &
+     micro_pumas_utils_init, &
+     size_dist_param_liq, &
+     size_dist_param_basic, &
+     avg_diameter, &
+     rising_factorial, &
+     ice_deposition_sublimation, &
+     ice_deposition_sublimation_mg4, &  !! ktc
+     sb2001v2_liq_autoconversion,&
+     sb2001v2_accre_cld_water_rain,&
+     kk2000_liq_autoconversion, &
+     ice_autoconversion, &
+     immersion_freezing, &
+     contact_freezing, &
+     snow_self_aggregation, &
+     ice_self_aggregation, &  !! mg4 added for using instead of snow_self_agg
+     accrete_cloud_water_snow, &
+     accrete_cloud_water_ice, &  !! mg4 added for using instead of cloud_water_snow
+     secondary_ice_production, &
+     accrete_rain_snow, &
+     accrete_rain_ice, &  !! mg4 added for using instead of rain_snow
+     heterogeneous_rain_freezing, &
+     accrete_cloud_water_rain, &
+     self_collection_rain, &
+     accrete_cloud_ice_snow, &
+     evaporate_sublimate_precip, &
+     bergeron_process_snow, &
+     graupel_collecting_snow, &
+     graupel_collecting_rain, &
+     graupel_collecting_cld_water, &
+     graupel_riming_liquid_snow, &
+     graupel_rain_riming_snow, &
+     graupel_rime_splintering, &
+     vapor_deposition_onto_snow, &
+     evaporate_sublimate_precip_graupel, &
+     evaporate_sublimate_precip_mg4, &
+     evaporate_sublimate_precip_graupel_mg4, &
+     access_lookup_table, & !! mg4
+     access_lookup_table_coll, & !! mg4
+     init_lookup_table, &      !! mg4
+     avg_diameter_vec
+
+integer, parameter, public :: VLENS = 128  ! vector length of a GPU compute kernel
+
+public :: MGHydrometeorProps
+
+type :: MGHydrometeorProps
+   ! Density (kg/m^3)
+   real(r8) :: rho
+   ! Information for size calculations.
+   ! Basic calculation of mean size is:
+   !     lambda = (shape_coef*nic/qic)^(1/eff_dim)
+   ! Then lambda is constrained by bounds.
+   real(r8) :: eff_dim
+   real(r8) :: shape_coef
+   real(r8) :: lambda_bounds(2)
+   ! Minimum average particle mass (kg).
+   ! Limit is applied at the beginning of the size distribution calculations.
+   real(r8) :: min_mean_mass
+end type MGHydrometeorProps
+
+interface MGHydrometeorProps
+   module procedure NewMGHydrometeorProps
+end interface
+
+type(MGHydrometeorProps), public :: mg_liq_props
+type(MGHydrometeorProps), public :: mg_ice_props
+type(MGHydrometeorProps), public :: mg_rain_props
+type(MGHydrometeorProps), public :: mg_snow_props
+type(MGHydrometeorProps), public :: mg_graupel_props
+type(MGHydrometeorProps), public :: mg_hail_props
+
+interface size_dist_param_liq
+  module procedure size_dist_param_liq_2D
+  module procedure size_dist_param_liq_vect
+  module procedure size_dist_param_liq_line
+end interface
+interface size_dist_param_basic
+  module procedure size_dist_param_basic_2D
+  module procedure size_dist_param_basic_vect
+  module procedure size_dist_param_basic_line
+end interface
+interface calc_ab
+  module procedure calc_ab_line
+  module procedure calc_ab_vect
+end interface
+
+!=================================================
+! Public module parameters (mostly for MG itself)
+!=================================================
+
+! Pi to 20 digits; more than enough to reach the limit of double precision.
+real(r8), parameter, public :: pi = 3.14159265358979323846_r8
+
+! "One minus small number": number near unity for round-off issues.
+real(r8), parameter, public :: omsm   = 1._r8 - 1.e-5_r8
+
+! Smallest mixing ratio considered in microphysics.
+real(r8), parameter, public :: qsmall = 1.e-18_r8
+
+! Minimum cloud water mixing ratio for running the ML warm-rain (TAU) emulator.
+real(r8), parameter, public :: qsmall_emulator = 1.e-8_r8
+
+! minimum allowed cloud fraction
+real(r8), parameter, public :: mincld = 0.0001_r8
+
+real(r8), parameter, public :: rhosn = 250._r8  ! bulk density snow
+real(r8), parameter, public :: rhoi = 500._r8   ! bulk density ice
+real(r8), parameter, public :: rhow = 1000._r8  ! bulk density liquid
+real(r8), parameter, public :: rhows = 917._r8  ! bulk density water solid
+
+!Hail and Graupel (set in MG3)
+real(r8), parameter, public :: rhog = 500._r8
+real(r8), parameter, public :: rhoh = 900._r8
+
+! fall speed parameters, V = aD^b (V is in m/s)
+! droplets
+real(r8), parameter, public :: ac = 3.e7_r8
+real(r8), parameter, public :: bc = 2._r8
+! snow
+real(r8), parameter, public :: as = 11.72_r8
+real(r8), parameter, public :: bs = 0.41_r8
+! cloud ice
+real(r8), parameter, public :: ai = 700._r8
+real(r8), parameter, public :: bi = 1._r8
+! small cloud ice (r< 10 um) - sphere, bulk density
+real(r8), parameter, public :: aj = ac*((rhoi/rhows)**(bc/3._r8))*rhows/rhow
+real(r8), parameter, public :: bj = bc
+! rain
+real(r8), parameter, public :: ar = 841.99667_r8
+real(r8), parameter, public :: br = 0.8_r8
+! graupel
+real(r8), parameter, public :: ag = 19.3_r8
+real(r8), parameter, public :: bg = 0.37_r8
+! hail
+real(r8), parameter, public :: ah = 114.5_r8
+real(r8), parameter, public :: bh = 0.5_r8
+
+! mass of new crystal due to aerosol freezing and growth (kg)
+! Make this consistent with the lower bound, to support UTLS and
+! stratospheric ice, and the smaller ice size limit.
+real(r8), parameter, public :: mi0 = 4._r8/3._r8*pi*rhoi*(1.e-6_r8)**3
+
+! mass of new graupel particle  (assume same as mi0 for now, may want to make bigger?)
+!real(r8), parameter, public :: mg0 = 4._r8/3._r8*pi*rhoi*(1.e-6_r8)**3
+!or set based on M2005:
+real(r8), parameter, public :: mg0 = 1.6e-10_r8
+! radius of contact nuclei
+real(r8), parameter, public :: mmult = 4._r8/3._r8*pi*rhoi*(5.e-6_r8)**3
+
+!=================================================
+! Private module parameters
+!=================================================
+
+! Signaling NaN bit pattern that represents a limiter that's turned off.
+integer(i8), parameter :: limiter_off = int(Z'7FF1111111111111', i8)
+
+! alternate threshold used for some in-cloud mmr
+real(r8), parameter, public :: icsmall = 1.e-8_r8
+
+! particle mass-diameter relationship
+! currently we assume spherical particles for cloud ice/snow
+! m = cD^d
+! exponent
+real(r8), parameter :: dsph = 3._r8
+
+! Bounds for mean diameter for different constituents.
+real(r8), parameter :: lam_bnd_rain(2) = 1._r8/[500.e-6_r8, 20.e-6_r8]
+real(r8), parameter :: lam_bnd_snow(2) = 1._r8/[2000.e-6_r8, 10.e-6_r8]
+
+! Minimum average mass of particles.
+real(r8), parameter :: min_mean_mass_liq = 1.e-20_r8
+real(r8), parameter :: min_mean_mass_ice = 1.e-20_r8
+
+! ventilation parameters
+! for snow
+real(r8), parameter :: f1s = 0.86_r8
+real(r8), parameter :: f2s = 0.28_r8
+! for rain
+real(r8), parameter :: f1r = 0.78_r8
+real(r8), parameter :: f2r = 0.308_r8
+
+! collection efficiencies
+! aggregation of cloud ice and snow
+real(r8), parameter :: eii = 0.5_r8
+! collection efficiency, ice-droplet collisions
+real(r8), parameter, public :: ecid = 0.7_r8
+! collection efficiency between droplets/rain and snow/rain
+real(r8), parameter, public :: ecr = 1.0_r8
+
+! immersion freezing parameters, bigg 1953
+real(r8), parameter :: bimm = 100._r8
+real(r8), parameter :: aimm = 0.66_r8
+
+! Mass of each raindrop created from autoconversion.
+real(r8), parameter :: droplet_mass_25um = 4._r8/3._r8*pi*rhow*(25.e-6_r8)**3
+real(r8), parameter :: droplet_mass_40um = 4._r8/3._r8*pi*rhow*(40.e-6_r8)**3
+
+!!!!!!
+! MG4 look up table parameters
+!!!!!!
+! ice microphysics lookup table array dimensions
+integer, parameter, public :: tsize     = 3
+integer, parameter, public :: isize     = 20
+integer, parameter, public :: jsize     = 20
+integer, parameter, public :: rcollsize = 30
+
+! number of ice microphysical quantities used from lookup table
+integer, parameter, public :: tabsize   = 14
+
+! number of ice-rain collection microphysical quantities used from lookup table
+integer, parameter, public :: colltabsize = 2
+
+
+!ice lookup table values
+real(r8) :: itab(tsize,isize,jsize,tabsize)
+
+!ice lookup table values for ice-rain collision/collection
+real(r8) :: itabcoll(tsize,isize,jsize,rcollsize,colltabsize)
+
+private :: itab,itabcoll
+
+!=========================================================
+! Constants set in initialization
+!=========================================================
+
+! Set using arguments to micro_pumas_init
+real(r8) :: rv          ! water vapor gas constant
+real(r8) :: cpp         ! specific heat of dry air
+real(r8) :: tmelt       ! freezing point of water (K)
+
+real(r8) :: ra        ! dry air gas constant
+
+! latent heats of:
+real(r8) :: xxlv        ! vaporization
+real(r8) :: xlf         ! freezing
+real(r8) :: xxls        ! sublimation
+
+! additional constants to help speed up code
+real(r8) :: gamma_bs_plus3
+real(r8) :: gamma_half_br_plus5
+real(r8) :: gamma_half_bs_plus5
+real(r8) :: gamma_2bs_plus2
+
+!$acc declare create (rv,cpp,tmelt,xxlv,xxls,gamma_bs_plus3,   &
+!$acc                 gamma_half_br_plus5,gamma_half_bs_plus5, &
+!$acc                 gamma_2bs_plus2)
+
+!=========================================================
+! Utilities that are cheaper if the compiler knows that
+! some argument is an integer.
+!=========================================================
+
+interface rising_factorial
+   module procedure rising_factorial_r8
+   module procedure rising_factorial_r8_vec
+   module procedure rising_factorial_integer
+   module procedure rising_factorial_integer_vec
+end interface rising_factorial
+
+interface var_coef
+   module procedure var_coef_r8
+   module procedure var_coef_r8_vect
+   module procedure var_coef_integer
+   module procedure var_coef_integer_vect
+end interface var_coef
+
+!==========================================================================
+contains
+!==========================================================================
+
+! Initialize module variables.
+!
+! "kind" serves no purpose here except to check for unlikely linking
+! issues; always pass in the kind for a double precision real.
+!
+! "errstring" is the only output; it is blank if there is no error, or set
+! to a message if there is an error.
+!
+! Check the list at the top of this module for descriptions of all other
+! arguments.
+subroutine micro_pumas_utils_init( kind, rair, rh2o, cpair, tmelt_in, latvap, &
+     latice, dcs, errstring)
+
+  integer,  intent(in)  :: kind
+  real(r8), intent(in)  :: rair
+  real(r8), intent(in)  :: rh2o
+  real(r8), intent(in)  :: cpair
+  real(r8), intent(in)  :: tmelt_in
+  real(r8), intent(in)  :: latvap
+  real(r8), intent(in)  :: latice
+  real(r8), intent(in)  :: dcs
+
+  character(128), intent(out) :: errstring
+
+  ! Name this array to workaround an XLF bug (otherwise could just use the
+  ! expression that sets it).
+  real(r8) :: ice_lambda_bounds(2)
+
+  !-----------------------------------------------------------------------
+
+  errstring = ' '
+
+  if( kind .ne. r8 ) then
+     errstring = 'micro_pumas_init: KIND of reals does not match'
+     return
+  endif
+
+  ! declarations for MG code (transforms variable names)
+
+  rv    = rh2o          ! water vapor gas constant
+  cpp   = cpair         ! specific heat of dry air
+  tmelt = tmelt_in
+  ra    = rair          ! dry air gas constant
+
+  ! latent heats
+
+  xxlv = latvap         ! latent heat vaporization
+  xlf  = latice         ! latent heat freezing
+  xxls = xxlv + xlf     ! latent heat of sublimation
+
+  ! Define constants to help speed up code (this limits calls to gamma function)
+  gamma_bs_plus3      = gamma(3._r8+bs)
+  gamma_half_br_plus5 = gamma(5._r8/2._r8+br/2._r8)
+  gamma_half_bs_plus5 = gamma(5._r8/2._r8+bs/2._r8)
+  gamma_2bs_plus2     = gamma(2._r8*bs+2._r8)
+
+  ! Don't specify lambda bounds for cloud liquid, as they are determined by
+  ! pgam dynamically.
+  mg_liq_props = MGHydrometeorProps(rhow, dsph, &
+       min_mean_mass=min_mean_mass_liq)
+
+  ! Mean ice diameter can not grow bigger than twice the autoconversion
+  ! threshold for snow.
+  ice_lambda_bounds(1) = 1._r8/2._r8*dcs
+  ice_lambda_bounds(2) = 1._r8/1.e-6_r8
+
+  mg_ice_props = MGHydrometeorProps(rhoi, dsph, &
+       ice_lambda_bounds, min_mean_mass_ice)
+
+  mg_rain_props = MGHydrometeorProps(rhow, dsph, lam_bnd_rain)
+  mg_snow_props = MGHydrometeorProps(rhosn, dsph, lam_bnd_snow)
+  mg_graupel_props = MGHydrometeorProps(rhog, dsph, lam_bnd_snow)
+  mg_hail_props = MGHydrometeorProps(rhoh, dsph, lam_bnd_snow)
+
+  !$acc update device (rv,cpp,tmelt,xxlv,xxls,gamma_bs_plus3,   &
+  !$acc                gamma_half_br_plus5,gamma_half_bs_plus5, &
+  !$acc                gamma_2bs_plus2)
+
+end subroutine micro_pumas_utils_init
+
+! Constructor for a constituent property object.
+function NewMGHydrometeorProps(rho, eff_dim, lambda_bounds, min_mean_mass) &
+     result(res)
+  real(r8), intent(in) :: rho, eff_dim
+  real(r8), intent(in), optional :: lambda_bounds(2), min_mean_mass
+  type(MGHydrometeorProps) :: res
+
+  res%rho = rho
+  res%eff_dim = eff_dim
+  if (present(lambda_bounds)) then
+     res%lambda_bounds = lambda_bounds
+  else
+     res%lambda_bounds = no_limiter()
+  end if
+  if (present(min_mean_mass)) then
+     res%min_mean_mass = min_mean_mass
+  else
+     res%min_mean_mass = no_limiter()
+  end if
+
+  res%shape_coef = rho*pi*gamma(eff_dim+1._r8)/6._r8
+
+end function NewMGHydrometeorProps
+
+!========================================================================
+!FORMULAS
+!========================================================================
+
+! Use gamma function to implement rising factorial extended to the reals.
+subroutine rising_factorial_r8(x, n, res)
+  !$acc routine seq
+  real(r8), intent(in) :: x, n
+  real(r8), intent(out) :: res
+
+  res = gamma(x+n)/gamma(x)
+
+end subroutine rising_factorial_r8
+
+subroutine rising_factorial_r8_vec(x, n, res,vlen)
+  integer, intent(in)   :: vlen
+  real(r8), intent(in)  :: x(vlen), n
+  real(r8), intent(out) :: res(vlen)
+  integer :: i
+  real(r8) :: tmp
+
+  !$acc parallel vector_length(VLENS) default(present)
+  !$acc loop gang vector
+  do i=1,vlen
+     tmp = x(i)+n
+     res(i) = gamma(tmp)
+     tmp = gamma(x(i))
+     res(i) = res(i)/tmp
+  end do
+  !$acc end parallel
+
+end subroutine rising_factorial_r8_vec
+
+! Rising factorial can be performed much cheaper if n is a small integer.
+subroutine rising_factorial_integer(x, n, res)
+  !$acc routine seq
+  real(r8), intent(in)  :: x
+  integer,  intent(in)  :: n
+  real(r8), intent(out) :: res
+
+  integer :: i
+  real(r8) :: factor
+
+  res = 1._r8
+  factor = x
+
+  !$acc loop seq
+  do i = 1, n
+     res = res * factor
+     factor = factor + 1._r8
+  end do
+
+end subroutine rising_factorial_integer
+
+subroutine rising_factorial_integer_vec(x, n, res,vlen)
+  integer,  intent(in)  :: vlen
+  real(r8), intent(in)  :: x(vlen)
+  integer,  intent(in)  :: n
+  real(r8), intent(out) :: res(vlen)
+
+  integer  :: i,j
+  real(r8) :: factor
+
+  !$acc parallel vector_length(VLENS) default(present)
+  !$acc loop gang vector
+  do i=1,vlen
+     res(i)    = 1._r8
+     factor    = x(i)
+
+     if (n == 3) then
+        res(i) = res(i) * factor
+        factor = factor + 1._r8
+        res(i) = res(i) * factor
+        factor = factor + 1._r8
+        res(i) = res(i) * factor
+     elseif (n == 2) then
+        res(i) = res(i) * factor
+        factor = factor + 1._r8
+        res(i) = res(i) * factor
+     else
+       !$acc loop seq
+       do j = 1, n
+          res(i) = res(i) * factor
+          factor = factor + 1._r8
+       end do
+     end if
+  end do
+  !$acc end parallel
+
+end subroutine rising_factorial_integer_vec
+
+! Calculate correction due to latent heat for evaporation/sublimation
+subroutine calc_ab_line(t, qv, xxl, ab)
+  !$acc routine seq
+  real(r8), intent(in)  :: t     ! Temperature
+  real(r8), intent(in)  :: qv    ! Saturation vapor pressure
+  real(r8), intent(in)  :: xxl   ! Latent heat
+  real(r8), intent(out) :: ab
+
+  real(r8) :: dqsdt
+
+  dqsdt = xxl*qv / (rv * t**2)
+  ab = 1._r8 + dqsdt*xxl/cpp
+
+end subroutine calc_ab_line
+
+! Calculate correction due to latent heat for evaporation/sublimation
+subroutine calc_ab_vect(t, qv, xxl, ab, vlen)
+  integer,  intent(in) :: vlen
+  real(r8), intent(in) :: t(vlen)     ! Temperature
+  real(r8), intent(in) :: qv(vlen)    ! Saturation vapor pressure
+  real(r8), intent(in) :: xxl         ! Latent heat
+
+  real(r8), intent(out) :: ab(vlen)
+  real(r8) :: dqsdt
+  integer :: i
+
+  !$acc parallel vector_length(VLENS) default(present)
+  !$acc loop gang vector
+  do i=1,vlen
+     dqsdt = xxl*qv(i) / (rv * t(i)**2)
+     ab(i) = 1._r8 + dqsdt*xxl/cpp
+  end do
+  !$acc end parallel
+
+end subroutine calc_ab_vect
+
+! get cloud droplet size distribution parameters
+subroutine size_dist_param_liq_line(props, qcic, ncic, rho, pgam, lamc)
+  !$acc routine seq
+  type(MGHydrometeorProps), intent(in)    :: props
+  real(r8),                 intent(in)    :: qcic
+  real(r8),                 intent(inout) :: ncic
+  real(r8),                 intent(in)    :: rho
+  real(r8),                 intent(out)   :: pgam
+  real(r8),                 intent(out)   :: lamc
+
+  ! local variables
+  type(MGHydrometeorProps)                :: props_loc
+  real(r8)                                :: tmp
+
+  if (qcic > qsmall) then
+     ! Local copy of properties that can be modified.
+     ! (Elemental routines that operate on arrays can't modify scalar
+     ! arguments.)
+     props_loc = props
+
+     ! Get pgam from fit Rotstayn and Liu 2003 (changed from Martin 1994 for CAM6)
+     pgam = 1.0_r8 - 0.7_r8 * exp(-0.008_r8*1.e-6_r8*ncic*rho)
+     pgam = 1._r8/(pgam**2) - 1._r8
+     pgam = max(pgam, 2._r8)
+
+     ! Set coefficient for use in size_dist_param_basic.
+     ! The 3D case is so common and optimizable that we specialize it:
+     if (props_loc%eff_dim == 3._r8) then
+        call rising_factorial(pgam+1._r8, 3, tmp)
+        props_loc%shape_coef = pi / 6._r8 * props_loc%rho * tmp
+     else
+        call rising_factorial(pgam+1._r8, props_loc%eff_dim, tmp)
+        props_loc%shape_coef = pi / 6._r8 * props_loc%rho * tmp
+     end if
+
+     ! Limit to between 2 and 50 microns mean size.
+     props_loc%lambda_bounds(1) = (pgam+1._r8)*1._r8/50.e-6_r8
+     props_loc%lambda_bounds(2) = (pgam+1._r8)*1._r8/2.e-6_r8
+
+     call size_dist_param_basic(props_loc, qcic, ncic, lamc)
+  else
+     ! pgam not calculated in this case, so set it to a value likely to
+     ! cause an error if it is accidentally used
+     ! (gamma function undefined for negative integers)
+     pgam = -100._r8
+     lamc = 0._r8
+  end if
+
+end subroutine size_dist_param_liq_line
+
+! get cloud droplet size distribution parameters
+
+subroutine size_dist_param_liq_2D(props, qcic, ncic, rho, pgam, lamc, dim1, dim2)
+
+  type(mghydrometeorprops),       intent(in)    :: props
+  integer,                        intent(in)    :: dim1, dim2
+  real(r8), dimension(dim1,dim2), intent(in)    :: qcic
+  real(r8), dimension(dim1,dim2), intent(inout) :: ncic
+  real(r8), dimension(dim1,dim2), intent(in)    :: rho
+  real(r8), dimension(dim1,dim2), intent(out)   :: pgam
+  real(r8), dimension(dim1,dim2), intent(out)   :: lamc
+
+  ! local variables
+  integer  :: i, k
+  real(r8) :: tmp(dim1,dim2),pgamp1(dim1,dim2)
+  real(r8) :: shapeC(dim1,dim2),lbnd(dim1,dim2),ubnd(dim1,dim2)
+
+  !$acc data create (tmp,pgamp1,shapeC,lbnd,ubnd)
+
+  !$acc parallel vector_length(VLENS) default(present)
+  !$acc loop gang vector collapse(2)
+  do k = 1, dim2
+     do i = 1, dim1
+        if (qcic(i,k) > qsmall) then
+           ! Get pgam from fit Rotstayn and Liu 2003 (changed from Martin 1994 for CAM6)
+           pgam(i,k) = 1.0_r8 - 0.7_r8 * exp(-0.008_r8*1.e-6_r8*ncic(i,k)*rho(i,k))
+           pgam(i,k) = 1._r8/(pgam(i,k)**2) - 1._r8
+           pgam(i,k) = max(pgam(i,k), 2._r8)
+           pgamp1(i,k) = pgam(i,k)+1._r8
+        else
+           pgamp1(i,k) = 0._r8
+        end if
+     end do
+  end do
+  !$acc end parallel
+
+  ! Set coefficient for use in size_dist_param_basic.
+  ! The 3D case is so common and optimizable that we specialize it:
+  if (props%eff_dim == 3._r8) then
+     call rising_factorial_integer_vec(pgamp1,3,tmp,dim1*dim2)
+  else
+     call rising_factorial_r8_vec(pgamp1, props%eff_dim,tmp,dim1*dim2)
+  end if
+
+  !$acc parallel vector_length(VLENS) default(present)
+  !$acc loop gang vector collapse(2)
+  do k = 1, dim2
+     do i = 1, dim1
+        if (qcic(i,k) > qsmall) then
+           shapeC(i,k) = pi / 6._r8 * props%rho * tmp(i,k)
+           ! Limit to between 2 and 50 microns mean size.
+           lbnd(i,k)   = pgamp1(i,k)*1._r8/50.e-6_r8
+           ubnd(i,k)   = pgamp1(i,k)*1._r8/2.e-6_r8
+        else
+           shapeC(i,k) = 0._r8
+           lbnd(i,k) = 0._r8
+           ubnd(i,k) = 0._r8
+        end if
+     end do
+  end do
+  !$acc end parallel
+
+  call size_dist_param_basic_vect2(props, qcic, ncic, shapeC, lbnd, ubnd, lamc, dim1*dim2)
+
+  !$acc parallel vector_length(VLENS) default(present)
+  !$acc loop gang vector collapse(2)
+  do k = 1, dim2
+     do i = 1, dim1
+        if (qcic(i,k) <= qsmall) then
+           ! pgam not calculated in this case, so set it to a value likely to
+           ! cause an error if it is accidentally used
+           ! (gamma function undefined for negative integers)
+           pgam(i,k) = -100._r8
+           lamc(i,k) = 0._r8
+        end if
+     end do
+  end do
+  !$acc end parallel
+
+  !$acc end data
+end subroutine size_dist_param_liq_2D
+
+! get cloud droplet size distribution parameters
+
+subroutine size_dist_param_liq_vect(props, qcic, ncic, rho, pgam, lamc, vlen)
+
+  type(mghydrometeorprops),  intent(in)    :: props
+  integer,                   intent(in)    :: vlen
+  real(r8), dimension(vlen), intent(in)    :: qcic
+  real(r8), dimension(vlen), intent(inout) :: ncic
+  real(r8), dimension(vlen), intent(in)    :: rho
+  real(r8), dimension(vlen), intent(out)   :: pgam
+  real(r8), dimension(vlen), intent(out)   :: lamc
+
+  ! local variables
+  integer  :: i
+  real(r8) :: tmp(vlen),pgamp1(vlen)
+  real(r8) :: shapeC(vlen),lbnd(vlen),ubnd(vlen)
+
+  !$acc data create (tmp,pgamp1,shapeC,lbnd,ubnd)
+
+  !$acc parallel vector_length(VLENS) default(present)
+  !$acc loop gang vector
+  do i = 1, vlen
+     if (qcic(i) > qsmall) then
+        ! Get pgam from fit Rotstayn and Liu 2003 (changed from Martin 1994 for CAM6)
+        pgam(i) = 1.0_r8 - 0.7_r8 * exp(-0.008_r8*1.e-6_r8*ncic(i)*rho(i))
+        pgam(i) = 1._r8/(pgam(i)**2) - 1._r8
+        pgam(i) = max(pgam(i), 2._r8)
+        pgamp1(i) = pgam(i)+1._r8
+     else
+        pgamp1(i) = 0._r8
+     end if
+  end do
+  !$acc end parallel
+
+  ! Set coefficient for use in size_dist_param_basic.
+  ! The 3D case is so common and optimizable that we specialize it:
+  if (props%eff_dim == 3._r8) then
+     call rising_factorial_integer_vec(pgamp1,3,tmp,vlen)
+  else
+     call rising_factorial_r8_vec(pgamp1, props%eff_dim,tmp,vlen)
+  end if
+
+  !$acc parallel vector_length(VLENS) default(present)
+  !$acc loop gang vector
+  do i = 1, vlen
+     if (qcic(i) > qsmall) then
+        shapeC(i) = pi / 6._r8 * props%rho * tmp(i)
+        ! Limit to between 2 and 50 microns mean size.
+        lbnd(i)   = pgamp1(i)*1._r8/50.e-6_r8
+        ubnd(i)   = pgamp1(i)*1._r8/2.e-6_r8
+     else
+        shapeC(i) = 0._r8
+        lbnd(i) = 0._r8
+        ubnd(i) = 0._r8
+     end if
+  end do
+  !$acc end parallel
+
+  call size_dist_param_basic_vect2(props, qcic, ncic, shapeC, lbnd, ubnd, lamc, vlen)
+
+  !$acc parallel vector_length(VLENS) default(present)
+  !$acc loop gang vector
+  do i = 1, vlen
+     if (qcic(i) <= qsmall) then
+        ! pgam not calculated in this case, so set it to a value likely to
+        ! cause an error if it is accidentally used
+        ! (gamma function undefined for negative integers)
+        pgam(i) = -100._r8
+        lamc(i) = 0._r8
+     end if
+  end do
+  !$acc end parallel
+
+  !$acc end data
+end subroutine size_dist_param_liq_vect
+
+! Basic routine for getting size distribution parameters.
+subroutine size_dist_param_basic_line(props, qic, nic, lam, n0)
+  !$acc routine seq
+  type(MGHydrometeorProps), intent(in)    :: props
+  real(r8),                 intent(in)    :: qic
+  real(r8),                 intent(inout) :: nic
+  real(r8),                 intent(out)           :: lam
+  real(r8),                 intent(out), optional :: n0
+
+  logical :: present_n0
+  present_n0 = present(n0)
+
+  if (qic > qsmall) then
+     ! add upper limit to in-cloud number concentration to prevent
+     ! numerical error
+     if (limiter_is_on(props%min_mean_mass)) then
+        nic = min(nic, qic / props%min_mean_mass)
+     end if
+
+     ! lambda = (c n/q)^(1/d)
+     lam = (props%shape_coef * nic/qic)**(1._r8/props%eff_dim)
+
+     ! check for slope
+     ! adjust vars
+     if (lam < props%lambda_bounds(1)) then
+        lam = props%lambda_bounds(1)
+        nic = lam**(props%eff_dim) * qic/props%shape_coef
+     else if (lam > props%lambda_bounds(2)) then
+        lam = props%lambda_bounds(2)
+        nic = lam**(props%eff_dim) * qic/props%shape_coef
+     end if
+  else
+     lam = 0._r8
+  end if
+
+  if (present_n0) n0 = nic * lam
+
+end subroutine size_dist_param_basic_line
+
+subroutine size_dist_param_basic_vect(props, qic, nic, lam, vlen, n0)
+
+  type (mghydrometeorprops), intent(in)    :: props
+  integer,                   intent(in)    :: vlen
+  real(r8), dimension(vlen), intent(in)    :: qic
+  real(r8), dimension(vlen), intent(inout) :: nic
+  real(r8), dimension(vlen), intent(out)   :: lam
+  real(r8), dimension(vlen), intent(out), optional :: n0
+  integer  :: i
+  logical  :: limiterActive, present_n0
+  real(r8) :: effDim,shapeCoef,ubnd,lbnd, minMass
+
+  limiterActive = limiter_is_on(props%min_mean_mass)
+  effDim    = props%eff_dim
+  shapeCoef = props%shape_coef
+  lbnd      = props%lambda_bounds(1)
+  ubnd      = props%lambda_bounds(2)
+  minMass   = props%min_mean_mass
+  present_n0 = present(n0)
+
+  !$acc parallel vector_length(VLENS) default(present)
+  !$acc loop gang vector
+  do i = 1, vlen
+     if (qic(i) > qsmall) then
+        ! add upper limit to in-cloud number concentration to prevent
+        ! numerical error
+        if (limiterActive) then
+           nic(i) = min(nic(i), qic(i) / minMass)
+        end if
+
+        ! lambda = (c n/q)^(1/d)
+        lam(i) = (shapeCoef * nic(i)/qic(i))**(1._r8/effDim)
+
+        ! check for slope
+        ! adjust vars
+        if (lam(i) < lbnd) then
+           lam(i) = lbnd
+           nic(i) = lam(i)**(effDim) * qic(i)/shapeCoef
+        else if (lam(i) > ubnd) then
+           lam(i) = ubnd
+           nic(i) = lam(i)**(effDim) * qic(i)/shapeCoef
+        end if
+     else
+        lam(i) = 0._r8
+     end if
+
+     if (present_n0) n0(i) = nic(i) * lam(i)
+  end do
+  !$acc end parallel
+
+end subroutine size_dist_param_basic_vect
+
+subroutine size_dist_param_basic_2D(props, qic, nic, lam, dim1, dim2, n0)
+
+  type (mghydrometeorprops),      intent(in)    :: props
+  integer,                        intent(in)    :: dim1, dim2
+  real(r8), dimension(dim1,dim2), intent(in)    :: qic
+  real(r8), dimension(dim1,dim2), intent(inout) :: nic
+  real(r8), dimension(dim1,dim2), intent(out)   :: lam
+  real(r8), dimension(dim1,dim2), intent(out), optional :: n0
+  integer  :: i, k
+  logical  :: limiterActive, present_n0
+  real(r8) :: effDim,shapeCoef,ubnd,lbnd, minMass
+
+  limiterActive = limiter_is_on(props%min_mean_mass)
+  effDim    = props%eff_dim
+  shapeCoef = props%shape_coef
+  lbnd      = props%lambda_bounds(1)
+  ubnd      = props%lambda_bounds(2)
+  minMass   = props%min_mean_mass
+  present_n0 = present(n0)
+
+  !$acc parallel vector_length(VLENS) default(present)
+  !$acc loop gang vector collapse(2)
+  do k = 1, dim2
+     do i = 1, dim1
+        if (qic(i,k) > qsmall) then
+           ! add upper limit to in-cloud number concentration to prevent
+           ! numerical error
+           if (limiterActive) then
+              nic(i,k) = min(nic(i,k), qic(i,k) / minMass)
+           end if
+
+           ! lambda = (c n/q)^(1/d)
+           lam(i,k) = (shapeCoef * nic(i,k)/qic(i,k))**(1._r8/effDim)
+
+           ! check for slope
+           ! adjust vars
+           if (lam(i,k) < lbnd) then
+              lam(i,k) = lbnd
+              nic(i,k) = lam(i,k)**(effDim) * qic(i,k)/shapeCoef
+           else if (lam(i,k) > ubnd) then
+              lam(i,k) = ubnd
+              nic(i,k) = lam(i,k)**(effDim) * qic(i,k)/shapeCoef
+           end if
+        else
+           lam(i,k) = 0._r8
+        end if
+
+        if (present_n0) n0(i,k) = nic(i,k) * lam(i,k)
+     end do
+  end do
+  !$acc end parallel
+
+end subroutine size_dist_param_basic_2D
+
+subroutine size_dist_param_basic_vect2(props, qic, nic, shapeC, lbnd, ubnd, lam, vlen, n0)
+
+  type (mghydrometeorprops), intent(in)    :: props
+  integer,                   intent(in)    :: vlen
+  real(r8), dimension(vlen), intent(in)    :: qic
+  real(r8), dimension(vlen), intent(inout) :: nic
+  real(r8), dimension(vlen), intent(in)    :: shapeC,lbnd,ubnd
+  real(r8), dimension(vlen), intent(out)   :: lam
+  real(r8), dimension(vlen), intent(out), optional :: n0
+  integer  :: i
+  integer  :: cnt
+  logical  :: limiterActive, present_n0
+  real(r8) :: effDim,shapeCoef, minMass
+
+  limiterActive = limiter_is_on(props%min_mean_mass)
+  effDim        = props%eff_dim
+  minMass       = props%min_mean_mass
+  present_n0    = present(n0)
+
+  !$acc parallel vector_length(VLENS) default(present)
+  !$acc loop gang vector
+  do i=1,vlen
+
+     if (qic(i) > qsmall) then
+        ! add upper limit to in-cloud number concentration to prevent
+        ! numerical error
+
+        if (limiterActive) then
+           nic(i) = min(nic(i), qic(i) / minMass)
+        end if
+        ! lambda = (c n/q)^(1/d)
+
+        lam(i) = (shapeC(i) * nic(i)/qic(i))**(1._r8/effDim)
+        ! check for slope
+        ! adjust vars
+
+        if (lam(i) < lbnd(i)) then
+           lam(i) = lbnd(i)
+           nic(i) = lam(i)**(effDim) * qic(i)/shapeC(i)
+        else if (lam(i) > ubnd(i)) then
+           lam(i) = ubnd(i)
+           nic(i) = lam(i)**(effDim) * qic(i)/shapeC(i)
+        end if
+     else
+        lam(i) = 0._r8
+     end if
+
+     if (present_n0) n0(i) = nic(i) * lam(i)
+  end do
+  !$acc end parallel
+
+end subroutine size_dist_param_basic_vect2
+
+real(r8) elemental function avg_diameter(q, n, rho_air, rho_sub)
+  ! Finds the average diameter of particles given their density, and
+  ! mass/number concentrations in the air.
+  ! Assumes that diameter follows an exponential distribution.
+  real(r8), intent(in) :: q         ! mass mixing ratio
+  real(r8), intent(in) :: n         ! number concentration (per volume)
+  real(r8), intent(in) :: rho_air   ! local density of the air
+  real(r8), intent(in) :: rho_sub   ! density of the particle substance
+
+  avg_diameter = (q*rho_air/(pi * rho_sub * n))**(1._r8/3._r8)
+
+end function avg_diameter
+
+subroutine avg_diameter_vec (q, n, rho_air, rho_sub, avg_diameter, vlen)
+   ! Finds the average diameter of particles given their density, and
+   ! mass/number concentrations in the air.
+   ! Assumes that diameter follows an exponential distribution.
+   integer,  intent(in)  :: vlen
+   real(r8), intent(in)  :: q(vlen)         ! mass mixing ratio
+   real(r8), intent(in)  :: n(vlen)         ! number concentration (per volume)
+   real(r8), intent(in)  :: rho_air(vlen)   ! local density of the air
+   real(r8), intent(in)  :: rho_sub   ! density of the particle substance
+   real(r8), intent(out) :: avg_diameter(vlen)
+   integer :: i
+
+   !$acc parallel vector_length(VLENS) default(present)
+   !$acc loop gang vector
+   do i=1,vlen
+      avg_diameter(i) = (q(i)*rho_air(i)/(pi * rho_sub * n(i)))**(1._r8/3._r8)
+   end do
+   !$acc end parallel
+end subroutine avg_diameter_vec
+
+subroutine var_coef_r8(relvar, a, res)
+  !$acc routine seq
+
+  ! Finds a coefficient for process rates based on the relative variance
+  ! of cloud water.
+  real(r8), intent(in)  :: relvar
+  real(r8), intent(in)  :: a
+  real(r8), intent(out) :: res
+
+  call rising_factorial(relvar, a, res)
+  res = res / relvar**a
+
+end subroutine var_coef_r8
+
+subroutine var_coef_r8_vect(relvar, a, res, vlen)
+  ! Finds a coefficient for process rates based on the relative variance
+  ! of cloud water.
+  integer,  intent(in)  :: vlen
+  real(r8), intent(in)  :: relvar(vlen)
+  real(r8), intent(in)  :: a
+  real(r8), intent(out) :: res(vlen)
+  integer  :: i
+  real(r8) :: tmpA(vlen)
+
+  !$acc data create (tmpA)
+
+  call rising_factorial(relvar,a,tmpA,vlen)
+
+  !$acc parallel vector_length(VLENS) default(present)
+  !$acc loop gang vector
+  do i=1,vlen
+     res(i) = tmpA(i)/relvar(i)**a
+  end do
+  !$acc end parallel
+
+  !$acc end data
+end subroutine var_coef_r8_vect
+
+subroutine var_coef_integer(relvar, a, res)
+  !$acc routine seq
+
+  ! Finds a coefficient for process rates based on the relative variance
+  ! of cloud water.
+  real(r8), intent(in) :: relvar
+  integer, intent(in) :: a
+  real(r8), intent(out) :: res
+
+  call rising_factorial(relvar, a, res)
+  res = res / relvar**a
+
+end subroutine var_coef_integer
+
+subroutine var_coef_integer_vect(relvar, a, res, vlen)
+  ! Finds a coefficient for process rates based on the relative variance
+  ! of cloud water.
+  integer, intent(in)   :: vlen
+  real(r8), intent(in)  :: relvar(vlen)
+  integer, intent(in)   :: a
+  real(r8), intent(out) :: res(vlen)
+  integer  :: i
+  real(r8) :: tmp(vlen)
+
+  !$acc data create (tmp)
+
+  call rising_factorial(relvar, a,tmp,vlen)
+
+  !$acc parallel vector_length(VLENS) default(present)
+  !$acc loop gang vector
+  do i=1,vlen
+     res(i) = tmp(i) / relvar(i)**a
+  end do
+  !$acc end parallel
+
+  !$acc end data
+end subroutine var_coef_integer_vect
+
+!========================================================================
+!MICROPHYSICAL PROCESS CALCULATIONS
+!========================================================================
+!========================================================================
+! Initial ice deposition and sublimation loop.
+! Run before the main loop
+! This subroutine written by Peter Caldwell
+
+subroutine ice_deposition_sublimation(t, qv, qi, ni, &
+                                      icldm, rho, dv,qvl, qvi, &
+                                      berg, vap_dep, ice_sublim, vlen)
+
+  !INPUT VARS:
+  !===============================================
+  integer,  intent(in)                  :: vlen
+  real(r8), dimension(vlen), intent(in) :: t
+  real(r8), dimension(vlen), intent(in) :: qv
+  real(r8), dimension(vlen), intent(in) :: qi
+  real(r8), dimension(vlen), intent(in) :: ni
+  real(r8), dimension(vlen), intent(in) :: icldm
+  real(r8), dimension(vlen), intent(in) :: rho
+  real(r8), dimension(vlen), intent(in) :: dv
+  real(r8), dimension(vlen), intent(in) :: qvl
+  real(r8), dimension(vlen), intent(in) :: qvi
+
+  !OUTPUT VARS:
+  !===============================================
+  real(r8), dimension(vlen), intent(out) :: vap_dep !ice deposition (cell-ave value)
+  real(r8), dimension(vlen), intent(out) :: ice_sublim !ice sublimation (cell-ave value)
+  real(r8), dimension(vlen), intent(out) :: berg !bergeron enhancement (cell-ave value)
+
+  !INTERNAL VARS:
+  !===============================================
+  real(r8) :: ab(vlen)
+  real(r8) :: epsi
+  real(r8) :: qiic(vlen)
+  real(r8) :: niic(vlen)
+  real(r8) :: lami(vlen)
+  real(r8) :: n0i(vlen)
+  integer :: i
+
+  !$acc data create (ab,qiic,niic,lami,n0i)
+
+  !GET IN-CLOUD qi, ni
+  !===============================================
+
+  !Compute linearized condensational heating correction
+  call calc_ab(t, qvi, xxls, ab, vlen)
+
+  !$acc parallel vector_length(VLENS) default(present)
+  !$acc loop gang vector
+  do i = 1,vlen
+     qiic(i) = qi(i)/icldm(i)
+     niic(i) = ni(i)/icldm(i)
+     if (qi(i)<qsmall) then
+        qiic(i) = 0._r8
+        niic(i) = 0._r8
+        ab(i)   = 0._r8
+     end if
+  end do
+  !$acc end parallel
+
+  !Get slope and intercept of gamma distn for ice.
+  call size_dist_param_basic_vect(mg_ice_props, qiic, niic, lami, vlen, n0i)
+
+  !$acc parallel vector_length(VLENS) default(present)
+  !$acc loop gang vector
+  do i=1,vlen
+     if (qi(i)>=qsmall) then
+        !Get depletion timescale=1/eps
+        epsi = 2._r8*pi*n0i(i)*rho(i)*Dv(i)/(lami(i)*lami(i))
+
+        !Compute deposition/sublimation
+        vap_dep(i) = epsi/ab(i)*(qv(i) - qvi(i))
+
+        !Make this a grid-averaged quantity
+        vap_dep(i) = vap_dep(i)*icldm(i)
+
+        !Split into deposition or sublimation.
+        if (t(i) < tmelt .and. vap_dep(i) > 0._r8) then
+           ice_sublim(i) = 0._r8
+        else
+        ! make ice_sublim negative for consistency with other evap/sub processes
+           ice_sublim(i) = min(vap_dep(i),0._r8)
+           vap_dep(i)    = 0._r8
+        end if
+
+        !sublimation occurs @ any T. Not so for berg.
+        if (t(i) < tmelt) then
+
+           !Compute bergeron rate assuming cloud for whole step.
+           berg(i) = max(epsi/ab(i)*(qvl(i) - qvi(i)), 0._r8)
+        else   !T>frz
+           berg(i)=0._r8
+        end if !T<frz
+     else      !where qi<qsmall
+        berg(i)       = 0._r8
+        vap_dep(i)    = 0._r8
+        ice_sublim(i) = 0._r8
+     end if    !qi>qsmall
+  end do
+  !$acc end parallel
+
+  !$acc end data
+end subroutine ice_deposition_sublimation
+
+subroutine ice_deposition_sublimation_mg4(t, qv, qi, niic, &
+                                      icldm, rho, dv,qvl, qvi, &
+                                      berg, vap_dep, ice_sublim, &
+                                      af1pr5, af1pr14, rhof, mu, sc, &
+                                      vlen)
+
+  !INPUT VARS:
+  !===============================================
+  integer,  intent(in)                  :: vlen
+  real(r8), dimension(vlen), intent(in) :: t
+  real(r8), dimension(vlen), intent(in) :: qv
+  real(r8), dimension(vlen), intent(in) :: qi
+  real(r8), dimension(vlen), intent(in) :: niic ! trude: input nicc as other routines
+  real(r8), dimension(vlen), intent(in) :: icldm
+  real(r8), dimension(vlen), intent(in) :: rho
+  real(r8), dimension(vlen), intent(in) :: dv
+  real(r8), dimension(vlen), intent(in) :: qvl
+  real(r8), dimension(vlen), intent(in) :: qvi
+  real(r8), dimension(vlen), intent(in) :: af1pr5, af1pr14
+  real(r8), dimension(vlen), intent(in) :: rhof
+  real(r8), dimension(vlen), intent(in) :: mu
+  real(r8), dimension(vlen), intent(in) :: sc
+
+  !OUTPUT VARS:
+  !===============================================
+  real(r8), dimension(vlen), intent(out) :: vap_dep !ice deposition (cell-ave value)
+  real(r8), dimension(vlen), intent(out) :: ice_sublim !ice sublimation (cell-ave value)
+  real(r8), dimension(vlen), intent(out) :: berg !bergeron enhancement (cell-ave value)
+
+  !INTERNAL VARS:
+  !===============================================
+  real(r8) :: ab(vlen)
+  real(r8) :: epsi
+  real(r8) :: qiic(vlen)
+  real(r8) :: lami(vlen)
+  real(r8) :: n0i(vlen)
+  real(r8), parameter :: thrd = 1._r8/3._r8
+  integer :: i
+
+  !$acc data create (ab,qiic,lami,n0i)
+
+  !GET IN-CLOUD qi, ni
+  !===============================================
+  !$acc parallel vector_length(VLENS) default(present)
+  !$acc loop gang vector
+  do i = 1,vlen
+     if (qi(i)>=qsmall) then
+        qiic(i) = qi(i)/icldm(i)
+        !Compute linearized condensational heating correction
+        call calc_ab(t(i), qvi(i), xxls, ab(i))
+     end if
+  end do
+  !$acc end parallel
+
+  !$acc parallel vector_length(VLENS) default(present)
+  !$acc loop gang vector
+  do i=1,vlen
+     if (qi(i)>=qsmall) then
+        if ( t(i) .lt. tmelt ) then
+           epsi = (af1pr5(i)+af1pr14(i)*sc(i)**thrd*(rhof(i)*rho(i)/mu(i))**0.5_r8)*2._r8*pi* &
+             rho(i)*dv(i)
+        else
+           epsi = 0._r8
+        end if
+
+        !Compute deposition/sublimation
+        vap_dep(i) = epsi/ab(i)*(qv(i) - qvi(i))
+
+        !Make this a grid-averaged quantity
+        vap_dep(i) = vap_dep(i)*icldm(i)
+
+        !Split into deposition or sublimation.
+        if (t(i) < tmelt .and. vap_dep(i) > 0._r8) then
+           ice_sublim(i)=0._r8
+        else
+           ! make ice_sublim negative for consistency with other evap/sub processes
+           ice_sublim(i)=min(vap_dep(i),0._r8)
+           vap_dep(i)=0._r8
+        end if
+
+        !sublimation occurs @ any T. Not so for berg.
+        if (t(i) < tmelt) then
+           !Compute bergeron rate assuming cloud for whole step.
+           berg(i) = max(epsi/ab(i)*(qvl(i) - qvi(i)), 0._r8)
+        else   !T>frz
+           berg(i) = 0._r8
+        end if !T<frz
+     else      !where qi<qsmall
+        berg(i)       = 0._r8
+        vap_dep(i)    = 0._r8
+        ice_sublim(i) = 0._r8
+     end if    !qi>qsmall
+  end do
+  !$acc end parallel
+
+  !$acc end data
+end subroutine ice_deposition_sublimation_mg4
+
+subroutine vapor_deposition_onto_snow(t, qv, qs, ns, &
+   precip_frac, rho, dv,qvl, qvi, asn, mu, sc, &
+   vap_deps, vlen)
+
+!INPUT VARS:
+!===============================================
+integer,  intent(in) :: vlen
+real(r8), dimension(vlen), intent(in) :: t     ! Temperature
+real(r8), dimension(vlen), intent(in) :: qv    ! Specific Humidity
+real(r8), dimension(vlen), intent(in) :: qs    ! Snow Mass Mixing Ratio
+real(r8), dimension(vlen), intent(in) :: ns    ! Snow number concentration
+real(r8), dimension(vlen), intent(in) :: precip_frac ! Precipitation Fraction
+real(r8), dimension(vlen), intent(in) :: rho   ! Air Density
+real(r8), dimension(vlen), intent(in) :: dv    ! diffusivity of water vapor
+real(r8), dimension(vlen), intent(in) :: qvl   ! saturation vapor pressure liq
+real(r8), dimension(vlen), intent(in) :: qvi   ! saturation vapor pressure ice
+real(r8), dimension(vlen), intent(in) :: asn   ! fall speed parameter for snow
+real(r8), dimension(vlen), intent(in) :: mu    ! viscosity
+real(r8), dimension(vlen), intent(in) :: sc    ! schmidt number
+
+!OUTPUT VARS:
+!===============================================
+real(r8), dimension(vlen), intent(out) :: vap_deps !vapor deposition onto snow (cell-ave value)
+
+!INTERNAL VARS:
+!===============================================
+real(r8) :: ab
+real(r8) :: eps
+real(r8) :: qsic
+real(r8) :: nsic
+real(r8) :: lams
+real(r8) :: n0s
+integer :: i
+
+!$acc parallel vector_length(VLENS) default(present)
+!$acc loop gang vector
+do i=1,vlen
+   vap_deps(i)=0._r8
+   if (qs(i)>=qsmall.and.precip_frac(i)>=0.1) then
+
+!GET IN-CLOUD qs, ns
+!===============================================
+      qsic = qs(i)/precip_frac(i)
+      nsic = ns(i)/precip_frac(i)
+
+!Compute linearized condensational heating correction
+      call calc_ab(t(i), qvi(i), xxls, ab)
+!Get slope and intercept of gamma distn for ice.
+      call size_dist_param_basic_line(mg_snow_props, qsic, nsic, lams, n0s)
+!Get depletion timescale eps
+      eps = 2._r8*pi*n0s*rho(i)*dv(i)* &
+        (f1s/(lams*lams)+ &
+        f2s*(asn(i)*rho(i)/mu(i))**0.5_r8* &
+        sc(i)**(1._r8/3._r8)*gamma_half_bs_plus5/ &
+        (lams**(5._r8/2._r8+bs/2._r8)))
+
+!Compute deposition/sublimation
+      vap_deps(i) = eps/ab*(qv(i) - qvi(i))
+
+!Make this a grid-averaged quantity
+      vap_deps(i)=vap_deps(i)*precip_frac(i)
+
+!Only want deposition
+      if (t(i) < tmelt .and. vap_deps(i)>0._r8) then
+         vap_deps(i)=max(vap_deps(i),0._r8)
+      else
+         vap_deps(i)=0._r8
+      end if
+
+   end if !qs>qsmall
+enddo
+!$acc end parallel
+
+end subroutine vapor_deposition_onto_snow
+
+!========================================================================
+! autoconversion of cloud liquid water to rain
+! formula from Khrouditnov and Kogan (2000), modified for sub-grid distribution of qc
+! minimum qc of 1 x 10^-8 prevents floating point error
+
+subroutine kk2000_liq_autoconversion(microp_uniform, qcic, &
+     ncic, rho, relvar, prc, nprc, nprc1, micro_mg_autocon_fact, &
+     micro_mg_autocon_nd_exp, micro_mg_autocon_lwp_exp, vlen)
+
+  integer, intent(in) :: vlen
+  logical, intent(in) :: microp_uniform
+
+  real(r8), dimension(vlen), intent(in) :: qcic
+  real(r8), dimension(vlen), intent(in) :: ncic
+  real(r8), dimension(vlen), intent(in) :: rho
+
+  real(r8), dimension(vlen), intent(in) :: relvar
+
+  real(r8), dimension(vlen), intent(out) :: prc
+  real(r8), dimension(vlen), intent(out) :: nprc
+  real(r8), dimension(vlen), intent(out) :: nprc1
+
+  real(r8), intent(in) :: micro_mg_autocon_fact
+  real(r8), intent(in) :: micro_mg_autocon_nd_exp
+  real(r8), intent(in) :: micro_mg_autocon_lwp_exp
+
+  real(r8), dimension(vlen) :: prc_coef
+  integer :: i
+
+  !$acc data create (prc_coef)
+
+  ! Take variance into account, or use uniform value.
+  if (.not. microp_uniform) then
+     call var_coef(relvar, micro_mg_autocon_lwp_exp, prc_coef,vlen)
+  else
+     !$acc parallel vector_length(VLENS) default(present)
+     !$acc loop gang vector
+     do i = 1,vlen
+        prc_coef(i) = 1._r8
+     end do
+     !$acc end parallel
+  end if
+
+  !$acc parallel vector_length(VLENS) default(present)
+  !$acc loop gang vector
+  do i=1,vlen
+     if (qcic(i) >= icsmall) then
+        ! nprc is increase in rain number conc due to autoconversion
+        ! nprc1 is decrease in cloud droplet conc due to autoconversion
+
+        ! assume exponential sub-grid distribution of qc, resulting in additional
+        ! factor related to qcvar below
+        ! switch for sub-columns, don't include sub-grid qc
+        prc(i)   = prc_coef(i) * &
+             micro_mg_autocon_fact * 1350._r8 * qcic(i)**micro_mg_autocon_lwp_exp * &
+             (ncic(i)*1.e-6_r8*rho(i))**(micro_mg_autocon_nd_exp)
+
+        nprc(i)  = prc(i) * (1._r8/droplet_mass_25um)
+        nprc1(i) = prc(i)*ncic(i)/qcic(i)
+
+     else
+        prc(i)   = 0._r8
+        nprc(i)  = 0._r8
+        nprc1(i) = 0._r8
+     end if
+  end do
+  !$acc end parallel
+
+  !$acc end data
+end subroutine kk2000_liq_autoconversion
+
+!========================================================================
+
+subroutine sb2001v2_liq_autoconversion(pgam,qc,nc,qr,rho,relvar,au,nprc,nprc1,vlen)
+  !
+  ! ---------------------------------------------------------------------
+  ! AUTO_SB:  calculates the evolution of mass- and number mxg-ratio for
+  ! drizzle drops due to autoconversion. The autoconversion rate assumes
+  ! f(x)=A*x**(nu_c)*exp(-Bx) in drop MASS x.
+
+  ! Code from Hugh Morrison, Sept 2014
+
+  ! autoconversion
+  ! use simple lookup table of dnu values to get mass spectral shape parameter
+  ! equivalent to the size spectral shape parameter pgam
+
+  integer,                   intent(in)     :: vlen
+  real(r8), dimension(vlen), intent (in)    :: pgam
+  real(r8), dimension(vlen), intent (in)    :: qc  ! = qc (cld water mixing ratio)
+  real(r8), dimension(vlen), intent (in)    :: nc  ! = nc (cld water number conc /kg)
+  real(r8), dimension(vlen), intent (in)    :: qr  ! = qr (rain water mixing ratio)
+  real(r8), dimension(vlen), intent (in)    :: rho ! = rho : density profile
+  real(r8), dimension(vlen), intent (in)    :: relvar
+
+  real(r8), dimension(vlen), intent (out)   :: au ! = prc autoconversion rate
+  real(r8), dimension(vlen), intent (out)   :: nprc1 ! = number tendency
+  real(r8), dimension(vlen), intent (out)   :: nprc ! = number tendency fixed size for rain
+
+  ! parameters for droplet mass spectral shape,
+  !used by Seifert and Beheng (2001)
+  ! warm rain scheme only (iparam = 1)
+  real(r8), parameter :: dnu(16) = [0._r8,-0.557_r8,-0.430_r8,-0.307_r8, &
+     -0.186_r8,-0.067_r8,0.050_r8,0.167_r8,0.282_r8,0.397_r8,0.512_r8, &
+     0.626_r8,0.739_r8,0.853_r8,0.966_r8,0.966_r8]
+
+  ! parameters for Seifert and Beheng (2001) autoconversion/accretion
+  real(r8), parameter :: kc = 9.44e9_r8
+  real(r8), parameter :: kr = 5.78e3_r8
+  real(r8) :: dum, dum1, nu
+  integer  :: dumi, i
+
+  !$acc parallel vector_length(VLENS) default(present)
+  !$acc loop gang vector
+  do i=1,vlen
+     if (qc(i) > qsmall) then
+       dumi = int(pgam(i))
+       nu   = dnu(dumi)+(dnu(dumi+1)-dnu(dumi))* &
+               (pgam(i)-dumi)
+
+       dum  = 1._r8-qc(i)/(qc(i)+qr(i))
+       dum1 = 600._r8*dum**0.68_r8*(1._r8-dum**0.68_r8)**3
+
+       au(i) = kc/(20._r8*2.6e-7_r8)* &
+         (nu+2._r8)*(nu+4._r8)/(nu+1._r8)**2._r8* &
+         (rho(i)*qc(i)/1000._r8)**4._r8/(rho(i)*nc(i)/1.e6_r8)**2._r8* &
+         (1._r8+dum1/(1._r8-dum)**2)*1000._r8 / rho(i)
+
+       nprc1(i) = au(i)*2._r8/2.6e-7_r8*1000._r8
+       nprc(i)  = au(i)/droplet_mass_40um
+     else
+       au(i)    = 0._r8
+       nprc1(i) = 0._r8
+       nprc(i)  = 0._r8
+     end if
+  end do
+  !$acc end parallel
+
+end subroutine sb2001v2_liq_autoconversion
+
+!========================================================================
+!SB2001 Accretion V2
+
+subroutine sb2001v2_accre_cld_water_rain(qc,nc,qr,rho,relvar,pra,npra,vlen)
+  !
+  ! ---------------------------------------------------------------------
+  ! ACCR_SB calculates the evolution of mass mxng-ratio due to accretion
+  ! and self collection following Seifert & Beheng (2001).
+  !
+
+  integer, intent(in) :: vlen
+
+  real(r8), dimension(vlen), intent (in)    :: qc  ! = qc (cld water mixing ratio)
+  real(r8), dimension(vlen), intent (in)    :: nc  ! = nc (cld water number conc /kg)
+  real(r8), dimension(vlen), intent (in)    :: qr  ! = qr (rain water mixing ratio)
+  real(r8), dimension(vlen), intent (in)    :: rho ! = rho : density profile
+  real(r8), dimension(vlen), intent (in)    :: relvar
+
+  ! Output tendencies
+  real(r8), dimension(vlen), intent(out) :: pra  ! MMR
+  real(r8), dimension(vlen), intent(out) :: npra ! Number
+
+  ! parameters for Seifert and Beheng (2001) autoconversion/accretion
+  real(r8), parameter :: kc = 9.44e9_r8
+  real(r8), parameter :: kr = 5.78e3_r8
+
+  real(r8) :: dum, dum1
+  integer :: i
+
+  ! accretion
+
+  !$acc parallel vector_length(VLENS) default(present)
+  !$acc loop gang vector
+  do i = 1,vlen
+    if (qc(i) > qsmall) then
+      dum     = 1._r8-qc(i)/(qc(i)+qr(i))
+      dum1    = (dum/(dum+5.e-4_r8))**4._r8
+      pra(i)  = kr*rho(i)*0.001_r8*qc(i)*qr(i)*dum1
+      npra(i) = pra(i)*rho(i)*0.001_r8*(nc(i)*rho(i)*1.e-6_r8)/ &
+           (qc(i)*rho(i)*0.001_r8)*1.e6_r8 / rho(i)
+    else
+      pra(i)  = 0._r8
+      npra(i) = 0._r8
+    end if
+  end do
+  !$acc end parallel
+
+end subroutine sb2001v2_accre_cld_water_rain
+
+!========================================================================
+! Autoconversion of cloud ice to snow
+! similar to Ferrier (1994)
+
+subroutine ice_autoconversion(t, qiic, lami, n0i, dcs, prci, nprci, vlen)
+
+  integer, intent(in) :: vlen
+  real(r8), dimension(vlen), intent(in) :: t
+  real(r8), dimension(vlen), intent(in) :: qiic
+  real(r8), dimension(vlen), intent(in) :: lami
+  real(r8), dimension(vlen), intent(in) :: n0i
+  real(r8),                    intent(in) :: dcs
+
+  real(r8), dimension(vlen), intent(out) :: prci
+  real(r8), dimension(vlen), intent(out) :: nprci
+
+  ! Assume autoconversion timescale of 180 seconds.
+  real(r8), parameter :: ac_time = 180._r8
+
+  ! Average mass of an ice particle.
+  real(r8) :: m_ip
+  ! Ratio of autoconversion diameter to average diameter.
+  real(r8) :: d_rat
+  integer :: i
+
+  !$acc parallel vector_length(VLENS) default(present)
+  !$acc loop gang vector
+  do i=1,vlen
+     if (t(i) <= tmelt .and. qiic(i) >= qsmall) then
+        d_rat = lami(i)*dcs
+
+        ! Rate of ice particle conversion (number).
+        nprci(i) = n0i(i)/(lami(i)*ac_time)*exp(-d_rat)
+        m_ip = (rhoi*pi/6._r8) / lami(i)**3
+
+        ! Rate of mass conversion.
+        ! Note that this is:
+        ! m n (d^3 + 3 d^2 + 6 d + 6)
+        prci(i) = m_ip * nprci(i) * &
+             (((d_rat + 3._r8)*d_rat + 6._r8)*d_rat + 6._r8)
+     else
+        prci(i)  = 0._r8
+        nprci(i) = 0._r8
+     end if
+  end do
+  !$acc end parallel
+
+end subroutine ice_autoconversion
+
+! immersion freezing (Bigg, 1953)
+!===================================
+
+subroutine immersion_freezing(microp_uniform, t, pgam, lamc, &
+     qcic, ncic, relvar, mnuccc, nnuccc, vlen)
+
+  integer, intent(in) :: vlen
+  logical, intent(in) :: microp_uniform
+
+  ! Temperature
+  real(r8), dimension(vlen), intent(in) :: t
+
+  ! Cloud droplet size distribution parameters
+  real(r8), dimension(vlen), intent(in) :: pgam
+  real(r8), dimension(vlen), intent(in) :: lamc
+
+  ! MMR and number concentration of in-cloud liquid water
+  real(r8), dimension(vlen), intent(in) :: qcic
+  real(r8), dimension(vlen), intent(in) :: ncic
+
+  ! Relative variance of cloud water
+  real(r8), dimension(vlen), intent(in) :: relvar
+
+  ! Output tendencies
+  real(r8), dimension(vlen), intent(out) :: mnuccc ! MMR
+  real(r8), dimension(vlen), intent(out) :: nnuccc ! Number
+
+  ! Coefficients that will be omitted for sub-columns
+  real(r8), dimension(vlen) :: dum
+  integer  :: i
+  real(r8) :: tmp
+
+  !$acc data create (dum)
+
+  if (.not. microp_uniform) then
+     call var_coef(relvar, 2, dum, vlen)
+  else
+     !$acc parallel vector_length(VLENS) default(present)
+     !$acc loop gang vector
+     do i =1,vlen
+        dum(i) = 1._r8
+     end do
+     !$acc end parallel
+  end if
+
+  !$acc parallel vector_length(VLENS) default(present)
+  !$acc loop gang vector
+  do i=1,vlen
+     if (qcic(i) >= qsmall .and. t(i) < 269.15_r8) then
+        call rising_factorial(pgam(i)+1._r8, 3, tmp)
+        nnuccc(i) = &
+             pi/6._r8*ncic(i)*tmp* &
+             bimm*(exp(aimm*(tmelt - t(i)))-1._r8)/lamc(i)**3
+
+        call rising_factorial(pgam(i)+4._r8, 3, tmp)
+        mnuccc(i) = dum(i) * nnuccc(i) * &
+             pi/6._r8*rhow* &
+             tmp/lamc(i)**3
+     else
+        mnuccc(i) = 0._r8
+        nnuccc(i) = 0._r8
+     end if ! qcic > qsmall and t < 4 deg C
+  end do
+  !$acc end parallel
+
+  !$acc end data
+end subroutine immersion_freezing
+
+! contact freezing (-40<T<-3 C) (Young, 1974) with hooks into simulated dust
+!===================================================================
+! dust size and number in multiple bins are read in from companion routine
+
+subroutine contact_freezing (microp_uniform, t, p, rndst, nacon, &
+     pgam, lamc, qcic, ncic, relvar, mnucct, nnucct, vlen, mdust)
+
+  logical, intent(in) :: microp_uniform
+
+  integer, intent(in) :: vlen
+  integer, intent(in) :: mdust
+
+  real(r8), dimension(vlen), intent(in) :: t            ! Temperature
+  real(r8), dimension(vlen), intent(in) :: p            ! Pressure
+  real(r8), dimension(vlen, mdust), intent(in) :: rndst ! Radius (for multiple dust bins)
+  real(r8), dimension(vlen, mdust), intent(in) :: nacon ! Number (for multiple dust bins)
+
+  ! Size distribution parameters for cloud droplets
+  real(r8), dimension(vlen), intent(in) :: pgam
+  real(r8), dimension(vlen), intent(in) :: lamc
+
+  ! MMR and number concentration of in-cloud liquid water
+  real(r8), dimension(vlen), intent(in) :: qcic
+  real(r8), dimension(vlen), intent(in) :: ncic
+
+  ! Relative cloud water variance
+  real(r8), dimension(vlen), intent(in) :: relvar
+
+  ! Output tendencies
+  real(r8), dimension(vlen), intent(out) :: mnucct ! MMR
+  real(r8), dimension(vlen), intent(out) :: nnucct ! Number
+
+  real(r8) :: tcnt                  ! scaled relative temperature
+  real(r8) :: viscosity             ! temperature-specific viscosity (kg/m/s)
+  real(r8) :: mfp                   ! temperature-specific mean free path (m)
+
+  ! Dimension these according to number of dust bins, inferred from rndst size
+  real(r8) :: nslip(size(rndst,2))  ! slip correction factors
+  real(r8) :: ndfaer(size(rndst,2)) ! aerosol diffusivities (m^2/sec)
+
+  ! Coefficients not used for subcolumns
+  real(r8) :: dum, dum1, tmp
+
+  ! Common factor between mass and number.
+  real(r8) :: contact_factor
+
+  integer  :: i, j
+
+  !$acc data create (nslip,ndfaer)
+
+  !$acc parallel vector_length(VLENS) default(present)
+  !$acc loop gang vector
+  do i = 1,vlen
+     if (qcic(i) >= qsmall .and. t(i) < 269.15_r8) then
+        if (microp_uniform) then
+           dum  = 1._r8
+           dum1 = 1._r8
+        else
+           call var_coef(relvar(i), 4._r8/3._r8, dum)
+           call var_coef(relvar(i), 1._r8/3._r8, dum1)
+        end if
+
+        tcnt=(270.16_r8-t(i))**1.3_r8
+        viscosity = 1.8e-5_r8*(t(i)/298.0_r8)**0.85_r8    ! Viscosity (kg/m/s)
+        mfp = 2.0_r8*viscosity/ &                         ! Mean free path (m)
+                     (p(i)*sqrt( 8.0_r8*28.96e-3_r8/(pi*8.314409_r8*t(i)) ))
+
+        do j = 1, mdust
+           ! Note that these two are vectors.
+           nslip(j) = 1.0_r8+(mfp/rndst(i,j))*(1.257_r8+(0.4_r8*exp(-(1.1_r8*rndst(i,j)/mfp))))! Slip correction factor
+
+           ndfaer(j) = 1.381e-23_r8*t(i)*nslip(j)/(6._r8*pi*viscosity*rndst(i,j))  ! aerosol diffusivity (m2/s)
+        end do
+
+        contact_factor = dot_product(ndfaer,nacon(i,:)*tcnt) * pi * &
+                                     ncic(i) * (pgam(i) + 1._r8) / lamc(i)
+        call rising_factorial(pgam(i)+2._r8, 3, tmp)
+        mnucct(i) = dum * contact_factor * pi/3._r8*rhow*tmp/lamc(i)**3
+        nnucct(i) = dum1 * 2._r8 * contact_factor
+     else
+        mnucct(i) = 0._r8
+        nnucct(i) = 0._r8
+     end if ! qcic > qsmall and t < 4 deg C
+  end do
+  !$acc end parallel
+
+  !$acc end data
+end subroutine contact_freezing
+
+! snow self-aggregation from passarelli, 1978, used by reisner, 1998
+!===================================================================
+! this is hard-wired for bs = 0.4 for now
+! ignore self-collection of cloud ice
+
+subroutine snow_self_aggregation(t, rho, asn, rhosn, qsic, nsic, nsagg, vlen)
+
+  integer,                   intent(in) :: vlen
+
+  real(r8), dimension(vlen), intent(in) :: t     ! Temperature
+  real(r8), dimension(vlen), intent(in) :: rho   ! Density
+  real(r8), dimension(vlen), intent(in) :: asn   ! fall speed parameter for snow
+  real(r8),                  intent(in) :: rhosn ! density of snow
+
+  ! In-cloud snow
+  real(r8), dimension(vlen), intent(in) :: qsic ! MMR
+  real(r8), dimension(vlen), intent(in) :: nsic ! Number
+
+  ! Output number tendency
+  real(r8), dimension(vlen), intent(out) :: nsagg
+
+  integer :: i
+
+  !$acc parallel vector_length(VLENS) default(present)
+  !$acc loop gang vector
+  do i=1,vlen
+     if (qsic(i) >= qsmall .and. t(i) <= tmelt) then
+        nsagg(i) = -1108._r8*eii/(4._r8*720._r8*rhosn)*asn(i)*qsic(i)*nsic(i)*rho(i)*&
+             ((qsic(i)/nsic(i))*(1._r8/(rhosn*pi)))**((bs-1._r8)/3._r8)
+     else
+        nsagg(i) = 0._r8
+     end if
+  end do
+  !$acc end parallel
+
+end subroutine snow_self_aggregation
+
+! ice self-aggregation used in mg4
+!===================================================================
+
+subroutine ice_self_aggregation(t, rho, rhof, af1pr3, qiic, nsagg, vlen)
+
+  integer,                   intent(in) :: vlen
+
+  real(r8), dimension(vlen), intent(in) :: t        ! Temperature
+  real(r8), dimension(vlen), intent(in) :: rho      ! Density
+  real(r8), dimension(vlen), intent(in) :: rhof     ! Density correction
+
+  real(r8), dimension(vlen), intent(in) :: af1pr3   ! process rate
+
+  ! In-cloud ice
+  real(r8), dimension(vlen), intent(in) :: qiic ! MMR
+
+  ! Collection efficiency
+  real(r8), parameter :: eii = 0.1_r8
+
+  ! Output number tendency
+  real(r8), dimension(vlen), intent(out) :: nsagg
+
+  integer :: i
+
+  !$acc parallel vector_length(VLENS) default(present)
+  !$acc loop gang vector
+  do i=1,vlen
+     if (qiic(i) >= qsmall .and. t(i) <= tmelt) then
+        nsagg(i) = af1pr3(i)*rho(i)*eii*rhof(i)
+     else
+        nsagg(i)=0._r8
+     end if
+  end do
+  !$acc end parallel
+
+end subroutine ice_self_aggregation
+
+! accretion of cloud droplets onto snow/graupel
+!===================================================================
+! here use continuous collection equation with
+! simple gravitational collection kernel
+! ignore collisions between droplets/cloud ice
+! since minimum size ice particle for accretion is 50 - 150 micron
+
+subroutine accrete_cloud_water_snow(t, rho, asn, uns, mu, qcic, ncic, qsic, &
+     pgam, lamc, lams, n0s, psacws, npsacws, vlen)
+
+  integer,                   intent(in) :: vlen
+  real(r8), dimension(vlen), intent(in) :: t   ! Temperature
+  real(r8), dimension(vlen), intent(in) :: rho ! Density
+  real(r8), dimension(vlen), intent(in) :: asn ! Fallspeed parameter (snow)
+  real(r8), dimension(vlen), intent(in) :: uns ! Current fallspeed   (snow)
+  real(r8), dimension(vlen), intent(in) :: mu  ! Viscosity
+
+  ! In-cloud liquid water
+  real(r8), dimension(vlen), intent(in) :: qcic ! MMR
+  real(r8), dimension(vlen), intent(in) :: ncic ! Number
+
+  ! In-cloud snow
+  real(r8), dimension(vlen), intent(in) :: qsic ! MMR
+
+  ! Cloud droplet size parameters
+  real(r8), dimension(vlen), intent(in) :: pgam
+  real(r8), dimension(vlen), intent(in) :: lamc
+
+  ! Snow size parameters
+  real(r8), dimension(vlen), intent(in) :: lams
+  real(r8), dimension(vlen), intent(in) :: n0s
+
+  ! Output tendencies
+  real(r8), dimension(vlen), intent(out) :: psacws  ! Mass mixing ratio
+  real(r8), dimension(vlen), intent(out) :: npsacws ! Number concentration
+
+  real(r8) :: dc0 ! Provisional mean droplet size
+  real(r8) :: dum
+  real(r8) :: eci ! collection efficiency for riming of snow by droplets
+
+  ! Fraction of cloud droplets accreted per second
+  real(r8) :: accrete_rate
+  integer :: i
+
+  ! ignore collision of snow with droplets above freezing
+
+  !$acc parallel vector_length(VLENS) default(present)
+  !$acc loop gang vector
+  do i=1,vlen
+     if (qsic(i) >= qsmall .and. t(i) <= tmelt .and. qcic(i) >= qsmall) then
+        ! put in size dependent collection efficiency
+        ! mean diameter of snow is area-weighted, since
+        ! accretion is function of crystal geometric area
+        ! collection efficiency is approximation based on stoke's law (Thompson et al. 2004)
+        dc0 = (pgam(i)+1._r8)/lamc(i)
+        dum = dc0*dc0*uns(i)*rhow*lams(i)/(9._r8*mu(i))
+        eci = dum*dum/((dum+0.4_r8)*(dum+0.4_r8))
+        eci = max(eci,0._r8)
+        eci = min(eci,1._r8)
+
+        ! no impact of sub-grid distribution of qc since psacws
+        ! is linear in qc
+        accrete_rate = pi/4._r8*asn(i)*rho(i)*n0s(i)*eci*gamma_bs_plus3 / lams(i)**(bs+3._r8)
+        psacws(i)  = accrete_rate*qcic(i)
+        npsacws(i) = accrete_rate*ncic(i)
+     else
+        psacws(i)  = 0._r8
+        npsacws(i) = 0._r8
+     end if
+  end do
+  !$acc end parallel
+
+end subroutine accrete_cloud_water_snow
+
+! Version used in MG4
+subroutine accrete_cloud_water_ice(t, rho, rhof, af1pr4, qcic, ncic, qiic, psacws, npsacws, vlen)
+
+  integer,                   intent(in) :: vlen
+  real(r8), dimension(vlen), intent(in) :: t        ! Temperature
+  real(r8), dimension(vlen), intent(in) :: rho      ! Density
+  real(r8), dimension(vlen), intent(in) :: rhof     ! Density correction factor
+  real(r8), dimension(vlen), intent(in) :: af1pr4   ! Process rate from look-up table
+  ! In-cloud liquid water
+  real(r8), dimension(vlen), intent(in) :: qcic     ! MMR
+  real(r8), dimension(vlen), intent(in) :: ncic     ! Number
+  ! In-cloud ice
+  real(r8), dimension(vlen), intent(in) :: qiic     ! MMR
+  ! Output tendencies
+  real(r8), dimension(vlen), intent(out) :: psacws  ! Mass mixing ratio
+  real(r8), dimension(vlen), intent(out) :: npsacws ! Number concentration
+
+  real(r8) :: eci     ! collection efficiency for riming of snow by droplets
+  integer  :: i
+
+  ! ignore collision of snow with droplets above freezing
+  eci = 0.5_r8 ! from p3 program
+
+  !$acc parallel vector_length(VLENS) default(present)
+  !$acc loop gang vector
+  do i=1,vlen
+     if (qiic(i) >= qsmall .and. t(i) <= tmelt .and. qcic(i) >= qsmall) then
+         psacws(i)  = rhof(i)*af1pr4(i)*qcic(i)*eci*rho(i)
+         npsacws(i) = rhof(i)*af1pr4(i)*ncic(i)*eci*rho(i)
+     else
+         psacws(i)  = 0._r8
+         npsacws(i) = 0._r8
+     end if
+  end do
+  !$acc end parallel
+
+end subroutine accrete_cloud_water_ice
+
+! add secondary ice production due to accretion of droplets by snow
+!===================================================================
+! (Hallet-Mossop process) (from Cotton et al., 1986)
+
+subroutine secondary_ice_production(t, psacws, msacwi, nsacwi, vlen)
+
+  integer,                   intent(in) :: vlen
+  real(r8), dimension(vlen), intent(in) :: t ! Temperature
+
+  ! Accretion of cloud water to snow tendencies
+  real(r8), dimension(vlen), intent(inout) :: psacws ! MMR
+
+  ! Output (ice) tendencies
+  real(r8), dimension(vlen), intent(out) :: msacwi ! MMR
+  real(r8), dimension(vlen), intent(out) :: nsacwi ! Number
+  integer :: i
+
+  !$acc parallel vector_length(VLENS) default(present)
+  !$acc loop gang vector
+  do i=1,vlen
+     if((t(i) < 270.16_r8) .and. (t(i) >= 268.16_r8)) then
+        nsacwi(i) = 3.5e8_r8*(270.16_r8-t(i))/2.0_r8*psacws(i)
+     else if((t(i) < 268.16_r8) .and. (t(i) >= 265.16_r8)) then
+        nsacwi(i) = 3.5e8_r8*(t(i)-265.16_r8)/3.0_r8*psacws(i)
+     else
+        nsacwi(i) = 0.0_r8
+     endif
+
+     msacwi(i) = min(nsacwi(i)*mi0, psacws(i))
+     psacws(i) = psacws(i) - msacwi(i)
+  end do
+  !$acc end parallel
+
+end subroutine secondary_ice_production
+
+! accretion of rain water by snow
+!===================================================================
+! formula from ikawa and saito, 1991, used by reisner et al., 1998
+
+subroutine accrete_rain_snow(t, rho, umr, ums, unr, uns, qric, qsic, &
+     lamr, n0r, lams, n0s, pracs, npracs, vlen)
+
+  integer,                   intent(in) :: vlen
+  real(r8), dimension(vlen), intent(in) :: t   ! Temperature
+  real(r8), dimension(vlen), intent(in) :: rho ! Density
+  ! Fallspeeds
+  ! mass-weighted
+  real(r8), dimension(vlen), intent(in) :: umr ! rain
+  real(r8), dimension(vlen), intent(in) :: ums ! snow
+  ! number-weighted
+  real(r8), dimension(vlen), intent(in) :: unr ! rain
+  real(r8), dimension(vlen), intent(in) :: uns ! snow
+  ! In cloud MMRs
+  real(r8), dimension(vlen), intent(in) :: qric ! rain
+  real(r8), dimension(vlen), intent(in) :: qsic ! snow
+  ! Size distribution parameters
+  ! rain
+  real(r8), dimension(vlen), intent(in) :: lamr
+  real(r8), dimension(vlen), intent(in) :: n0r
+  ! snow
+  real(r8), dimension(vlen), intent(in) :: lams
+  real(r8), dimension(vlen), intent(in) :: n0s
+  ! Output tendencies
+  real(r8), dimension(vlen), intent(out) :: pracs  ! MMR
+  real(r8), dimension(vlen), intent(out) :: npracs ! Number
+  ! Collection efficiency for accretion of rain by snow
+  real(r8), parameter :: ecr = 1.0_r8
+  ! Ratio of average snow diameter to average rain diameter.
+  real(r8) :: d_rat
+  ! Common factor between mass and number expressions
+  real(r8) :: common_factor
+  integer  :: i
+
+  !$acc parallel vector_length(VLENS) default(present)
+  !$acc loop gang vector
+  do i=1,vlen
+     if (qric(i) >= icsmall .and. qsic(i) >= icsmall .and. t(i) <= tmelt) then
+        common_factor = pi*ecr*rho(i)*n0r(i)*n0s(i)/(lamr(i)**3 * lams(i))
+        d_rat = lamr(i)/lams(i)
+        pracs(i) = common_factor*pi*rhow* &
+             sqrt((1.2_r8*umr(i)-0.95_r8*ums(i))**2 + 0.08_r8*ums(i)*umr(i)) / lamr(i)**3 * &
+             ((0.5_r8*d_rat + 2._r8)*d_rat + 5._r8)
+        npracs(i) = common_factor*0.5_r8* &
+             sqrt(1.7_r8*(unr(i)-uns(i))**2 + 0.3_r8*unr(i)*uns(i)) * &
+             ((d_rat + 1._r8)*d_rat + 1._r8)
+     else
+        pracs(i) = 0._r8
+        npracs(i) = 0._r8
+     end if
+  end do
+  !$acc end parallel
+
+end subroutine accrete_rain_snow
+
+! Version used in MG4
+subroutine accrete_rain_ice(t, rho, rhof, af1pr8, af1pr7, qric, qiic, &
+      n0r, pracs, npracs, vlen )
+
+  integer,                   intent(in) :: vlen
+  real(r8), dimension(vlen), intent(in) :: rhof ! Density correction factor
+  real(r8), dimension(vlen), intent(in) :: rho  ! Density
+  real(r8), dimension(vlen), intent(in) :: t    ! Temperature
+  ! In cloud MMRs
+  real(r8), dimension(vlen), intent(in) :: qric ! rain
+  real(r8), dimension(vlen), intent(in) :: qiic ! combined snow and ice
+  ! Size distribution parameters
+  ! rain
+  real(r8), dimension(vlen), intent(in) :: n0r
+  ! Processrates
+  real(r8), dimension(vlen), intent(in) :: af1pr8
+  real(r8), dimension(vlen), intent(in) :: af1pr7
+  ! Output tendencies
+  real(r8), dimension(vlen), intent(out) :: pracs  ! MMR
+  real(r8), dimension(vlen), intent(out) :: npracs ! Number
+  ! Collection efficiency for accretion of rain by snow
+  real(r8), parameter :: ecr = 1.0_r8
+  integer :: i
+
+  !$acc parallel vector_length(VLENS) default(present)
+  !$acc loop gang vector
+  do i=1,vlen
+     if (qric(i) >= icsmall .and. qiic(i) >= icsmall .and. t(i) <= tmelt) then
+        pracs(i)  = 10._r8**(af1pr8(i)+dlog10(n0r(i)))*rho(i)*rhof(i)*ecr
+        npracs(i) = 10._r8**(af1pr7(i)+dlog10(n0r(i)))*rho(i)*rhof(i)*ecr
+     else
+        pracs(i)  = 0._r8
+        npracs(i) = 0._r8
+     end if
+  end do
+  !$acc end parallel
+
+end subroutine accrete_rain_ice
+
+! heterogeneous freezing of rain drops
+!===================================================================
+! follows from Bigg (1953)
+
+subroutine heterogeneous_rain_freezing(t, qric, nric, lamr, mnuccr, nnuccr, vlen)
+
+  integer,                   intent(in) :: vlen
+  real(r8), dimension(vlen), intent(in) :: t    ! Temperature
+  ! In-cloud rain
+  real(r8), dimension(vlen), intent(in) :: qric ! MMR
+  real(r8), dimension(vlen), intent(in) :: nric ! Number
+  real(r8), dimension(vlen), intent(in) :: lamr ! size parameter
+  ! Output tendencies
+  real(r8), dimension(vlen), intent(out) :: mnuccr ! MMR
+  real(r8), dimension(vlen), intent(out) :: nnuccr ! Number
+  integer :: i
+
+  !$acc parallel vector_length(VLENS) default(present)
+  !$acc loop gang vector
+  do i=1,vlen
+     if (t(i) < 269.15_r8 .and. qric(i) >= qsmall) then
+        nnuccr(i) = pi*nric(i)*bimm* &
+             (exp(aimm*(tmelt - t(i)))-1._r8)/lamr(i)**3
+        mnuccr(i) = nnuccr(i) * 20._r8*pi*rhow/lamr(i)**3
+     else
+        mnuccr(i) = 0._r8
+        nnuccr(i) = 0._r8
+     end if
+  end do
+  !$acc end parallel
+
+end subroutine heterogeneous_rain_freezing
+
+! accretion of cloud liquid water by rain
+!===================================================================
+! formula from Khrouditnov and Kogan (2000)
+! gravitational collection kernel, droplet fall speed neglected
+
+subroutine accrete_cloud_water_rain(microp_uniform, qric, qcic, &
+     ncic, relvar, accre_enhan, pra, npra, vlen)
+
+  logical, intent(in) :: microp_uniform
+  integer, intent(in) :: vlen
+  ! In-cloud rain
+  real(r8), dimension(vlen), intent(in) :: qric ! MMR
+  ! Cloud droplets
+  real(r8), dimension(vlen), intent(in) :: qcic ! MMR
+  real(r8), dimension(vlen), intent(in) :: ncic ! Number
+  ! SGS variability
+  real(r8), dimension(vlen), intent(in) :: relvar
+  real(r8), dimension(vlen), intent(in) :: accre_enhan
+  ! Output tendencies
+  real(r8), dimension(vlen), intent(out) :: pra  ! MMR
+  real(r8), dimension(vlen), intent(out) :: npra ! Number
+  ! Coefficient that varies for subcolumns
+  real(r8), dimension(vlen) :: pra_coef
+  integer :: i
+
+  !$acc data create (pra_coef)
+
+  if (.not. microp_uniform) then
+     call var_coef(relvar, 1.15_r8, pra_coef, vlen)
+     !$acc parallel vector_length(VLENS) default(present)
+     !$acc loop gang vector
+     do i = 1, vlen
+        pra_coef(i) = accre_enhan(i) * pra_coef(i)
+     end do
+     !$acc end parallel
+  else
+     !$acc parallel vector_length(VLENS) default(present)
+     !$acc loop gang vector
+     do i = 1, vlen
+        pra_coef(i) = 1._r8
+     end do
+     !$acc end parallel
+  end if
+
+  !$acc parallel vector_length(VLENS) default(present)
+  !$acc loop gang vector
+  do i=1,vlen
+     if (qric(i) >= qsmall .and. qcic(i) >= qsmall) then
+        ! include sub-grid distribution of cloud water
+        pra(i)  = pra_coef(i) * 67._r8*(qcic(i)*qric(i))**1.15_r8
+        npra(i) = pra(i)*ncic(i)/qcic(i)
+     else
+        pra(i)  = 0._r8
+        npra(i) = 0._r8
+     end if
+  end do
+  !$acc end parallel
+
+  !$acc end data
+end subroutine accrete_cloud_water_rain
+
+! Self-collection of rain drops
+!===================================================================
+! from Beheng(1994)
+
+subroutine self_collection_rain(rho, qric, nric, nragg, vlen)
+
+  integer,                   intent(in) :: vlen
+  real(r8), dimension(vlen), intent(in) :: rho  ! Air density
+  ! Rain
+  real(r8), dimension(vlen), intent(in) :: qric ! MMR
+  real(r8), dimension(vlen), intent(in) :: nric ! Number
+  ! Output number tendency
+  real(r8), dimension(vlen), intent(out) :: nragg
+  integer :: i
+
+  !$acc parallel vector_length(VLENS) default(present)
+  !$acc loop gang vector
+  do i=1,vlen
+     if (qric(i) >= qsmall) then
+        nragg(i) = -8._r8*nric(i)*qric(i)*rho(i)
+     else
+        nragg(i) = 0._r8
+     end if
+  end do
+  !$acc end parallel
+
+end subroutine self_collection_rain
+
+! Accretion of cloud ice by snow
+!===================================================================
+! For this calculation, it is assumed that the Vs >> Vi
+! and Ds >> Di for continuous collection
+
+subroutine accrete_cloud_ice_snow(t, rho, asn, qiic, niic, qsic, &
+     lams, n0s, prai, nprai, vlen)
+
+  integer,                   intent(in) :: vlen
+  real(r8), dimension(vlen), intent(in) :: t    ! Temperature
+  real(r8), dimension(vlen), intent(in) :: rho   ! Density
+  real(r8), dimension(vlen), intent(in) :: asn  ! Snow fallspeed parameter
+  ! Cloud ice
+  real(r8), dimension(vlen), intent(in) :: qiic ! MMR
+  real(r8), dimension(vlen), intent(in) :: niic ! Number
+  real(r8), dimension(vlen), intent(in) :: qsic ! Snow MMR
+  ! Snow size parameters
+  real(r8), dimension(vlen), intent(in) :: lams
+  real(r8), dimension(vlen), intent(in) :: n0s
+  ! Output tendencies
+  real(r8), dimension(vlen), intent(out) :: prai ! MMR
+  real(r8), dimension(vlen), intent(out) :: nprai ! Number
+  ! Fraction of cloud ice particles accreted per second
+  real(r8) :: accrete_rate
+  integer  :: i
+
+  !$acc parallel vector_length(VLENS) default(present)
+  !$acc loop gang vector
+  do i=1,vlen
+     if (qsic(i) >= qsmall .and. qiic(i) >= qsmall .and. t(i) <= tmelt) then
+        accrete_rate = pi/4._r8 * eii * asn(i) * rho(i) * n0s(i) * gamma_bs_plus3/ &
+             lams(i)**(bs+3._r8)
+        prai(i)  = accrete_rate * qiic(i)
+        nprai(i) = accrete_rate * niic(i)
+     else
+        prai(i)  = 0._r8
+        nprai(i) = 0._r8
+     end if
+  end do
+  !$acc end parallel
+
+end subroutine accrete_cloud_ice_snow
+
+! calculate evaporation/sublimation of rain and snow
+!===================================================================
+! note: evaporation/sublimation occurs only in cloud-free portion of grid cell
+! in-cloud condensation/deposition of rain and snow is neglected
+! except for transfer of cloud water to snow through bergeron process
+
+subroutine evaporate_sublimate_precip(t, rho, dv, mu, sc, q, qvl, qvi, &
+     lcldm, precip_frac, arn, asn, qcic, qiic, qric, qsic, lamr, n0r, lams, n0s, &
+     pre, prds, am_evp_st, vlen, evap_rhthrsh)
+
+  integer,                   intent(in) :: vlen
+  real(r8), dimension(vlen), intent(in) :: t           ! temperature
+  real(r8), dimension(vlen), intent(in) :: rho         ! air density
+  real(r8), dimension(vlen), intent(in) :: dv          ! water vapor diffusivity
+  real(r8), dimension(vlen), intent(in) :: mu          ! viscosity
+  real(r8), dimension(vlen), intent(in) :: sc          ! schmidt number
+  real(r8), dimension(vlen), intent(in) :: q           ! humidity
+  real(r8), dimension(vlen), intent(in) :: qvl         ! saturation humidity (water)
+  real(r8), dimension(vlen), intent(in) :: qvi         ! saturation humidity (ice)
+  real(r8), dimension(vlen), intent(in) :: lcldm       ! liquid cloud fraction
+  real(r8), dimension(vlen), intent(in) :: precip_frac ! precipitation fraction (maximum overlap)
+  ! fallspeed parameters
+  real(r8), dimension(vlen), intent(in) :: arn         ! rain
+  real(r8), dimension(vlen), intent(in) :: asn         ! snow
+  ! In-cloud MMRs
+  real(r8), dimension(vlen), intent(in) :: qcic        ! cloud liquid
+  real(r8), dimension(vlen), intent(in) :: qiic        ! cloud ice
+  real(r8), dimension(vlen), intent(in) :: qric        ! rain
+  real(r8), dimension(vlen), intent(in) :: qsic        ! snow
+  ! Size parameters
+  ! rain
+  real(r8), dimension(vlen), intent(in) :: lamr
+  real(r8), dimension(vlen), intent(in) :: n0r
+  ! snow
+  real(r8), dimension(vlen), intent(in) :: lams
+  real(r8), dimension(vlen), intent(in) :: n0s
+  ! Output tendencies
+  real(r8), dimension(vlen), intent(out) :: pre
+  real(r8), dimension(vlen), intent(out) :: prds
+  real(r8), dimension(vlen), intent(out) :: am_evp_st  ! Fractional area where rain evaporates.
+  ! Switch
+  logical, intent(in)                    :: evap_rhthrsh
+
+  real(r8) :: qclr   ! water vapor mixing ratio in clear air
+  real(r8) :: ab,abr ! correction to account for latent heat
+  real(r8) :: eps    ! 1/ sat relaxation timescale
+  real(r8), dimension(vlen) :: dum
+  integer :: i
+
+  !$acc data create (dum)
+
+  ! set temporary cloud fraction to zero if cloud water + ice is very small
+  ! this will ensure that evaporation/sublimation of precip occurs over
+  ! entire grid cell, since min cloud fraction is specified otherwise
+
+  !$acc parallel vector_length(VLENS) default(present)
+  !$acc loop gang vector
+  do i=1,vlen
+     am_evp_st(i) = 0._r8
+     if (qcic(i)+qiic(i) < 1.e-6_r8) then
+        dum(i) = 0._r8
+     else
+        dum(i) = lcldm(i)
+     end if
+  end do
+  !$acc end parallel
+
+  !$acc parallel vector_length(VLENS) default(present)
+  !$acc loop gang vector
+  do i=1,vlen
+     ! only calculate if there is some precip fraction > cloud fraction
+     if (precip_frac(i) > dum(i)) then
+        if (qric(i) >= qsmall .or. qsic(i) >= qsmall) then
+           am_evp_st(i) = precip_frac(i) - dum(i)
+           ! calculate q for out-of-cloud region
+           qclr=(q(i)-dum(i)*qvl(i))/(1._r8-dum(i))
+        end if
+
+        ! evaporation of rain
+        if (qric(i) >= qsmall) then
+           if (.not.evap_rhthrsh.or.(evap_rhthrsh.and.qclr/qvl(i).le.0.9_r8)) then
+              call calc_ab(t(i), qvl(i), xxlv, abr)
+              eps = 2._r8*pi*n0r(i)*rho(i)*Dv(i)* &
+                    (f1r/(lamr(i)*lamr(i))+ &
+                    f2r*(arn(i)*rho(i)/mu(i))**0.5_r8* &
+                    sc(i)**(1._r8/3._r8)*gamma_half_br_plus5/ &
+                    (lamr(i)**(5._r8/2._r8+br/2._r8)))
+              pre(i) = eps*(qclr-qvl(i))/abr
+              ! only evaporate in out-of-cloud region
+              ! and distribute across precip_frac
+              pre(i)=min(pre(i)*am_evp_st(i),0._r8)
+              pre(i)=pre(i)/precip_frac(i)
+           else
+              pre(i) = 0._r8
+           end if
+        else
+           pre(i) = 0._r8
+        end if
+
+        ! sublimation of snow
+        if (qsic(i) >= qsmall) then
+           call calc_ab(t(i), qvi(i), xxls, ab)
+           eps = 2._r8*pi*n0s(i)*rho(i)*Dv(i)* &
+                (f1s/(lams(i)*lams(i))+ &
+                f2s*(asn(i)*rho(i)/mu(i))**0.5_r8* &
+                sc(i)**(1._r8/3._r8)*gamma_half_bs_plus5/ &
+                (lams(i)**(5._r8/2._r8+bs/2._r8)))
+           prds(i) = eps*(qclr-qvi(i))/ab
+           ! only sublimate in out-of-cloud region and distribute over precip_frac
+           prds(i) = min(prds(i)*am_evp_st(i),0._r8)
+           prds(i) = prds(i)/precip_frac(i)
+        else
+           prds(i) = 0._r8
+        end if
+     else
+        prds(i) = 0._r8
+        pre(i)  = 0._r8
+     end if
+  end do
+  !$acc end parallel
+
+  !$acc end data
+end subroutine evaporate_sublimate_precip
+
+! calculate evaporation/sublimation of rain (no snow in mg4)
+!===================================================================
+! note: evaporation/sublimation occurs only in cloud-free portion of grid cell
+! in-cloud condensation/deposition of rain and snow is neglected
+! except for transfer of cloud water to snow through bergeron process
+
+subroutine evaporate_sublimate_precip_mg4(t, rho, dv, mu, sc, q, qvl, qvi, &
+     lcldm, precip_frac, arn, qcic, qiic, qric, lamr, n0r, &
+     pre, am_evp_st, vlen, evap_rhthrsh)
+
+  integer,  intent(in)                   :: vlen
+  real(r8), dimension(vlen), intent(in)  :: t           ! temperature
+  real(r8), dimension(vlen), intent(in)  :: rho         ! air density
+  real(r8), dimension(vlen), intent(in)  :: dv          ! water vapor diffusivity
+  real(r8), dimension(vlen), intent(in)  :: mu          ! viscosity
+  real(r8), dimension(vlen), intent(in)  :: sc          ! schmidt number
+  real(r8), dimension(vlen), intent(in)  :: q           ! humidity
+  real(r8), dimension(vlen), intent(in)  :: qvl         ! saturation humidity (water)
+  real(r8), dimension(vlen), intent(in)  :: qvi         ! saturation humidity (ice)
+  real(r8), dimension(vlen), intent(in)  :: lcldm       ! liquid cloud fraction
+  real(r8), dimension(vlen), intent(in)  :: precip_frac ! precipitation fraction (maximum overlap)
+  ! fallspeed parameters
+  real(r8), dimension(vlen), intent(in)  :: arn         ! rain
+  ! In-cloud MMRs
+  real(r8), dimension(vlen), intent(in)  :: qcic        ! cloud liquid
+  real(r8), dimension(vlen), intent(in)  :: qiic        ! cloud ice
+  real(r8), dimension(vlen), intent(in)  :: qric        ! rain
+  ! Size parameters
+  ! rain
+  real(r8), dimension(vlen), intent(in)  :: lamr
+  real(r8), dimension(vlen), intent(in)  :: n0r
+  ! Output tendencies
+  real(r8), dimension(vlen), intent(out) :: pre
+  real(r8), dimension(vlen), intent(out) :: am_evp_st   ! Fractional area where rain evaporates.
+  ! Switch
+  logical, intent(in)                    :: evap_rhthrsh
+  real(r8) :: qclr   ! water vapor mixing ratio in clear air
+  real(r8) :: abr    ! correction to account for latent heat
+  real(r8) :: eps    ! 1/ sat relaxation timescale
+  real(r8), dimension(vlen) :: dum
+  integer :: i
+
+  !$acc data create (dum)
+
+  ! set temporary cloud fraction to zero if cloud water + ice is very small
+  ! this will ensure that evaporation/sublimation of precip occurs over
+  ! entire grid cell, since min cloud fraction is specified otherwise
+
+  !$acc parallel vector_length(VLENS) default(present)
+  !$acc loop gang vector
+  do i=1,vlen
+     am_evp_st(i) = 0._r8
+     if (qcic(i)+qiic(i) < 1.e-6_r8) then
+        dum(i) = 0._r8
+     else
+        dum(i) = lcldm(i)
+     end if
+  end do
+  !$acc end parallel
+
+  !$acc parallel vector_length(VLENS) default(present)
+  !$acc loop gang vector
+  do i=1,vlen
+     ! only calculate if there is some precip fraction > cloud fraction
+     if (precip_frac(i) > dum(i)) then
+        if (qric(i) >= qsmall) then
+           am_evp_st(i) = precip_frac(i) - dum(i)
+           ! calculate q for out-of-cloud region
+           qclr=(q(i)-dum(i)*qvl(i))/(1._r8-dum(i))
+        end if
+
+        ! evaporation of rain
+        if (qric(i) >= qsmall) then
+           if (.not.evap_rhthrsh.or.(evap_rhthrsh.and.qclr/qvl(i).le.0.9_r8)) then
+              call calc_ab(t(i), qvl(i), xxlv, abr)
+              eps = 2._r8*pi*n0r(i)*rho(i)*Dv(i)* &
+                 (f1r/(lamr(i)*lamr(i))+ &
+                 f2r*(arn(i)*rho(i)/mu(i))**0.5_r8* &
+                 sc(i)**(1._r8/3._r8)*gamma_half_br_plus5/ &
+                 (lamr(i)**(5._r8/2._r8+br/2._r8)))
+              pre(i) = eps*(qclr-qvl(i))/abr
+              ! only evaporate in out-of-cloud region
+              ! and distribute across precip_frac
+              pre(i) = min(pre(i)*am_evp_st(i),0._r8)
+              pre(i) = pre(i)/precip_frac(i)
+           else
+              pre(i) = 0._r8
+           end if
+        else
+           pre(i) = 0._r8
+        end if
+     else
+        pre(i) = 0._r8
+     end if
+  end do
+  !$acc end parallel
+
+  !$acc end data
+end subroutine evaporate_sublimate_precip_mg4
+
+! evaporation/sublimation of rain, snow and graupel
+!===================================================================
+! note: evaporation/sublimation occurs only in cloud-free portion of grid cell
+! in-cloud condensation/deposition of rain and snow is neglected
+! except for transfer of cloud water to snow through bergeron process
+
+subroutine evaporate_sublimate_precip_graupel(t, rho, dv, mu, sc, q, qvl, qvi, &
+     lcldm, precip_frac, arn, asn, agn, bg, qcic, qiic, qric, qsic, qgic, lamr, n0r, lams, n0s, lamg, n0g, &
+     pre, prds, prdg, am_evp_st, vlen, evap_rhthrsh)
+
+  integer,                   intent(in)  :: vlen
+  real(r8), dimension(vlen), intent(in)  :: t           ! temperature
+  real(r8), dimension(vlen), intent(in)  :: rho         ! air density
+  real(r8), dimension(vlen), intent(in)  :: dv          ! water vapor diffusivity
+  real(r8), dimension(vlen), intent(in)  :: mu          ! viscosity
+  real(r8), dimension(vlen), intent(in)  :: sc          ! schmidt number
+  real(r8), dimension(vlen), intent(in)  :: q           ! humidity
+  real(r8), dimension(vlen), intent(in)  :: qvl         ! saturation humidity (water)
+  real(r8), dimension(vlen), intent(in)  :: qvi         ! saturation humidity (ice)
+  real(r8), dimension(vlen), intent(in)  :: lcldm       ! liquid cloud fraction
+  real(r8), dimension(vlen), intent(in)  :: precip_frac ! precipitation fraction (maximum overlap)
+  ! fallspeed parameters
+  real(r8), dimension(vlen), intent(in)  :: arn         ! rain
+  real(r8), dimension(vlen), intent(in)  :: asn         ! snow
+  real(r8), dimension(vlen), intent(in)  :: agn         ! graupel
+  real(r8),                  intent(in)  :: bg
+  ! In-cloud MMRs
+  real(r8), dimension(vlen), intent(in)  :: qcic        ! cloud liquid
+  real(r8), dimension(vlen), intent(in)  :: qiic        ! cloud ice
+  real(r8), dimension(vlen), intent(in)  :: qric        ! rain
+  real(r8), dimension(vlen), intent(in)  :: qsic        ! snow
+  real(r8), dimension(vlen), intent(in)  :: qgic        ! graupel
+  ! Size parameters
+  ! rain
+  real(r8), dimension(vlen), intent(in)  :: lamr
+  real(r8), dimension(vlen), intent(in)  :: n0r
+  ! snow
+  real(r8), dimension(vlen), intent(in)  :: lams
+  real(r8), dimension(vlen), intent(in)  :: n0s
+  ! graupel
+  real(r8), dimension(vlen), intent(in)  :: lamg
+  real(r8), dimension(vlen), intent(in)  :: n0g
+  ! Output tendencies
+  real(r8), dimension(vlen), intent(out) :: pre
+  real(r8), dimension(vlen), intent(out) :: prds
+  real(r8), dimension(vlen), intent(out) :: prdg
+  real(r8), dimension(vlen), intent(out) :: am_evp_st   ! Fractional area where rain evaporates.
+  ! Switch
+  logical, intent(in) :: evap_rhthrsh
+
+  real(r8) :: qclr   ! water vapor mixing ratio in clear air
+  real(r8) :: ab, abr, abg    ! correction to account for latent heat
+  real(r8) :: eps    ! 1/ sat relaxation timescale
+  real(r8), dimension(vlen) :: dum
+  integer :: i
+
+  !$acc data create (dum)
+
+  ! set temporary cloud fraction to zero if cloud water + ice is very small
+  ! this will ensure that evaporation/sublimation of precip occurs over
+  ! entire grid cell, since min cloud fraction is specified otherwise
+
+  !$acc parallel vector_length(VLENS) default(present)
+  !$acc loop gang vector
+  do i=1,vlen
+     am_evp_st(i) = 0._r8
+     if (qcic(i)+qiic(i) < 1.e-6_r8) then
+        dum(i) = 0._r8
+     else
+        dum(i) = lcldm(i)
+     end if
+  end do
+  !$acc end parallel
+
+  !$acc parallel vector_length(VLENS) default(present)
+  !$acc loop gang vector
+  do i=1,vlen
+     ! only calculate if there is some precip fraction > cloud fraction
+     if (precip_frac(i) > dum(i)) then
+        if (qric(i) >= qsmall .or. qsic(i) >= qsmall .or. qgic(i) >= qsmall) then
+           am_evp_st(i) = precip_frac(i) - dum(i)
+           ! calculate q for out-of-cloud region
+           qclr=(q(i)-dum(i)*qvl(i))/(1._r8-dum(i))
+        end if
+
+        ! evaporation of rain
+        if (qric(i) >= qsmall) then
+           if (.not.evap_rhthrsh.or.(evap_rhthrsh.and.qclr/qvl(i).le.0.9_r8)) then
+              call calc_ab(t(i), qvl(i), xxlv, abr)
+              eps = 2._r8*pi*n0r(i)*rho(i)*Dv(i)* &
+                 (f1r/(lamr(i)*lamr(i))+ &
+                 f2r*(arn(i)*rho(i)/mu(i))**0.5_r8* &
+                 sc(i)**(1._r8/3._r8)*gamma_half_br_plus5/ &
+                 (lamr(i)**(5._r8/2._r8+br/2._r8)))
+              pre(i) = eps*(qclr-qvl(i))/abr
+              ! only evaporate in out-of-cloud region
+              ! and distribute across precip_frac
+              pre(i) = min(pre(i)*am_evp_st(i),0._r8)
+              pre(i) = pre(i)/precip_frac(i)
+           else
+              pre(i) = 0._r8
+           end if
+        else
+           pre(i) = 0._r8
+        end if
+
+        ! sublimation of snow
+        if (qsic(i) >= qsmall) then
+           call calc_ab(t(i), qvi(i), xxls, ab)
+           eps = 2._r8*pi*n0s(i)*rho(i)*Dv(i)* &
+                (f1s/(lams(i)*lams(i))+ &
+                f2s*(asn(i)*rho(i)/mu(i))**0.5_r8* &
+                sc(i)**(1._r8/3._r8)*gamma_half_bs_plus5/ &
+                (lams(i)**(5._r8/2._r8+bs/2._r8)))
+           prds(i) = eps*(qclr-qvi(i))/ab
+           ! only sublimate in out-of-cloud region and distribute over precip_frac
+           prds(i) = min(prds(i)*am_evp_st(i),0._r8)
+           prds(i) = prds(i)/precip_frac(i)
+        else
+           prds(i) = 0._r8
+        end if
+
+        ! ADD GRAUPEL, do Same with prdg.
+        if (qgic(i).ge.qsmall) then
+           call calc_ab(t(i), qvi(i), xxls, abg)
+           eps = 2._r8*pi*n0g(i)*rho(i)*Dv(i)*                    &
+                (f1s/(lamg(i)*lamg(i))+                           &
+                f2s*(agn(i)*rho(i)/mu(i))**0.5_r8*                &
+                sc(i)**(1._r8/3._r8)*gamma(5._r8/2._r8+bg/2._r8)/ &
+                (lamg(i)**(5._r8/2._r8+bs/2._r8)))
+           prdg(i) = eps*(qclr-qvi(i))/abg
+           ! only sublimate in out-of-cloud region and distribute over precip_frac
+           prdg(i) = min(prdg(i)*am_evp_st(i),0._r8)
+           prdg(i) = prdg(i)/precip_frac(i)
+        else
+           prdg(i) = 0._r8
+        end if
+
+     else
+        prds(i) = 0._r8
+        pre(i)  = 0._r8
+        prdg(i) = 0._r8
+     end if
+  end do
+  !$acc end parallel
+
+  !$acc end data
+end subroutine evaporate_sublimate_precip_graupel
+
+! evaporation/sublimation of rain and graupel (no snow in mg4)
+!===================================================================
+! note: evaporation/sublimation occurs only in cloud-free portion of grid cell
+! in-cloud condensation/deposition of rain and graupel is neglected
+! except for transfer of cloud water to snow through bergeron process
+
+subroutine evaporate_sublimate_precip_graupel_mg4(t, rho, dv, mu, sc, q, qvl, qvi, &
+     lcldm, precip_frac, arn, agn, bg, qcic, qiic, qric, qgic, lamr, n0r, lamg, n0g, &
+     pre, prdg, am_evp_st, vlen)
+
+  integer,                   intent(in) :: vlen
+  real(r8), dimension(vlen), intent(in) :: t            ! temperature
+  real(r8), dimension(vlen), intent(in) :: rho          ! air density
+  real(r8), dimension(vlen), intent(in) :: dv           ! water vapor diffusivity
+  real(r8), dimension(vlen), intent(in) :: mu           ! viscosity
+  real(r8), dimension(vlen), intent(in) :: sc           ! schmidt number
+  real(r8), dimension(vlen), intent(in) :: q            ! humidity
+  real(r8), dimension(vlen), intent(in) :: qvl          ! saturation humidity (water)
+  real(r8), dimension(vlen), intent(in) :: qvi          ! saturation humidity (ice)
+  real(r8), dimension(vlen), intent(in) :: lcldm        ! liquid cloud fraction
+  real(r8), dimension(vlen), intent(in) :: precip_frac  ! precipitation fraction (maximum overlap)
+  ! fallspeed parameters
+  real(r8), dimension(vlen), intent(in) :: arn          ! rain
+  real(r8), dimension(vlen), intent(in) :: agn          ! graupel
+  real(r8),                  intent(in) :: bg
+  ! In-cloud MMRs
+  real(r8), dimension(vlen), intent(in) :: qcic         ! cloud liquid
+  real(r8), dimension(vlen), intent(in) :: qiic         ! cloud ice
+  real(r8), dimension(vlen), intent(in) :: qric         ! rain
+  real(r8), dimension(vlen), intent(in) :: qgic         ! graupel
+  ! Size parameters
+  ! rain
+  real(r8), dimension(vlen), intent(in) :: lamr
+  real(r8), dimension(vlen), intent(in) :: n0r
+  ! graupel
+  real(r8), dimension(vlen), intent(in) :: lamg
+  real(r8), dimension(vlen), intent(in) :: n0g
+  ! Output tendencies
+  real(r8), dimension(vlen), intent(out) :: pre
+  real(r8), dimension(vlen), intent(out) :: prdg
+  real(r8), dimension(vlen), intent(out) :: am_evp_st   ! Fractional area where rain evaporates.
+
+  real(r8) :: qclr                                      ! water vapor mixing ratio in clear air
+  real(r8) :: abr, abg                                  ! correction to account for latent heat
+  real(r8) :: eps                                       ! 1/ sat relaxation timescale
+  real(r8), dimension(vlen) :: dum
+  integer :: i
+
+  !$acc data create (dum)
+
+  ! set temporary cloud fraction to zero if cloud water + ice is very small
+  ! this will ensure that evaporation/sublimation of precip occurs over
+  ! entire grid cell, since min cloud fraction is specified otherwise
+
+  !$acc parallel vector_length(VLENS) default(present)
+  !$acc loop gang vector
+  do i=1,vlen
+     am_evp_st(i) = 0._r8
+     if (qcic(i)+qiic(i) < 1.e-6_r8) then
+        dum(i) = 0._r8
+     else
+        dum(i) = lcldm(i)
+     end if
+  end do
+  !$acc end parallel
+
+  !$acc parallel vector_length(VLENS) default(present)
+  !$acc loop gang vector
+  do i=1,vlen
+     ! only calculate if there is some precip fraction > cloud fraction
+     if (precip_frac(i) > dum(i)) then
+        if (qric(i) >= qsmall .or. qgic(i) >= qsmall) then
+           am_evp_st(i) = precip_frac(i) - dum(i)
+           ! calculate q for out-of-cloud region
+           qclr = (q(i)-dum(i)*qvl(i))/(1._r8-dum(i))
+        end if
+
+        ! evaporation of rain
+        if (qric(i) >= qsmall) then
+           call calc_ab(t(i), qvl(i), xxlv, abr)
+           eps = 2._r8*pi*n0r(i)*rho(i)*Dv(i)* &
+                (f1r/(lamr(i)*lamr(i))+ &
+                f2r*(arn(i)*rho(i)/mu(i))**0.5_r8* &
+                sc(i)**(1._r8/3._r8)*gamma_half_br_plus5/ &
+                (lamr(i)**(5._r8/2._r8+br/2._r8)))
+           pre(i) = eps*(qclr-qvl(i))/abr
+           ! only evaporate in out-of-cloud region
+           ! and distribute across precip_frac
+           pre(i) = min(pre(i)*am_evp_st(i),0._r8)
+           pre(i) = pre(i)/precip_frac(i)
+        else
+           pre(i) = 0._r8
+        end if
+
+        ! ADD GRAUPEL, do Same with prdg.
+        if (qgic(i).ge.qsmall) then
+           call calc_ab(t(i), qvi(i), xxls, abg)
+           eps = 2._r8*pi*n0g(i)*rho(i)*Dv(i)*                    &
+                (f1s/(lamg(i)*lamg(i))+                           &
+                f2s*(agn(i)*rho(i)/mu(i))**0.5_r8*                &
+                sc(i)**(1._r8/3._r8)*gamma(5._r8/2._r8+bg/2._r8)/ &
+                (lamg(i)**(5._r8/2._r8+bs/2._r8)))
+           prdg(i) = eps*(qclr-qvi(i))/abg
+           ! only sublimate in out-of-cloud region and distribute over precip_frac
+           prdg(i) = min(prdg(i)*am_evp_st(i),0._r8)
+           prdg(i) = prdg(i)/precip_frac(i)
+        else
+           prdg(i) = 0._r8
+        end if
+     else
+        pre(i) = 0._r8
+        prdg(i) = 0._r8
+     end if
+  end do
+  !$acc end parallel
+
+  !$acc end data
+end subroutine evaporate_sublimate_precip_graupel_mg4
+
+! bergeron process - evaporation of droplets and deposition onto snow
+!===================================================================
+
+subroutine bergeron_process_snow(t, rho, dv, mu, sc, qvl, qvi, asn, &
+     qcic, qsic, lams, n0s, bergs, vlen)
+
+  integer,                   intent(in) :: vlen
+  real(r8), dimension(vlen), intent(in) :: t    ! temperature
+  real(r8), dimension(vlen), intent(in) :: rho  ! air density
+  real(r8), dimension(vlen), intent(in) :: dv   ! water vapor diffusivity
+  real(r8), dimension(vlen), intent(in) :: mu   ! viscosity
+  real(r8), dimension(vlen), intent(in) :: sc   ! schmidt number
+  real(r8), dimension(vlen), intent(in) :: qvl  ! saturation humidity (water)
+  real(r8), dimension(vlen), intent(in) :: qvi  ! saturation humidity (ice)
+  ! fallspeed parameter for snow
+  real(r8), dimension(vlen), intent(in) :: asn
+  ! In-cloud MMRs
+  real(r8), dimension(vlen), intent(in) :: qcic ! cloud liquid mixing ratio
+  real(r8), dimension(vlen), intent(in) :: qsic ! snow mixing ratio
+  ! Size parameters for snow
+  real(r8), dimension(vlen), intent(in) :: lams
+  real(r8), dimension(vlen), intent(in) :: n0s
+  ! Output tendencies
+  real(r8), dimension(vlen), intent(out) :: bergs
+
+  real(r8) :: ab     ! correction to account for latent heat
+  real(r8) :: eps    ! 1/ sat relaxation timescale
+  integer :: i
+
+  !$acc parallel vector_length(VLENS) default(present)
+  !$acc loop gang vector
+  do i=1,vlen
+     if (qsic(i) >= qsmall.and. qcic(i) >= qsmall .and. t(i) < tmelt) then
+        call calc_ab(t(i), qvi(i), xxls, ab)
+        eps = 2._r8*pi*n0s(i)*rho(i)*Dv(i)* &
+             (f1s/(lams(i)*lams(i))+ &
+             f2s*(asn(i)*rho(i)/mu(i))**0.5_r8* &
+             sc(i)**(1._r8/3._r8)*gamma_half_bs_plus5/ &
+             (lams(i)**(5._r8/2._r8+bs/2._r8)))
+        bergs(i) = eps*(qvl(i)-qvi(i))/ab
+     else
+        bergs(i) = 0._r8
+     end if
+  end do
+  !$acc end parallel
+
+end subroutine bergeron_process_snow
+
+!========================================================================
+! Collection of snow by rain to form graupel
+!========================================================================
+
+subroutine graupel_collecting_snow(qsic,qric,umr,ums,rho,lamr,n0r,lams,n0s, &
+     psacr, vlen)
+
+  integer,                   intent(in)  :: vlen
+  ! In-cloud MMRs
+  real(r8), dimension(vlen), intent(in)  :: qsic  ! snow
+  real(r8), dimension(vlen), intent(in)  :: qric  ! rain
+  ! mass-weighted fall speeds
+  real(r8), dimension(vlen), intent(in)  :: umr   ! rain
+  real(r8), dimension(vlen), intent(in)  :: ums   ! snow
+  real(r8), dimension(vlen), intent(in)  :: rho   ! air density
+  ! Size parameters for rain
+  real(r8), dimension(vlen), intent(in)  :: lamr
+  real(r8), dimension(vlen), intent(in)  :: n0r
+  ! Size parameters for snow
+  real(r8), dimension(vlen), intent(in)  :: lams
+  real(r8), dimension(vlen), intent(in)  :: n0s
+  real(r8), dimension(vlen), intent(out) :: psacr ! conversion due to coll of snow by rain
+
+  real(r8), parameter :: cons31 = pi*pi*ecr*rhosn
+  integer :: i
+
+  !$acc parallel vector_length(VLENS) default(present)
+  !$acc loop gang vector
+  do i=1,vlen
+     if (qsic(i).ge.0.1e-3_r8 .and. qric(i).ge.0.1e-3_r8) then
+        psacr(i) = cons31*(((1.2_r8*umr(i)-0.95_r8*ums(i))**2+ &
+             0.08_r8*ums(i)*umr(i))**0.5_r8*rho(i)*            &
+             n0r(i)*n0s(i)/lams(i)**3*                         &
+             (5._r8/(lams(i)**3*lamr(i))+                      &
+             2._r8/(lams(i)**2*lamr(i)**2)+                    &
+             0.5_r8/(lams(i)*lamr(i)**3)))
+     else
+        psacr(i) = 0._r8
+     end if
+  end do
+  !$acc end parallel
+
+end subroutine graupel_collecting_snow
+
+!========================================================================
+! Collection of cloud water by graupel
+!========================================================================
+
+subroutine graupel_collecting_cld_water(qgic,qcic,ncic,rho,n0g,lamg,bg,agn, &
+     psacwg, npsacwg, vlen)
+
+  integer,                   intent(in) :: vlen
+  ! In-cloud MMRs
+  real(r8), dimension(vlen), intent(in) :: qgic ! graupel
+  real(r8), dimension(vlen), intent(in) :: qcic ! cloud water
+  real(r8), dimension(vlen), intent(in) :: ncic ! cloud water number conc
+  real(r8), dimension(vlen), intent(in) :: rho  ! air density
+  ! Size parameters for graupel
+  real(r8), dimension(vlen), intent(in) :: lamg
+  real(r8), dimension(vlen), intent(in) :: n0g
+  ! fallspeed parameters for graupel
+  ! Set AGN and BG  as input (in micro_pumas_v1.F90)  (select hail or graupel as appropriate)
+  real(r8),                  intent(in) :: bg
+  real(r8), dimension(vlen), intent(in) :: agn
+  ! Output tendencies
+  real(r8), dimension(vlen), intent(out) :: psacwg
+  real(r8), dimension(vlen), intent(out) :: npsacwg
+
+  real(r8) :: cons
+  integer  :: i
+
+  cons = gamma(bg + 3._r8)*pi/4._r8 * ecid
+
+  !$acc parallel vector_length(VLENS) default(present)
+  !$acc loop gang vector
+  do i=1,vlen
+     if (qgic(i).ge.1.e-8_r8 .and. qcic(i).ge.qsmall) then
+        psacwg(i) = cons*agn(i)*qcic(i)*rho(i)*  &
+               n0g(i)/                           &
+               lamg(i)**(bg+3._r8)
+        npsacwg(i) = cons*agn(i)*ncic(i)*rho(i)* &
+               n0g(i)/                           &
+               lamg(i)**(bg+3._r8)
+     else
+        psacwg(i)  = 0._r8
+        npsacwg(i) = 0._r8
+     end if
+  end do
+  !$acc end parallel
+
+end subroutine graupel_collecting_cld_water
+
+!========================================================================
+! Conversion of rimed cloud water onto snow to graupel/hail
+!========================================================================
+
+subroutine graupel_riming_liquid_snow(psacws,qsic,qcic,nsic,rho,rhosn,rhog,asn,lams,n0s,dtime, &
+     pgsacw,nscng,vlen)
+
+  integer,                   intent(in)    :: vlen
+  ! Accretion of cloud water to snow tendency (modified)
+  real(r8), dimension(vlen), intent(inout) :: psacws
+  real(r8), dimension(vlen), intent(in)    :: qsic    ! snow mixing ratio
+  real(r8), dimension(vlen), intent(in)    :: qcic    ! cloud liquid mixing ratio
+  real(r8), dimension(vlen), intent(in)    :: nsic    ! snow number concentration
+  real(r8), dimension(vlen), intent(in)    :: rho     ! air density
+  real(r8),                  intent(in)    :: rhosn   ! snow density
+  real(r8),                  intent(in)    :: rhog    ! graupel density
+  real(r8), dimension(vlen), intent(in)    :: asn     ! fall speed parameter for snow
+  ! Size parameters for snow
+  real(r8), dimension(vlen), intent(in)    :: lams
+  real(r8), dimension(vlen), intent(in)    :: n0s
+  real(r8),                  intent(in)    :: dtime
+  !Output process rates
+  real(r8), dimension(vlen), intent(out)   :: pgsacw  ! dQ graupel due to collection droplets by snow
+  real(r8), dimension(vlen), intent(out)   :: nscng   ! dN graupel due to collection droplets by snow
+
+  real(r8) :: cons
+  real(r8) :: rhosu
+  real(r8) :: dum
+  integer  :: i
+
+!........................................................................
+!Input: PSACWS,qs,qc,n0s,rho,lams,rhos,rhog
+!Output:PSACWS,PGSACW,NSCNG
+
+  rhosu = 85000._r8/(ra * tmelt)    ! typical air density at 850 mb
+
+  cons  = 4._r8 *2._r8 *3._r8*rhosu*pi*ecid*ecid*gamma_2bs_plus2/(8._r8*(rhog-rhosn))
+
+  !$acc parallel vector_length(VLENS) default(present)
+  !$acc loop gang vector
+  do i=1,vlen
+     if (psacws(i).gt.0._r8 .and. qsic(i).GE.0.1e-3_r8 .AND. qcic(i).GE.0.5E-3_r8) then
+        ! Only allow conversion if qni > 0.1 and qc > 0.5 g/kg following Rutledge and Hobbs (1984)
+        ! if (qsic(i).GE.0.1e-3_r8 .AND. qcic(i).GE.0.5E-3_r8) then
+
+        ! portion of riming converted to graupel (Reisner et al. 1998, originally IS1991)
+        ! dtime here is correct.
+        pgsacw(i) = min(psacws(i),cons*dtime*n0s(i)*qcic(i)*qcic(i)* &
+             asn(i)*asn(i)/ &
+             (rho(i)*lams(i)**(2._r8*bs+2._r8)))
+
+        ! Mix rat converted into graupel as embryo (Reisner et al. 1998, orig M1990)
+        dum       = max(rhosn/(rhog-rhosn)*pgsacw(i),0._r8)
+
+        ! Number concentraiton of embryo graupel from riming of snow
+        nscng(i)  = dum/mg0*rho(i)
+        ! Limit max number converted to snow number  (dtime here correct? We think yes)
+        nscng(i)  = min(nscng(i),nsic(i)/dtime)
+
+        ! Portion of riming left for snow
+        psacws(i) = psacws(i) - pgsacw(i)
+     else
+        pgsacw(i) = 0._r8
+        nscng(i)  = 0._r8
+     end if
+  end do
+  !$acc end parallel
+
+end subroutine graupel_riming_liquid_snow
+
+!========================================================================
+!CHANGE IN Q,N COLLECTION RAIN BY GRAUPEL
+!========================================================================
+
+subroutine graupel_collecting_rain(qric,qgic,umg,umr,ung,unr,rho,n0r,lamr,n0g,lamg,&
+     pracg,npracg,vlen)
+
+  integer,                   intent(in) :: vlen
+  !MMR
+  real(r8), dimension(vlen), intent(in) :: qric  !rain mixing ratio
+  real(r8), dimension(vlen), intent(in) :: qgic  !graupel mixing ratio
+  !Mass weighted Fall speeds
+  real(r8), dimension(vlen), intent(in) :: umg ! graupel fall speed
+  real(r8), dimension(vlen), intent(in) :: umr ! rain fall speed
+  !Number weighted fall speeds
+  real(r8), dimension(vlen), intent(in) :: ung ! graupel fall speed
+  real(r8), dimension(vlen), intent(in) :: unr ! rain fall speed
+  real(r8), dimension(vlen), intent(in) :: rho   ! air density
+  ! Size parameters for rain
+  real(r8), dimension(vlen), intent(in) :: n0r
+  real(r8), dimension(vlen), intent(in) :: lamr
+  ! Size parameters for graupel
+  real(r8), dimension(vlen), intent(in) :: n0g
+  real(r8), dimension(vlen), intent(in) :: lamg
+  !Output process rates
+  real(r8), dimension(vlen), intent(out) :: pracg   ! Q collection rain by graupel
+  real(r8), dimension(vlen), intent(out) :: npracg  ! N collection rain by graupel
+
+! Add collection of graupel by rain above freezing
+! assume all rain collection by graupel above freezing is shed
+! assume shed drops are 1 mm in size
+  integer  :: i
+  real(r8), parameter :: cons41 = pi*pi*ecr*rhow
+  real(r8), parameter :: cons32 = pi/2._r8*ecr
+  real(r8) :: dum
+
+  !$acc parallel vector_length(VLENS) default(present)
+  !$acc loop gang vector
+  do i=1,vlen
+     if (qric(i).ge.1.e-8_r8.and.qgic(i).ge.1.e-8_r8) then
+        ! pracg is mixing ratio of rain per sec collected by graupel/hail
+        pracg(i) = cons41*(((1.2_r8*umr(i)-0.95_r8*umg(i))**2._r8+  &
+             0.08_r8*umg(i)*umr(i))**0.5_r8*rho(i)*                 &
+             n0r(i)*n0g(i)/lamr(i)**3._r8*                          &
+             (5._r8/(lamr(i)**3._r8*lamg(i))+                       &
+             2._r8/(lamr(i)**2._r8*lamg(i)**2._r8)+                 &
+             0.5_r8/(lamr(i)*lamg(i)**3._r8)))
+
+! assume 1 mm drops are shed, get number shed per sec
+        dum = pracg(i)/5.2e-7_r8
+        npracg(i) = cons32*rho(i)*(1.7_r8*(unr(i)-ung(i))**2._r8+   &
+             0.3_r8*unr(i)*ung(i))**0.5_r8*n0r(i)*n0g(i)*           &
+             (1._r8/(lamr(i)**3._r8*lamg(i))+                       &
+             1._r8/(lamr(i)**2._r8*lamg(i)**2._r8)+                 &
+             1._r8/(lamr(i)*lamg(i)**3._r8))
+
+! hm 7/15/13, remove limit so that the number of collected drops can smaller than
+! number of shed drops
+!            NPRACG(K)=MAX(NPRACG(K)-DUM,0.)
+        npracg(i) = npracg(i) - dum
+     else
+        npracg(i) = 0._r8
+        pracg(i)  = 0._r8
+     end if
+  end do
+  !$acc end parallel
+
+end subroutine graupel_collecting_rain
+
+!========================================================================
+! Rain riming snow to graupel
+!========================================================================
+! Conversion of rimed rainwater onto snow converted to graupel
+
+subroutine graupel_rain_riming_snow(pracs,npracs,psacr,qsic,qric,nric,nsic,n0s,lams,n0r,lamr,dtime,&
+     pgracs,ngracs,vlen)
+
+  integer,                   intent(in)    :: vlen
+  ! Accretion of rain by snow
+  real(r8), dimension(vlen), intent(inout) :: pracs
+  real(r8), dimension(vlen), intent(inout) :: npracs
+  real(r8), dimension(vlen), intent(inout) :: psacr  ! conversion due to coll of snow by rain
+  !MMR
+  real(r8), dimension(vlen), intent(in)    :: qsic   ! snow mixing ratio
+  real(r8), dimension(vlen), intent(in)    :: qric   ! rain mixing ratio
+  real(r8), dimension(vlen), intent(in)    :: nric   ! rain number concentration
+  real(r8), dimension(vlen), intent(in)    :: nsic   ! snow number concentration
+  ! Size parameters for snow
+  real(r8), dimension(vlen), intent(in)    :: n0s
+  real(r8), dimension(vlen), intent(in)    :: lams
+  ! Size parameters for rain
+  real(r8), dimension(vlen), intent(in)    :: n0r
+  real(r8), dimension(vlen), intent(in)    :: lamr
+  real(r8),                  intent(in)    :: dtime
+  !Output process rates
+  real(r8), dimension(vlen), intent(out)   :: pgracs  ! Q graupel due to collection rain by snow
+  real(r8), dimension(vlen), intent(out)   :: ngracs  ! N graupel due to collection rain by snow
+
+!Input: PRACS,NPRACS,PSACR,qni,qr,lams,lamr,nr,ns  Note: No PSACR in MG2
+!Output:PGRACS,NGRACS,PRACS,PSACR
+  integer  :: i
+  real(r8), parameter :: cons18 = rhosn*rhosn
+  real(r8), parameter :: cons19 = rhow*rhow
+  real(r8) :: dum
+
+  !$acc parallel vector_length(VLENS) default(present)
+  !$acc loop gang vector
+  do i=1,vlen
+     if (pracs(i).gt.0._r8.and.qsic(i).ge.0.1e-3_r8.and.qric(i).ge.0.1e-3_r8) then
+        ! only allow conversion if qs > 0.1 and qr > 0.1 g/kg following rutledge and hobbs (1984)
+        !if (qsic(i).ge.0.1e-3_r8.and.qric(i).ge.0.1e-3_r8) then
+           ! portion of collected rainwater converted to graupel (reisner et al. 1998)
+        dum = cons18*(4._r8/lams(i))**3*(4._r8/lams(i))**3 &
+             /(cons18*(4._r8/lams(i))**3*(4._r8/lams(i))**3+ &
+             cons19*(4._r8/lamr(i))**3*(4._r8/lamr(i))**3)
+        dum = min(dum,1._r8)
+        dum = max(dum,0._r8)
+        pgracs(i) = (1._r8-dum)*pracs(i)
+        ngracs(i) = (1._r8-dum)*npracs(i)
+        ! limit max number converted to min of either rain or snow number concentration
+        ngracs(i) = min(ngracs(i),nric(i)/dtime)
+        ngracs(i) = min(ngracs(i),nsic(i)/dtime)
+
+        ! amount left for snow production
+        pracs(i)  = pracs(i) - pgracs(i)
+        npracs(i) = npracs(i) - ngracs(i)
+
+        ! conversion to graupel due to collection of snow by rain
+        psacr(i)=psacr(i)*(1._r8-dum)
+     else
+        pgracs(i) = 0._r8
+        ngracs(i) = 0._r8
+     end if
+  end do
+  !$acc end parallel
+
+end subroutine graupel_rain_riming_snow
+
+!========================================================================
+! Rime Splintering
+!========================================================================
+subroutine graupel_rime_splintering(t,qcic,qric,qgic,psacwg,pracg,&
+     qmultg,nmultg,qmultrg,nmultrg,vlen)
+
+  integer,                   intent(in)    :: vlen
+  real(r8), dimension(vlen), intent(in)    :: t        ! temperature
+  !MMR
+  real(r8), dimension(vlen), intent(in)    :: qcic     ! liquid mixing ratio
+  real(r8), dimension(vlen), intent(in)    :: qric     ! rain mixing ratio
+  real(r8), dimension(vlen), intent(in)    :: qgic     ! graupel mixing ratio
+  ! Already calculated terms for collection
+  real(r8), dimension(vlen), intent(inout) :: psacwg   ! collection droplets by graupel
+  real(r8), dimension(vlen), intent(inout) :: pracg    ! collection rain by graupel
+  !Output process rates for splintering
+  real(r8), dimension(vlen), intent(out)   :: qmultg   ! Q ice mult of droplets/graupel
+  real(r8), dimension(vlen), intent(out)   :: nmultg   ! N ice mult of droplets/graupel
+  real(r8), dimension(vlen), intent(out)   :: qmultrg  ! Q ice mult of rain/graupel
+  real(r8), dimension(vlen), intent(out)   :: nmultrg  ! N ice mult of rain/graupel
+
+!Input: qg,qc,qr, PSACWG,PRACG,T
+!Output: NMULTG,QMULTG,NMULTRG,QMULTRG,PSACWG,PRACG
+  integer  :: i
+  real(r8) :: fmult
+  real(r8) :: tm_3, tm_5, tm_8
+
+  tm_3 = tmelt - 3._r8
+  tm_5 = tmelt - 5._r8
+  tm_8 = tmelt - 8._r8
+
+!nmultg,qmultg                                                                             .
+!========================================================================
+
+  !$acc parallel vector_length(VLENS) default(present)
+  !$acc loop gang vector
+  do i=1,vlen
+     nmultrg(i) = 0._r8
+     qmultrg(i) = 0._r8
+     nmultg(i)  = 0._r8
+     qmultg(i)  = 0._r8
+     if (qgic(i).ge.0.1e-3_r8) then
+        if (qcic(i).ge.0.5e-3_r8.or.qric(i).ge.0.1e-3_r8) then
+           if (psacwg(i).gt.0._r8.or.pracg(i).gt.0._r8) then
+              if (t(i).lt.tm_3 .and. t(i).gt.tm_8) then
+                 if (t(i).gt.tm_3) then
+                    fmult = 0._r8
+                 else if (t(i).le.tm_3.and.t(i).gt.tm_5)  then
+                    fmult = (tm_3-t(i))/2._r8
+                 else if (t(i).ge.tm_8.and.t(i).le.tm_5)   then
+                    fmult = (t(i)-tm_8)/3._r8
+                 else if (t(i).lt.tm_8) then
+                    fmult = 0._r8
+                 end if
+! 1000 is to convert from kg to g  (Check if needed for MG)
+! splintering from droplets accreted onto graupel
+                 if (psacwg(i).gt.0._r8) then
+                    nmultg(i) = 35.e4_r8*psacwg(i)*fmult*1000._r8
+                    qmultg(i) = nmultg(i)*mmult
+! constrain so that transfer of mass from graupel to ice cannot be more mass
+! than was rimed onto graupel
+                    qmultg(i) = min(qmultg(i),psacwg(i))
+                    psacwg(i) = psacwg(i)-qmultg(i)
+                 end if
+
+!nmultrg,qmultrg                                                                             .
+!========================================================================
+! riming and splintering from accreted raindrops
+! Factor of 1000. again (Check)
+                 if (pracg(i).gt.0._r8) then
+                    nmultrg(i) = 35.e4_r8*pracg(i)*fmult*1000._r8
+                    qmultrg(i) = nmultrg(i)*mmult
+! constrain so that transfer of mass from graupel to ice cannot be more mass
+! than was rimed onto graupel
+                    qmultrg(i) = min(qmultrg(i),pracg(i))
+                    pracg(i)   = pracg(i)-qmultrg(i)
+                 end if
+              end if
+           end if
+        end if
+     end if
+  end do
+  !$acc end parallel
+
+end subroutine graupel_rime_splintering
+
+!========================================================================
+! Evaporation and sublimation of graupel
+!========================================================================
+
+!MERGE WITH RAIN AND SNOW EVAP
+!
+!subroutine graupel_sublimate_evap(t,q,qgic,rho,n0g,lamg,qvi,dv,mu,sc,bg,agn,&
+!     prdg,eprdg,vlen)
+!
+!  integer, intent(in) :: vlen
+!
+!  real(r8), dimension(vlen), intent(in) :: t  !temperature
+!  real(r8), dimension(vlen), intent(in) :: q  !specific humidity (mixing ratio)
+!
+!  !MMR
+!  real(r8), dimension(vlen), intent(in) :: qgic  !graupel mixing ratio
+!
+!  real(r8), dimension(vlen), intent(in) :: rho   ! air density
+!
+! ! Size parameters for graupel
+!  real(r8), dimension(vlen), intent(in) :: n0g
+!  real(r8), dimension(vlen), intent(in) :: lamg
+!
+!  real(r8), dimension(vlen), intent(in) :: qvi  !saturation humidity (ice)
+!
+!  real(r8), dimension(vlen), intent(in) :: dv   ! water vapor diffusivity
+!  real(r8), dimension(vlen), intent(in) :: mu   ! viscosity
+!  real(r8), dimension(vlen), intent(in) :: sc   ! schmidt number
+!
+!  ! fallspeed parameters for graupel
+!  ! Set AGN and BG  as input (in micro_pumas_v1.F90)  (select hail or graupel as appropriate)
+!  real(r8),                    intent(in) :: bg
+!  real(r8), dimension(vlen), intent(in) :: agn
+!
+!  ! Output tendencies (sublimation or evaporation of graupel)
+!  real(r8), dimension(vlen), intent(out) :: prdg
+!  real(r8), dimension(vlen), intent(out) :: eprdg
+!
+!  real(r8) :: cons11,cons36
+!  real(r8) :: abi
+!  real(r8) :: epsg
+!  integer :: i
+!
+!  cons11=gamma(2.5_r8+bg/2._r8)  !bg will be different for graupel (bg) or hail (bh)
+!  cons36=(2.5_r8+bg/2._r8)
+!
+!
+!  do i=1,vlen
+!
+!     abi = calc_ab(t(i), qvi(i), xxls)
+!
+!      if (qgic(i).ge.qsmall) then
+!         epsg = 2._r8*pi*n0g(i)*rho(i)*dv(i)*                                &
+!              (f1s/(lamg(i)*lamg(i))+                               &
+!              f2s*(agn(i)*rho(i)/mu(i))**0.5_r8*                      &
+!              sc(i)**(1._r8/3._r8)*cons11/                   &
+!              (lamg(i)**cons36))
+!      else
+!         epsg = 0.
+!      end if
+!
+!! vapor dpeosition on graupel
+!      prdg(i) = epsg*(q(i)-qvi(i))/abi
+!
+!! make sure not pushed into ice supersat/subsat
+!! put this in main mg3 code…..check for it…
+!! formula from reisner 2 scheme
+!!
+!!          dum = (qv3d(k)-qvi(k))/dt
+!!
+!!           fudgef = 0.9999
+!!           sum_dep = prd(k)+prds(k)+mnuccd(k)+prdg(k)
+!!
+!!           if( (dum.gt.0. .and. sum_dep.gt.dum*fudgef) .or.                      &
+!!               (dum.lt.0. .and. sum_dep.lt.dum*fudgef) ) then
+!!	       prdg(k) = fudgef*prdg(k)*dum/sum_dep
+!!           endif
+!
+!! if cloud ice/snow/graupel vap deposition is neg, then assign to sublimation processes
+!
+!      eprdg(i)=0._r8
+!
+!      if (prdg(i).lt.0._r8) then
+!         eprdg(i)=prdg(i)
+!         prdg(i)=0.
+!      end if
+!
+!   enddo
+!
+!end subroutine graupel_sublimate_evap
+
+!========================================================================
+!MG4 Lookup Table
+!========================================================================
+
+SUBROUTINE init_lookup_table(lkuptable_filename)
+
+  implicit none
+    !character(100) :: lkuptable_filename = "/home/katec/mg4work/lookup_table.dat"
+    !character(100) :: lkuptable_filename = "/glade/p/work/katec/mg3work/lookup_table.dat"
+    !character(100) :: lkuptable_filename = "./lookup_table.dat"
+    character(len=256), intent(in) :: lkuptable_filename
+    integer :: i,j,k,ii,jj,kk, tt, unitn
+    real(r8)    :: dum
+
+    open(newunit=unitn,file=lkuptable_filename,status='old')
+
+    !------------------------------------------------------------------------------------------!
+    ! read in ice microphysics table
+     do tt = 1, tsize
+       do i = 1,isize
+          do k = 1,jsize
+             read(unitn,*) dum,dum,itab(tt,i,k,1),itab(tt,i,k,2),             &
+                  itab(tt,i,k,3),itab(tt,i,k,4),itab(tt,i,k,5),            &
+                  itab(tt,i,k,6),itab(tt,i,k,7),itab(tt,i,k,8),            &
+                  itab(tt,i,k,13),itab(tt,i,k,9),itab(tt,i,k,10),          &
+                  itab(tt,i,k,11),itab(tt,i,k,12),itab(tt,i,k,14)
+            enddo
+       enddo
+       ! read in table for ice-rain collection
+       do i = 1,isize
+          do k = 1,jsize
+             do j = 1,rcollsize
+                read(unitn,*) dum,dum,dum,itabcoll(tt,i,k,j,1),                  &
+                     itabcoll(tt,i,k,j,2),dum
+                itabcoll(tt,i,k,j,1) = dlog10(itabcoll(tt,i,k,j,1))
+                itabcoll(tt,i,k,j,2) = dlog10(itabcoll(tt,i,k,j,2))
+             end do
+          end do
+       end do
+    end do
+
+    close(unitn)
+
+END SUBROUTINE init_lookup_table
+
+pure SUBROUTINE access_lookup_table(dumii,dumi,dumk,index,dum1,dum2,dum4,proc)
+
+  implicit none
+
+  real(r8), intent(in) :: dum1,dum2,dum4
+  real(r8), intent(out) :: proc
+  real(r8) :: dproc1,dproc2,iproc1,gproc1,tmp1,tmp2
+  integer, intent(in) :: dumi,dumk,dumii,index
+
+
+  !(trude,  dumii could be the same as dumt)
+  ! get value at current density index
+  !***** without temperature dependence *******
+  ! first interpolate for current rimed fraction index
+  !   dproc1 = itab(dumi,dumk,index)+(dum1-real(dumi))*(itab(       &
+  !            dumi+1,dumk,index)-itab(dumi,dumk,index))
+
+  !   dproc2 = itab(dumi,dumk+1,index)+(dum1-real(dumi))*(itab(     &
+  !          dumi+1,dumk+1,index)-itab(dumi,dumk+1,index))
+
+  !   iproc1 = dproc1+(dum2-real(dumk))*(dproc2-dproc1)
+
+  !   proc    = iproc1
+  !! ***** end without temperature dependence ***********
+  ! ******************* from orig P3 ********************
+
+  ! trude comment, dumjj is for density index, dumii is for rime, which is subsituted by temperature. All dumjj should be removed.
+  ! first interpolate for current temperature
+  dproc1 = itab(dumii,dumi,dumk,index)+(dum1-real(dumi))*(itab(dumii,       &
+       dumi+1,dumk,index)-itab(dumii,dumi,dumk,index))
+
+  dproc2 = itab(dumii,dumi,dumk+1,index)+(dum1-real(dumi))*(itab(dumii,     &
+       dumi+1,dumk+1,index)-itab(dumii,dumi,dumk+1,index))
+
+  iproc1 = dproc1+(dum2-real(dumk))*(dproc2-dproc1)
+
+  ! linearly interpolate to get process rates for temperature index + 1
+  dproc1 = itab(dumii+1,dumi,dumk,index)+(dum1-real(dumi))*(itab(dumii+1,   &
+       dumi+1,dumk,index)-itab(dumii+1,dumi,dumk,index))
+
+  dproc2 = itab(dumii+1,dumi,dumk+1,index)+(dum1-real(dumi))*(itab(dumii+1, &
+       dumi+1,dumk+1,index)-itab(dumii+1,dumi,dumk+1,index))
+
+  gproc1 = dproc1+(dum2-real(dumk))*(dproc2-dproc1)
+  tmp1   = iproc1+(dum4-real(dumii))*(gproc1-iproc1)
+  proc   = tmp1
+
+  ! ********** end from orig P3 **************
+
+END SUBROUTINE access_lookup_table
+
+!------------------------------------------------------------------------------------------!
+pure SUBROUTINE access_lookup_table_coll(dumii,dumj,dumi,dumk,index,dum1,dum2,dum3,     &
+     dum4,proc)
+
+  implicit none
+
+  real(r8),intent(in)    :: dum1,dum2,dum3,dum4
+  real(r8), intent(out) :: proc
+  real(r8) :: dproc1,dproc2,iproc1,gproc1,tmp1,tmp2,dproc11, &
+       dproc12,dproc21,dproc22
+  integer, intent(in) :: dumii,dumj,dumi,dumk,index
+
+
+  ! This subroutine interpolates lookup table values for rain/ice collection processes
+  !!******for without temperature dependeny *****
+  !   dproc11 = itabcoll(dumi,dumk,dumj,index)+(dum1-real(dumi))*               &
+  !             (itabcoll(dumi+1,dumk,dumj,index)-itabcoll(dumi,    &
+  !             dumk,dumj,index))
+
+  !   dproc21 = itabcoll(dumi,dumk+1,dumj,index)+(dum1-real(dumi))*             &
+  !             (itabcoll(dumi+1,dumk+1,dumj,index)-itabcoll(dumi,  &
+  !             dumk+1,dumj,index))
+
+  !   dproc1  = dproc11+(dum2-real(dumk))*(dproc21-dproc11)
+
+  !   dproc12 = itabcoll(dumi,dumk,dumj+1,index)+(dum1-real(dumi))*             &
+  !             (itabcoll(dumi+1,dumk,dumj+1,index)-itabcoll(dumi,  &
+  !             dumk,dumj+1,index))
+
+  !   dproc22 = itabcoll(dumi,dumk+1,dumj+1,index)+(dum1-real(dumi))*           &
+  !             (itabcoll(dumi+1,dumk+1,dumj+1,index)-itabcoll(     &
+  !             dumi,dumk+1,dumj+1,index))
+
+  !   dproc2  = dproc12+(dum2-real(dumk))*(dproc22-dproc12)
+  !   iproc1  = dproc1+(dum3-real(dumj))*(dproc2-dproc1)
+
+  !   proc    = iproc1
+  !!******end for without temperature dependeny *****
+
+  ! ************ from original P3 ************
+  ! current density index
+
+  ! current temp index
+  dproc11 = itabcoll(dumii,dumi,dumk,dumj,index)+(dum1-real(dumi))*               &
+       (itabcoll(dumii,dumi+1,dumk,dumj,index)-itabcoll(dumii,dumi,    &
+       dumk,dumj,index))
+
+  dproc21 = itabcoll(dumii,dumi,dumk+1,dumj,index)+(dum1-real(dumi))*             &
+       (itabcoll(dumii,dumi+1,dumk+1,dumj,index)-itabcoll(dumii,dumi,  &
+       dumk+1,dumj,index))
+
+  dproc1  = dproc11+(dum2-real(dumk))*(dproc21-dproc11)
+  dproc12 = itabcoll(dumii,dumi,dumk,dumj+1,index)+(dum1-real(dumi))*             &
+       (itabcoll(dumii,dumi+1,dumk,dumj+1,index)-itabcoll(dumii,dumi,  &
+       dumk,dumj+1,index))
+
+  dproc22 = itabcoll(dumii,dumi,dumk+1,dumj+1,index)+(dum1-real(dumi))*           &
+       (itabcoll(dumii,dumi+1,dumk+1,dumj+1,index)-itabcoll(dumii,     &
+       dumi,dumk+1,dumj+1,index))
+
+  dproc2  = dproc12+(dum2-real(dumk))*(dproc22-dproc12)
+  iproc1  = dproc1+(dum3-real(dumj))*(dproc2-dproc1)
+
+  ! temp index + 1
+
+  dproc11 = itabcoll(dumii+1,dumi,dumk,dumj,index)+(dum1-real(dumi))*             &
+       (itabcoll(dumii+1,dumi+1,dumk,dumj,index)-itabcoll(dumii+1,     &
+       dumi,dumk,dumj,index))
+
+  dproc21 = itabcoll(dumii+1,dumi,dumk+1,dumj,index)+(dum1-real(dumi))*           &
+       (itabcoll(dumii+1,dumi+1,dumk+1,dumj,index)-itabcoll(dumii+1,   &
+       dumi,dumk+1,dumj,index))
+
+  dproc1  = dproc11+(dum2-real(dumk))*(dproc21-dproc11)
+
+  dproc12 = itabcoll(dumii+1,dumi,dumk,dumj+1,index)+(dum1-real(dumi))*           &
+       (itabcoll(dumii+1,dumi+1,dumk,dumj+1,index)-itabcoll(dumii+1,   &
+       dumi,dumk,dumj+1,index))
+
+  dproc22 = itabcoll(dumii+1,dumi,dumk+1,dumj+1,index)+(dum1-real(dumi))*         &
+       (itabcoll(dumii+1,dumi+1,dumk+1,dumj+1,index)-itabcoll(dumii+1, &
+       dumi,dumk+1,dumj+1,index))
+
+  dproc2  = dproc12+(dum2-real(dumk))*(dproc22-dproc12)
+
+  gproc1  = dproc1+(dum3-real(dumj))*(dproc2-dproc1)
+  tmp1    = iproc1+(dum4-real(dumii))*(gproc1-iproc1)
+  proc    = tmp1
+
+  ! ********** end orig P3 *******
+END SUBROUTINE access_lookup_table_coll
+
+!========================================================================
+!UTILITIES
+!========================================================================
+
+pure function no_limiter()
+  real(r8) :: no_limiter
+
+  no_limiter = transfer(limiter_off, no_limiter)
+
+end function no_limiter
+
+pure function limiter_is_on(lim)
+  !$acc routine seq
+
+  real(r8), intent(in) :: lim
+  logical :: limiter_is_on
+
+  limiter_is_on = transfer(lim, limiter_off) /= limiter_off
+
+end function limiter_is_on
+
+end module micro_pumas_utils

--- a/TAU_ML_microphysics/src/micro_pumas_v1.F90
+++ b/TAU_ML_microphysics/src/micro_pumas_v1.F90
@@ -1,0 +1,4958 @@
+module micro_pumas_v1
+!---------------------------------------------------------------------------------
+! Parameterization of Unified Microphysics Across Scales version 1 (PUMASv1)
+!
+! References:
+!
+!           Gettelman, A., H. Morrison, T. Eidhammer, K. Thayer-Calder, J. Sun,
+!
+!           R. Forbes, Z. McGraw, J. Zhu, T. Storelvmo, and J. Dennis (2023):
+!
+!           Importance of Ice Nucleation and Precipitation on Climate with the
+!
+!           Parameterization of Unified Microphysics Across Scales version 1
+!
+!           (PUMASv1). Geosci. Model Dev., 16, 1735-1754.
+!
+!           https://doi.org/10.5194/gmd-16-1735-2023
+!
+!
+! for questions contact Hugh Morrison, Andrew Gettelman
+! e-mail: morrison@ucar.edu, andrew@ucar.edu
+!---------------------------------------------------------------------------------
+!
+! NOTE: Modified to allow other microphysics packages (e.g. CARMA) to do ice
+! microphysics in cooperation with the MG liquid microphysics. This is
+! controlled by the do_cldice variable.
+!
+! If do_cldice is false, then MG microphysics should not update CLDICE or
+! NUMICE; it is assumed that the other microphysics scheme will have updated
+! CLDICE and NUMICE. The other microphysics should handle the following
+! processes that would have been done by MG:
+!   - Detrainment (liquid and ice)
+!   - Homogeneous ice nucleation
+!   - Heterogeneous ice nucleation
+!   - Bergeron process
+!   - Melting of ice
+!   - Freezing of cloud drops
+!   - Autoconversion (ice -> snow)
+!   - Growth/Sublimation of ice
+!   - Sedimentation of ice
+!
+! This option has not been updated since the introduction of prognostic
+! precipitation, and probably should be adjusted to cover snow as well.
+!
+!---------------------------------------------------------------------------------
+! Version 3.O based on micro_mg2_0.F90 and WRF3.8.1 module_mp_morr_two_moment.F
+!---------------------------------------------------------------------------------
+! Based on micro_mg (restructuring of former cldwat2m_micro)
+! Author: Andrew Gettelman, Hugh Morrison.
+! Contributions from: Xiaohong Liu and Steve Ghan
+! December 2005-May 2010
+! Description in: Morrison and Gettelman, 2008. J. Climate (MG2008)
+!                 Gettelman et al., 2010 J. Geophys. Res. - Atmospheres (G2010)
+! for questions contact Hugh Morrison, Andrew Gettelman
+! e-mail: morrison@ucar.edu, andrew@ucar.edu
+!---------------------------------------------------------------------------------
+! Code comments added by HM, 093011
+! General code structure:
+!
+! Code is divided into two main subroutines:
+!   subroutine micro_pumas_init --> initializes microphysics routine, should be called
+!                                  once at start of simulation
+!   subroutine micro_pumas_tend --> main microphysics routine to be called each time step
+!                                this also calls several smaller subroutines to calculate
+!                                microphysical processes and other utilities
+!
+! List of external functions:
+!   qsat_water --> for calculating saturation vapor pressure with respect to liquid water
+!   qsat_ice --> for calculating saturation vapor pressure with respect to ice
+!   gamma   --> standard mathematical gamma function
+! .........................................................................
+! List of inputs through use statement in fortran90:
+! Variable Name                      Description                Units
+! .........................................................................
+! gravit          acceleration due to gravity                    m s-2
+! rair            dry air gas constant for air                  J kg-1 K-1
+! tmelt           temperature of melting point for water          K
+! cpair           specific heat at constant pressure for dry air J kg-1 K-1
+! rh2o            gas constant for water vapor                  J kg-1 K-1
+! latvap          latent heat of vaporization                   J kg-1
+! latice          latent heat of fusion                         J kg-1
+! qsat_water      external function for calculating liquid water
+!                 saturation vapor pressure/humidity              -
+! qsat_ice        external function for calculating ice
+!                 saturation vapor pressure/humidity              pa
+! rhmini          relative humidity threshold parameter for
+!                 nucleating ice                                  -
+! .........................................................................
+! NOTE: List of all inputs/outputs passed through the call/subroutine statement
+!       for micro_pumas_tend is given below at the start of subroutine micro_pumas_tend.
+!---------------------------------------------------------------------------------
+
+! Procedures required:
+! 1) An implementation of the gamma function (if not intrinsic).
+! 2) saturation vapor pressure and specific humidity over water
+! 3) svp over ice
+
+use pumas_kinds, only: r8=>kind_r8
+
+#ifndef HAVE_GAMMA_INTRINSICS
+use pumas_gamma_function, only: gamma=>pumas_gamma
+#endif
+
+use wv_sat_methods, only: &
+     qsat_water => wv_sat_qsat_water_vect, &
+     qsat_ice => wv_sat_qsat_ice_vect
+
+! Parameters from the utilities module.
+use micro_pumas_utils, only: &
+     pi, &
+     omsm, &
+     qsmall, &
+     qsmall_emulator, &
+     mincld, &
+     rhosn, &
+     rhoi, &
+     rhow, &
+     rhows, &
+     ac, bc, &
+     ai, bi, &
+     aj, bj, &
+     ar, br, &
+     as, bs, &
+     ag, bg, &
+     ah, bh, &
+     rhog,rhoh, &
+     mi0, &
+     rising_factorial, &
+     VLENS
+
+implicit none
+private
+save
+
+public :: &
+     micro_pumas_init, &
+     micro_pumas_get_cols, &
+     micro_pumas_tend
+
+! Switches for specification rather than prediction of droplet and crystal number
+! note: number will be adjusted as needed to keep mean size within bounds,
+! even when specified droplet or ice number is used
+!
+! If constant cloud ice number is set (nicons = .true.),
+! then all microphysical processes except mass transfer due to ice nucleation
+! (mnuccd) are based on the fixed cloud ice number. Calculation of
+! mnuccd follows from the prognosed ice crystal number ni.
+
+logical :: nccons ! nccons = .true. to specify constant cloud droplet number
+logical :: nicons ! nicons = .true. to specify constant cloud ice number
+logical :: ngcons ! ngcons = .true. to specify constant graupel number
+logical :: nrcons ! constant rain number
+logical :: nscons ! constant snow number
+
+! specified ice and droplet number concentrations
+! note: these are local in-cloud values, not grid-mean
+real(r8) :: ncnst  ! droplet num concentration when nccons=.true. (m-3)
+real(r8) :: ninst  ! ice num concentration when nicons=.true. (m-3)
+real(r8) :: ngnst   ! graupel num concentration when ngcons=.true. (m-3)
+real(r8) :: nrnst
+real(r8) :: nsnst
+
+! IFS Switches....
+! Switch to turn off evaporation of sedimenting condensate
+! Found to interact badly in some models with diagnostic cloud fraction
+logical :: evap_sed_off
+
+! Remove RH conditional from ice nucleation
+logical :: icenuc_rh_off
+
+! Internally: Meyers Ice Nucleation
+logical :: icenuc_use_meyers
+
+! Scale evaporation as IFS does (*0.3)
+logical :: evap_scl_ifs
+
+! Evap RH threhold following ifs
+logical :: evap_rhthrsh_ifs
+
+! Rain freezing at 0C following ifs
+
+logical :: rainfreeze_ifs
+
+! Snow sedimentation = 1 m/s
+
+logical :: ifs_sed
+
+! Precipitation fall speed, prevent zero velocity if precip above
+
+logical :: precip_fall_corr
+
+!--ag
+
+!=========================================================
+! Private module parameters
+!=========================================================
+
+!Range of cloudsat reflectivities (dBz) for analytic simulator
+real(r8), parameter :: csmin = -30._r8
+real(r8), parameter :: csmax = 26._r8
+real(r8), parameter :: mindbz = -99._r8
+real(r8), parameter :: minrefl = 1.26e-10_r8    ! minrefl = 10._r8**(mindbz/10._r8)
+
+integer, parameter  :: MG_PRECIP_FRAC_INCLOUD = 101
+integer, parameter  :: MG_PRECIP_FRAC_OVERLAP = 102
+
+! Reflectivity min for 10cm (Rain) radar reflectivity
+real(r8), parameter :: minrefl10 = 1.e-26_r8
+
+! autoconversion size threshold for cloud ice to snow (m)
+real(r8) :: dcs
+
+! minimum mass of new crystal due to freezing of cloud droplets done
+! externally (kg)
+real(r8), parameter :: mi0l_min = 4._r8/3._r8*pi*rhow*(4.e-6_r8)**3
+
+! Ice number sublimation parameter. Assume some decrease in ice number with sublimation if non-zero. Else, no decrease in number with sublimation.
+real(r8), parameter :: sublim_factor =0.0_r8      !number sublimation factor.
+
+! Parameters related to GPU computing
+integer, parameter :: RQUEUE = 101    ! GPU stream ID for rain
+integer, parameter :: SQUEUE = 102    ! GPU stream ID for snow
+integer, parameter :: LQUEUE = 103    ! GPU stream ID for liquid
+integer, parameter :: IQUEUE = 104    ! GPU stream ID for ice
+integer, parameter :: GQUEUE = 105    ! GPU stream ID for hail/graupel
+
+!=========================================================
+! Constants set in initialization
+!=========================================================
+
+! Set using arguments to micro_pumas_init
+real(r8) :: g           ! gravity
+real(r8) :: r           ! dry air gas constant
+real(r8) :: rv          ! water vapor gas constant
+real(r8) :: cpp         ! specific heat of dry air
+real(r8) :: tmelt       ! freezing point of water (K)
+
+! latent heats of:
+real(r8) :: xxlv        ! vaporization
+real(r8) :: xlf         ! freezing
+real(r8) :: xxls        ! sublimation
+
+real(r8) :: rhmini      ! Minimum rh for ice cloud fraction > 0.
+
+! flags
+logical :: microp_uniform
+logical :: do_cldice
+logical :: use_hetfrz_classnuc
+logical :: do_hail
+logical :: do_graupel
+
+real(r8) :: rhosu       ! typical 850mn air density
+
+real(r8) :: icenuct     ! ice nucleation temperature: currently -5 degrees C
+
+real(r8) :: snowmelt    ! what temp to melt all snow: currently 2 degrees C
+real(r8) :: rainfrze    ! what temp to freeze all rain: currently -5 degrees C
+
+! additional constants to help speed up code
+real(r8) :: gamma_br_plus1
+real(r8) :: gamma_br_plus4
+real(r8) :: gamma_bs_plus1
+real(r8) :: gamma_bs_plus4
+real(r8) :: gamma_bi_plus1
+real(r8) :: gamma_bi_plus4
+real(r8) :: gamma_bj_plus1
+real(r8) :: gamma_bj_plus4
+real(r8) :: gamma_bg_plus1
+real(r8) :: gamma_bg_plus4
+real(r8) :: xxlv_squared
+real(r8) :: xxls_squared
+
+character(len=16)  :: micro_mg_precip_frac_method  ! type of precipitation fraction method
+real(r8)           :: micro_mg_berg_eff_factor     ! berg efficiency factor
+
+real(r8)           :: micro_mg_accre_enhan_fact     ! accretion enhancment factor
+real(r8)           :: micro_mg_autocon_fact     ! autoconversion prefactor
+real(r8)           :: micro_mg_autocon_nd_exp     ! autoconversion Nd exponent factor
+real(r8)           :: micro_mg_autocon_lwp_exp  !autoconversion LWP exponent
+real(r8)           :: micro_mg_homog_size ! size of freezing homogeneous ice
+real(r8)           :: micro_mg_vtrmi_factor
+real(r8)           :: micro_mg_vtrms_factor
+real(r8)           :: micro_mg_effi_factor
+real(r8)           :: micro_mg_iaccr_factor
+real(r8)           :: micro_mg_max_nicons
+
+logical            :: remove_supersat      ! If true, remove supersaturation after sedimentation loop
+character(len=16)  :: warm_rain            ! 'tau','emulated','sb2001' or 'kk2000'
+
+!Parameters for Implicit Sedimentation Calculation
+real(r8), parameter :: vfactor = 1.0        ! Rain/Snow/Graupel Factor
+real(r8), parameter :: vfac_drop = 1.0      ! Cloud Liquid Factor
+real(r8), parameter :: vfac_ice  = 1.0      ! Cloud Ice Factor
+
+logical           :: do_implicit_fall !   = .true.
+
+logical           :: accre_sees_auto  != .true.
+
+!$acc declare create (nccons,nicons,ngcons,nrcons,nscons,ncnst,ninst,ngnst,    &
+!$acc                 nrnst,nsnst,evap_sed_off,icenuc_rh_off,evap_scl_ifs,     &
+!$acc                 icenuc_use_meyers,evap_rhthrsh_ifs,rainfreeze_ifs,       &
+!$acc                 ifs_sed,precip_fall_corr,dcs,                            &
+!$acc                 g,r,rv,cpp,tmelt,xxlv,xlf,xxls,rhmini,microp_uniform,    &
+!$acc                 do_cldice,use_hetfrz_classnuc,do_hail,do_graupel,rhosu,  &
+!$acc                 icenuct,snowmelt,rainfrze,xxlv_squared,xxls_squared,     &
+!$acc                 gamma_br_plus1,gamma_br_plus4,gamma_bs_plus1,            &
+!$acc                 gamma_bs_plus4,gamma_bi_plus1,gamma_bi_plus4,            &
+!$acc                 gamma_bj_plus1,gamma_bj_plus4,gamma_bg_plus1,            &
+!$acc                 gamma_bg_plus4,micro_mg_berg_eff_factor,                 &
+!$acc                 micro_mg_accre_enhan_fact,micro_mg_autocon_fact,         &
+!$acc                 micro_mg_autocon_nd_exp,micro_mg_autocon_lwp_exp,        &
+!$acc                 micro_mg_homog_size,micro_mg_vtrmi_factor,               &
+!$acc                 micro_mg_vtrms_factor,                                   &
+!$acc                 micro_mg_effi_factor,micro_mg_iaccr_factor,              &
+!$acc                 micro_mg_max_nicons,remove_supersat,do_implicit_fall,    &
+!$acc                 accre_sees_auto)
+
+!===============================================================================
+contains
+!===============================================================================
+
+subroutine micro_pumas_init( &
+     kind, gravit, rair, rh2o, cpair,    &
+     tmelt_in, latvap, latice,           &
+     rhmini_in, micro_mg_dcs,            &
+     micro_mg_do_hail_in,micro_mg_do_graupel_in, &
+     microp_uniform_in, do_cldice_in, use_hetfrz_classnuc_in, &
+     micro_mg_precip_frac_method_in, micro_mg_berg_eff_factor_in, &
+     micro_mg_accre_enhan_fact_in, micro_mg_autocon_fact_in, &
+     micro_mg_autocon_nd_exp_in, micro_mg_autocon_lwp_exp_in, micro_mg_homog_size_in, &
+     micro_mg_vtrmi_factor_in, micro_mg_vtrms_factor_in, micro_mg_effi_factor_in, &
+     micro_mg_iaccr_factor_in, micro_mg_max_nicons_in, &
+     remove_supersat_in, warm_rain_in, &
+     micro_mg_evap_sed_off_in, micro_mg_icenuc_rh_off_in, micro_mg_icenuc_use_meyers_in, &
+     micro_mg_evap_scl_ifs_in, micro_mg_evap_rhthrsh_ifs_in, &
+     micro_mg_rainfreeze_ifs_in,  micro_mg_ifs_sed_in, micro_mg_precip_fall_corr, &
+     micro_mg_accre_sees_auto_in, micro_mg_implicit_fall_in, &
+     nccons_in, nicons_in, ncnst_in, ninst_in, ngcons_in, ngnst_in, &
+     nrcons_in, nrnst_in, nscons_in, nsnst_in, &
+     stochastic_emulated_filename_quantile, stochastic_emulated_filename_input_scale, &
+     stochastic_emulated_filename_output_scale, &
+     iulog, errstring)
+
+  use micro_pumas_utils,            only: micro_pumas_utils_init
+  use pumas_stochastic_collect_tau, only: pumas_stochastic_kernel_init
+  use tau_neural_net_quantile,      only: initialize_tau_emulators
+
+  !-----------------------------------------------------------------------
+  !
+  ! Purpose:
+  ! initialize constants for MG microphysics
+  !
+  ! Author: Andrew Gettelman Dec 2005
+  !
+  !-----------------------------------------------------------------------
+
+  integer,  intent(in)  :: kind         ! Kind used for reals
+  real(r8), intent(in)  :: gravit
+  real(r8), intent(in)  :: rair
+  real(r8), intent(in)  :: rh2o
+  real(r8), intent(in)  :: cpair
+  real(r8), intent(in)  :: tmelt_in     ! Freezing point of water (K)
+  real(r8), intent(in)  :: latvap
+  real(r8), intent(in)  :: latice
+  real(r8), intent(in)  :: rhmini_in    ! Minimum rh for ice cloud fraction > 0.
+  real(r8), intent(in)  :: micro_mg_dcs
+
+!MG3 dense precipitating ice. Note, only 1 can be true, or both false.
+  logical,  intent(in)  :: micro_mg_do_graupel_in    ! .true. = configure with graupel
+                                                   ! .false. = no graupel (hail possible)
+  logical,  intent(in)  :: micro_mg_do_hail_in    ! .true. = configure with hail
+                                                   ! .false. = no hail (graupel possible)
+  logical,  intent(in)  :: microp_uniform_in    ! .true. = configure uniform for sub-columns
+                                            ! .false. = use w/o sub-columns (standard)
+  logical,  intent(in)  :: do_cldice_in     ! .true. = do all processes (standard)
+                                            ! .false. = skip all processes affecting
+                                            !           cloud ice
+  logical,  intent(in)  :: use_hetfrz_classnuc_in ! use heterogeneous freezing
+
+  character(len=16),intent(in)  :: micro_mg_precip_frac_method_in  ! type of precipitation fraction method
+  real(r8),         intent(in)  :: micro_mg_berg_eff_factor_in     ! berg efficiency factor
+  real(r8),         intent(in)  :: micro_mg_accre_enhan_fact_in     !accretion enhancment factor
+  real(r8),         intent(in) ::  micro_mg_autocon_fact_in    !autconversion prefactor
+  real(r8),         intent(in) ::  micro_mg_autocon_nd_exp_in !autconversion exponent factor
+  real(r8),         intent(in) ::  micro_mg_autocon_lwp_exp_in    !autconversion exponent factor
+  real(r8),         intent(in) ::  micro_mg_homog_size_in  ! size of homoegenous freezing ice
+  real(r8),         intent(in)  :: micro_mg_vtrmi_factor_in    !factor for ice fall velocity
+  real(r8),         intent(in)  :: micro_mg_vtrms_factor_in    !factor for snow fall velocity
+  real(r8),         intent(in)  :: micro_mg_effi_factor_in    !factor for ice effective radius
+  real(r8),         intent(in)  :: micro_mg_iaccr_factor_in  ! ice accretion factor
+  real(r8),         intent(in)  :: micro_mg_max_nicons_in ! maximum number ice crystal allowed
+
+  logical,  intent(in)  ::  remove_supersat_in ! If true, remove supersaturation after sedimentation loop
+  character(len=*),  intent(in)  ::  warm_rain_in
+
+! IFS-like Switches
+
+  logical, intent(in) :: micro_mg_evap_sed_off_in ! Turn off evaporation/sublimation based on cloud fraction for sedimenting condensate
+
+  logical, intent(in) :: micro_mg_icenuc_rh_off_in ! Remove RH conditional from ice nucleation
+  logical, intent(in) :: micro_mg_icenuc_use_meyers_in ! Internally: Meyers Ice Nucleation
+  logical, intent(in) :: micro_mg_evap_scl_ifs_in ! Scale evaporation as IFS does (*0.3)
+  logical, intent(in) :: micro_mg_evap_rhthrsh_ifs_in ! Evap RH threhold following ifs
+  logical, intent(in) :: micro_mg_rainfreeze_ifs_in ! Rain freezing temp following ifs
+  logical, intent(in) :: micro_mg_ifs_sed_in ! snow sedimentation = 1m/s following ifs
+  logical, intent(in) :: micro_mg_precip_fall_corr ! ensure rain fall speed non-zero if rain above in column
+
+  logical, intent(in) :: micro_mg_accre_sees_auto_in ! autoconverted rain is passed to accretion
+
+  logical, intent(in) :: micro_mg_implicit_fall_in !Implicit fall speed (sedimentation) calculation for hydrometors
+
+
+
+  logical, intent(in)   :: nccons_in
+  logical, intent(in)   :: nicons_in
+  real(r8), intent(in)  :: ncnst_in
+  real(r8), intent(in)  :: ninst_in
+
+  logical, intent(in)   :: ngcons_in
+  real(r8), intent(in)  :: ngnst_in
+  logical, intent(in)   :: nrcons_in
+  real(r8), intent(in)  :: nrnst_in
+  logical, intent(in)   :: nscons_in
+  real(r8), intent(in)  :: nsnst_in
+
+  character(len=*), intent(in) :: stochastic_emulated_filename_quantile, &
+                                  stochastic_emulated_filename_input_scale, &
+                                  stochastic_emulated_filename_output_scale ! Files for emulated machine learning
+
+  integer, intent(in) :: iulog                ! Host model log file unit number
+  character(128), intent(out) :: errstring    ! Output status (non-blank for error return)
+
+  !-----------------------------------------------------------------------
+
+  ! Initialize ice autoconversion size
+  ! to host-model specified value:
+  dcs = micro_mg_dcs
+
+  ! Initialize subordinate utilities module.
+  call micro_pumas_utils_init(kind, rair, rh2o, cpair, tmelt_in, latvap, latice, &
+       dcs, errstring)
+
+  if (trim(errstring) /= "") then !If True then error occured
+     return
+  end if
+
+  ! declarations for MG code (transforms variable names)
+
+  g= gravit                 ! gravity
+  r= rair                   ! dry air gas constant: note units(phys_constants are in J/K/kmol)
+  rv= rh2o                  ! water vapor gas constant
+  cpp = cpair               ! specific heat of dry air
+  tmelt = tmelt_in
+  rhmini = rhmini_in
+  micro_mg_precip_frac_method = micro_mg_precip_frac_method_in
+  micro_mg_berg_eff_factor    = micro_mg_berg_eff_factor_in
+  micro_mg_accre_enhan_fact   =  micro_mg_accre_enhan_fact_in
+  micro_mg_autocon_fact  = micro_mg_autocon_fact_in
+  micro_mg_autocon_nd_exp = micro_mg_autocon_nd_exp_in
+  micro_mg_autocon_lwp_exp = micro_mg_autocon_lwp_exp_in
+  micro_mg_homog_size   = micro_mg_homog_size_in
+  micro_mg_vtrmi_factor = micro_mg_vtrmi_factor_in
+  micro_mg_vtrms_factor = micro_mg_vtrms_factor_in
+  micro_mg_effi_factor = micro_mg_effi_factor_in
+  micro_mg_iaccr_factor = micro_mg_iaccr_factor_in
+  micro_mg_max_nicons = micro_mg_max_nicons_in
+  remove_supersat          = remove_supersat_in
+  warm_rain                = warm_rain_in
+  do_implicit_fall   = micro_mg_implicit_fall_in
+  accre_sees_auto = micro_mg_accre_sees_auto_in
+
+  nccons = nccons_in
+  nicons = nicons_in
+  ncnst  = ncnst_in
+  ninst  = ninst_in
+  ngcons = ngcons_in
+  ngnst  = ngnst_in
+  nscons = nscons_in
+  nsnst  = nsnst_in
+  nrcons = nrcons_in
+  nrnst  = nrnst_in
+
+  ! latent heats
+
+  xxlv = latvap         ! latent heat vaporization
+  xlf  = latice         ! latent heat freezing
+  xxls = xxlv + xlf     ! latent heat of sublimation
+
+  ! flags
+  microp_uniform = microp_uniform_in
+  do_cldice  = do_cldice_in
+  use_hetfrz_classnuc = use_hetfrz_classnuc_in
+  do_hail = micro_mg_do_hail_in
+  do_graupel = micro_mg_do_graupel_in
+  evap_sed_off = micro_mg_evap_sed_off_in
+  icenuc_rh_off = micro_mg_icenuc_rh_off_in
+  icenuc_use_meyers = micro_mg_icenuc_use_meyers_in
+  evap_scl_ifs = micro_mg_evap_scl_ifs_in
+  evap_rhthrsh_ifs = micro_mg_evap_rhthrsh_ifs_in
+  rainfreeze_ifs = micro_mg_rainfreeze_ifs_in
+  ifs_sed = micro_mg_ifs_sed_in
+  precip_fall_corr = micro_mg_precip_fall_corr
+  ! typical air density at 850 mb
+
+  rhosu = 85000._r8/(rair * tmelt)
+
+  ! Maximum temperature at which snow is allowed to exist
+  snowmelt = tmelt + 2._r8
+  ! Minimum temperature at which rain is allowed to exist
+   if (rainfreeze_ifs) then
+      rainfrze = tmelt
+   else
+      rainfrze = tmelt - 40._r8
+   end if
+
+
+  ! Ice nucleation temperature
+  icenuct  = tmelt - 5._r8
+
+  ! Define constants to help speed up code (this limits calls to gamma function)
+  gamma_br_plus1=gamma(1._r8+br)
+  gamma_br_plus4=gamma(4._r8+br)
+  gamma_bs_plus1=gamma(1._r8+bs)
+  gamma_bs_plus4=gamma(4._r8+bs)
+  gamma_bi_plus1=gamma(1._r8+bi)
+  gamma_bi_plus4=gamma(4._r8+bi)
+  gamma_bj_plus1=gamma(1._r8+bj)
+  gamma_bj_plus4=gamma(4._r8+bj)
+  gamma_bg_plus1=gamma(1._r8)
+  gamma_bg_plus4=gamma(4._r8)
+  if (do_hail) then
+     gamma_bg_plus1 = gamma(1._r8+bh)
+     gamma_bg_plus4 = gamma(4._r8+bh)
+  end if
+  if (do_graupel) then
+     gamma_bg_plus1 = gamma(1._r8+bg)
+     gamma_bg_plus4 = gamma(4._r8+bg)
+  end if
+
+  xxlv_squared=xxlv**2
+  xxls_squared=xxls**2
+
+  !$acc update device (nccons,nicons,ngcons,nrcons,nscons,ncnst,ninst,ngnst,   &
+  !$acc                nrnst,nsnst,evap_sed_off,icenuc_rh_off,evap_scl_ifs,    &
+  !$acc                icenuc_use_meyers,evap_rhthrsh_ifs,rainfreeze_ifs,      &
+  !$acc                ifs_sed,precip_fall_corr,dcs,                           &
+  !$acc                g,r,rv,cpp,tmelt,xxlv,xlf,xxls,rhmini,microp_uniform,   &
+  !$acc                do_cldice,use_hetfrz_classnuc,do_hail,do_graupel,rhosu, &
+  !$acc                icenuct,snowmelt,rainfrze,xxlv_squared,xxls_squared,    &
+  !$acc                gamma_br_plus1,gamma_br_plus4,gamma_bs_plus1,           &
+  !$acc                gamma_bs_plus4,gamma_bi_plus1,gamma_bi_plus4,           &
+  !$acc                gamma_bj_plus1,gamma_bj_plus4,gamma_bg_plus1,           &
+  !$acc                gamma_bg_plus4,micro_mg_berg_eff_factor,                &
+  !$acc                micro_mg_accre_enhan_fact,micro_mg_autocon_fact,        &
+  !$acc                micro_mg_autocon_nd_exp,micro_mg_autocon_lwp_exp,       &
+  !$acc                micro_mg_homog_size,micro_mg_vtrmi_factor,              &
+  !$acc                micro_mg_vtrms_factor,                                  &
+  !$acc                micro_mg_effi_factor,micro_mg_iaccr_factor,             &
+  !$acc                micro_mg_max_nicons,remove_supersat,do_implicit_fall,   &
+  !$acc                accre_sees_auto)
+
+  if (trim(warm_rain) == 'emulated') then
+      call initialize_tau_emulators(stochastic_emulated_filename_quantile, stochastic_emulated_filename_input_scale, &
+                                    stochastic_emulated_filename_output_scale, iulog, errstring)
+  end if
+
+end subroutine micro_pumas_init
+
+!===============================================================================
+!microphysics routine for each timestep goes here...
+
+subroutine micro_pumas_tend ( &
+     mgncol,             nlev,               deltatin,           &
+     t,                            q,                            &
+     qcn,                          qin,                          &
+     ncn,                          nin,                          &
+     qrn,                          qsn,                          &
+     nrn,                          nsn,                          &
+     qgr,                          ngr,                          &
+     relvar,                       accre_enhan,                  &
+     p,                            pdel, pint,                   &
+     cldn,    liqcldf,        icecldf,       qsatfac,            &
+     qcsinksum_rate1ord,                                         &
+     naai,                         npccn,                        &
+     rndst,                        nacon,                        &
+     tlat,                         qvlat,                        &
+     qctend,                       qitend,                       &
+     nctend,                       nitend,                       &
+     qrtend,                       qstend,                       &
+     nrtend,                       nstend,                       &
+     qgtend,                       ngtend,                       &
+     effc,               effc_fn,            effi,               &
+     sadice,                       sadsnow,                      &
+     prect,                        preci,                        &
+     nevapr,                       am_evp_st,                    &
+     prain,                                                      &
+     cmeout,                       deffi,                        &
+     pgamrad,                      lamcrad,                      &
+     qsout,                        dsout,                        &
+     qgout,     ngout,             dgout,                        &
+     lflx,               iflx,                                   &
+     gflx,                                                       &
+     rflx,               sflx,               qrout,              &
+     reff_rain,          reff_snow,          reff_grau,          &
+     nrout,                        nsout,                        &
+     refl,               arefl,              areflz,             &
+     frefl,              csrfl,              acsrfl,             &
+     fcsrfl,        refl10cm, reflz10cm,     rercld,             &
+     ncai,                         ncal,                         &
+     qrout2,                       qsout2,                       &
+     nrout2,                       nsout2,                       &
+     drout2,                       dsout2,                       &
+     qgout2,        ngout2,        dgout2,    freqg,                   &
+     freqs,                        freqr,                        &
+     nfice,                        qcrat,                        &
+     proc_rates,                                                 &
+     errstring, &
+     tnd_qsnow,          tnd_nsnow,          re_ice,             &
+     prer_evap,                                                      &
+     frzimm,             frzcnt,             frzdep)
+
+  use pumas_stochastic_collect_tau, only: ncd, pumas_stochastic_collect_tau_tend
+  use tau_neural_net_quantile,      only: tau_emulated_cloud_rain_interactions
+  use ML_fixer_check,               only: ML_fixer_calc
+
+  ! Constituent properties.
+  use micro_pumas_utils, only: &
+       mg_liq_props, &
+       mg_ice_props, &
+       mg_rain_props, &
+       mg_graupel_props, &
+       mg_hail_props, &
+       mg_snow_props
+
+  ! Size calculation functions.
+  use micro_pumas_utils, only: &
+       size_dist_param_liq, &
+       size_dist_param_basic, &
+       avg_diameter, &
+       avg_diameter_vec
+
+  ! Microphysical processes.
+  use micro_pumas_utils, only: &
+       ice_deposition_sublimation, &
+       sb2001v2_liq_autoconversion,&
+       sb2001v2_accre_cld_water_rain,&
+       kk2000_liq_autoconversion, &
+       ice_autoconversion, &
+       immersion_freezing, &
+       contact_freezing, &
+       snow_self_aggregation, &
+       accrete_cloud_water_snow, &
+       secondary_ice_production, &
+       accrete_rain_snow, &
+       heterogeneous_rain_freezing, &
+       accrete_cloud_water_rain, &
+       self_collection_rain, &
+       accrete_cloud_ice_snow, &
+       evaporate_sublimate_precip, &
+       bergeron_process_snow, &
+       graupel_collecting_snow, &
+       graupel_collecting_rain, &
+       graupel_collecting_cld_water, &
+       graupel_riming_liquid_snow, &
+       graupel_rain_riming_snow, &
+       graupel_rime_splintering, &
+       vapor_deposition_onto_snow, &
+       evaporate_sublimate_precip_graupel
+
+  use micro_pumas_diags, only: proc_rates_type
+
+  !Authors: Hugh Morrison, Andrew Gettelman, NCAR, Peter Caldwell, LLNL
+  ! e-mail: morrison@ucar.edu, andrew@ucar.edu
+
+  ! input arguments
+  integer,  intent(in) :: mgncol         ! number of microphysics columns
+  integer,  intent(in) :: nlev           ! number of layers
+  real(r8), intent(in) :: deltatin       ! time step (s)
+  real(r8), intent(in) :: t(mgncol,nlev) ! input temperature (K)
+  real(r8), intent(in) :: q(mgncol,nlev) ! input h20 vapor mixing ratio (kg/kg)
+
+  ! note: all input cloud variables are grid-averaged
+  real(r8), intent(in) :: qcn(mgncol,nlev)       ! cloud water mixing ratio (kg/kg)
+  real(r8), intent(in) :: qin(mgncol,nlev)       ! cloud ice mixing ratio (kg/kg)
+  real(r8), intent(in) :: ncn(mgncol,nlev)       ! cloud water number conc (1/kg)
+  real(r8), intent(in) :: nin(mgncol,nlev)       ! cloud ice number conc (1/kg)
+
+  real(r8), intent(in) :: qrn(mgncol,nlev)       ! rain mixing ratio (kg/kg)
+  real(r8), intent(in) :: qsn(mgncol,nlev)       ! snow mixing ratio (kg/kg)
+  real(r8), intent(in) :: nrn(mgncol,nlev)       ! rain number conc (1/kg)
+  real(r8), intent(in) :: nsn(mgncol,nlev)       ! snow number conc (1/kg)
+  real(r8), intent(in) :: qgr(mgncol,nlev)       ! graupel/hail mixing ratio (kg/kg)
+  real(r8), intent(in) :: ngr(mgncol,nlev)       ! graupel/hail number conc (1/kg)
+
+  real(r8), intent(in) :: relvar(mgncol,nlev)      ! cloud water relative variance (-)
+  real(r8), intent(in) :: accre_enhan(mgncol,nlev) ! optional accretion
+                                             ! enhancement factor (-)
+
+  real(r8), intent(in) :: p(mgncol,nlev)        ! air pressure (pa)
+  real(r8), intent(in) :: pdel(mgncol,nlev)     ! pressure difference across level (pa)
+  real(r8), intent(in) :: pint(mgncol,nlev+1)   ! pressure at interfaces
+
+  real(r8), intent(in) :: cldn(mgncol,nlev)      ! cloud fraction (no units)
+  real(r8), intent(in) :: liqcldf(mgncol,nlev)   ! liquid cloud fraction (no units)
+  real(r8), intent(in) :: icecldf(mgncol,nlev)   ! ice cloud fraction (no units)
+  real(r8), intent(in) :: qsatfac(mgncol,nlev)   ! subgrid cloud water saturation scaling factor (no units)
+
+  ! used for scavenging
+  ! Inputs for aerosol activation
+  real(r8), intent(in) :: naai(mgncol,nlev)     ! ice nucleation number (from microp_aero_ts) (1/kg*s)
+  real(r8), intent(in) :: npccn(mgncol,nlev)   ! ccn activated number tendency (from microp_aero_ts) (1/kg*s)
+
+  ! Note that for these variables, the dust bin is assumed to be the last index.
+  ! (For example, in CAM, the last dimension is always size 4.)
+  real(r8), intent(in) :: rndst(:,:,:)  ! radius of each dust bin, for contact freezing (from microp_aero_ts) (m)
+  real(r8), intent(in) :: nacon(:,:,:) ! number in each dust bin, for contact freezing  (from microp_aero_ts) (1/m^3)
+
+  ! output arguments
+
+  real(r8), intent(out) :: qcsinksum_rate1ord(mgncol,nlev) ! 1st order rate for
+  ! direct cw to precip conversion
+  real(r8), intent(out) :: tlat(mgncol,nlev)         ! latent heating rate       (W/kg)
+  real(r8), intent(out) :: qvlat(mgncol,nlev)        ! microphysical tendency qv (1/s)
+  real(r8), intent(out) :: qctend(mgncol,nlev)       ! microphysical tendency qc (1/s)
+  real(r8), intent(out) :: qitend(mgncol,nlev)       ! microphysical tendency qi (1/s)
+  real(r8), intent(out) :: nctend(mgncol,nlev)       ! microphysical tendency nc (1/(kg*s))
+  real(r8), intent(out) :: nitend(mgncol,nlev)       ! microphysical tendency ni (1/(kg*s))
+
+  real(r8), intent(out) :: qrtend(mgncol,nlev)       ! microphysical tendency qr (1/s)
+  real(r8), intent(out) :: qstend(mgncol,nlev)       ! microphysical tendency qs (1/s)
+  real(r8), intent(out) :: nrtend(mgncol,nlev)       ! microphysical tendency nr (1/(kg*s))
+  real(r8), intent(out) :: nstend(mgncol,nlev)       ! microphysical tendency ns (1/(kg*s))
+  real(r8), intent(out) :: qgtend(mgncol,nlev)       ! microphysical tendency qg (1/s)
+  real(r8), intent(out) :: ngtend(mgncol,nlev)       ! microphysical tendency ng (1/(kg*s))
+
+  real(r8), intent(out) :: effc(mgncol,nlev)         ! droplet effective radius (micron)
+  real(r8), intent(out) :: effc_fn(mgncol,nlev)      ! droplet effective radius, assuming nc = 1.e8 kg-1
+  real(r8), intent(out) :: effi(mgncol,nlev)         ! cloud ice effective radius (micron)
+  real(r8), intent(out) :: sadice(mgncol,nlev)       ! cloud ice surface area density (cm2/cm3)
+  real(r8), intent(out) :: sadsnow(mgncol,nlev)      ! cloud snow surface area density (cm2/cm3)
+  real(r8), intent(out) :: prect(mgncol)             ! surface precip rate (m/s)
+  real(r8), intent(out) :: preci(mgncol)             ! cloud ice/snow precip rate (m/s)
+  real(r8), intent(out) :: nevapr(mgncol,nlev)       ! evaporation rate of rain + snow (kg/kg/s)
+  real(r8), intent(out) :: am_evp_st(mgncol,nlev)    ! stratiform evaporation area (frac)
+  real(r8), intent(out) :: prain(mgncol,nlev)        ! production of rain + snow (kg/kg/s)
+  real(r8), intent(out) :: cmeout(mgncol,nlev)       ! Rate of cond-evap of ice (kg/kg/s)
+  real(r8), intent(out) :: deffi(mgncol,nlev)        ! ice effective diameter for optics (radiation) (micron)
+  real(r8), intent(out) :: pgamrad(mgncol,nlev)      ! ice gamma parameter for optics (radiation) (no units)
+  real(r8), intent(out) :: lamcrad(mgncol,nlev)      ! slope of droplet distribution for optics (radiation) (1/m)
+  real(r8), intent(out) :: qsout(mgncol,nlev)        ! snow mixing ratio (kg/kg)
+  real(r8), intent(out) :: dsout(mgncol,nlev)        ! snow diameter (m)
+  real(r8), intent(out) :: lflx(mgncol,nlev+1)       ! grid-box average liquid condensate flux (kg m^-2 s^-1)
+  real(r8), intent(out) :: iflx(mgncol,nlev+1)       ! grid-box average ice condensate flux (kg m^-2 s^-1)
+  real(r8), intent(out) :: rflx(mgncol,nlev+1)       ! grid-box average rain flux (kg m^-2 s^-1)
+  real(r8), intent(out) :: sflx(mgncol,nlev+1)       ! grid-box average snow flux (kg m^-2 s^-1)
+  real(r8), intent(out) :: gflx(mgncol,nlev+1)       ! grid-box average graupel/hail flux (kg m^-2 s^-1)
+
+  real(r8), intent(out) :: qrout(mgncol,nlev)        ! grid-box average rain mixing ratio (kg/kg)
+  real(r8), intent(out) :: reff_rain(mgncol,nlev)    ! rain effective radius (micron)
+  real(r8), intent(out) :: reff_snow(mgncol,nlev)    ! snow effective radius (micron)
+  real(r8), intent(out) :: reff_grau(mgncol,nlev)    ! graupel effective radius (micron)
+
+  real(r8), intent(out) :: nrout(mgncol,nlev)        ! rain number concentration (1/m3)
+  real(r8), intent(out) :: nsout(mgncol,nlev)        ! snow number concentration (1/m3)
+  real(r8), intent(out) :: refl(mgncol,nlev)         ! analytic radar reflectivity (94GHZ, cloud radar) (dBZ)
+  real(r8), intent(out) :: arefl(mgncol,nlev)        ! average reflectivity will zero points outside valid range (dBZ)
+  real(r8), intent(out) :: areflz(mgncol,nlev)       ! average reflectivity in z. (mm6 m-3)
+  real(r8), intent(out) :: frefl(mgncol,nlev)        ! fractional occurrence of radar reflectivity
+  real(r8), intent(out) :: csrfl(mgncol,nlev)        ! cloudsat reflectivity (dBZ)
+  real(r8), intent(out) :: acsrfl(mgncol,nlev)       ! cloudsat average (dBZ)
+  real(r8), intent(out) :: fcsrfl(mgncol,nlev)       ! cloudsat fractional occurrence of radar reflectivity
+  real(r8), intent(out) :: refl10cm(mgncol,nlev)     ! 10cm (rain) analytic radar reflectivity (dBZ)
+  real(r8), intent(out) :: reflz10cm(mgncol,nlev)    ! 10cm (rain) analytic radar reflectivity (mm6 m-3)
+  real(r8), intent(out) :: rercld(mgncol,nlev)       ! effective radius calculation for rain + cloud
+  real(r8), intent(out) :: ncai(mgncol,nlev)         ! output number conc of ice nuclei available (1/m3)
+  real(r8), intent(out) :: ncal(mgncol,nlev)         ! output number conc of CCN (1/m3)
+  real(r8), intent(out) :: qrout2(mgncol,nlev)       ! copy of qrout as used to compute drout2
+  real(r8), intent(out) :: qsout2(mgncol,nlev)       ! copy of qsout as used to compute dsout2
+  real(r8), intent(out) :: nrout2(mgncol,nlev)       ! copy of nrout as used to compute drout2
+  real(r8), intent(out) :: nsout2(mgncol,nlev)       ! copy of nsout as used to compute dsout2
+  real(r8), intent(out) :: drout2(mgncol,nlev)       ! mean rain particle diameter (m)
+  real(r8), intent(out) :: dsout2(mgncol,nlev)       ! mean snow particle diameter (m)
+  real(r8), intent(out) :: freqs(mgncol,nlev)        ! fractional occurrence of snow
+  real(r8), intent(out) :: freqr(mgncol,nlev)        ! fractional occurrence of rain
+  real(r8), intent(out) :: nfice(mgncol,nlev)        ! fraction of frozen water to total condensed water
+  real(r8), intent(out) :: qcrat(mgncol,nlev)        ! limiter for qc process rates (1=no limit --> 0. no qc)
+  real(r8), intent(out) :: qgout(mgncol,nlev)        ! graupel/hail mixing ratio (kg/kg)
+  real(r8), intent(out) :: dgout(mgncol,nlev)        ! graupel/hail diameter (m)
+  real(r8), intent(out) :: ngout(mgncol,nlev)        ! graupel/hail number concentration (1/m3)
+  real(r8), intent(out) :: qgout2(mgncol,nlev)       ! copy of qgout as used to compute dgout2
+  real(r8), intent(out) :: ngout2(mgncol,nlev)       ! copy of ngout as used to compute dgout2
+  real(r8), intent(out) :: dgout2(mgncol,nlev)       ! mean graupel/hail particle diameter (m)
+  real(r8), intent(out) :: freqg(mgncol,nlev)        ! fractional occurrence of graupel
+
+  real(r8), intent(out) :: prer_evap(mgncol,nlev)    ! evaporation rate of rain (kg/kg/s)
+
+  type (proc_rates_type), intent(inout)  :: proc_rates
+
+  character(128),   intent(out) :: errstring  ! output status (non-blank for error return)
+
+  ! Tendencies calculated by external schemes that can replace MG's native
+  ! process tendencies.
+
+  ! Used with CARMA cirrus microphysics
+  ! (or similar external microphysics model)
+  real(r8), intent(in) :: tnd_qsnow(:,:) ! snow mass tendency (kg/kg/s)
+  real(r8), intent(in) :: tnd_nsnow(:,:) ! snow number tendency (#/kg/s)
+  real(r8), intent(in) :: re_ice(:,:)    ! ice effective radius (m)
+
+  ! From external ice nucleation.
+  real(r8), intent(in) :: frzimm(:,:) ! Number tendency due to immersion freezing (1/cm3)
+  real(r8), intent(in) :: frzcnt(:,:) ! Number tendency due to contact freezing (1/cm3)
+  real(r8), intent(in) :: frzdep(:,:) ! Number tendency due to deposition nucleation (1/cm3)
+
+  ! local workspace
+  ! all units mks unless otherwise stated
+
+  ! local copies of input variables
+  real(r8) :: qc(mgncol,nlev)      ! cloud liquid mixing ratio (kg/kg)
+  real(r8) :: qi(mgncol,nlev)      ! cloud ice mixing ratio (kg/kg)
+  real(r8) :: nc(mgncol,nlev)      ! cloud liquid number concentration (1/kg)
+  real(r8) :: ni(mgncol,nlev)      ! cloud liquid number concentration (1/kg)
+  real(r8) :: qr(mgncol,nlev)      ! rain mixing ratio (kg/kg)
+  real(r8) :: qs(mgncol,nlev)      ! snow mixing ratio (kg/kg)
+  real(r8) :: nr(mgncol,nlev)      ! rain number concentration (1/kg)
+  real(r8) :: ns(mgncol,nlev)      ! snow number concentration (1/kg)
+  real(r8) :: qg(mgncol,nlev)      ! graupel mixing ratio (kg/kg)
+  real(r8) :: ng(mgncol,nlev)      ! graupel number concentration (1/kg)
+  real(r8) :: rhogtmp              ! hail or graupel density (kg m-3)
+
+  ! general purpose variables
+  real(r8) :: deltat            ! sub-time step (s)
+  real(r8) :: rdeltat           ! reciprocal of sub-time step (1/s)
+
+  ! physical properties of the air at a given point
+  real(r8) :: rho(mgncol,nlev)    ! density (kg m-3)
+  real(r8) :: dv(mgncol,nlev)     ! diffusivity of water vapor
+  real(r8) :: mu(mgncol,nlev)     ! viscosity
+  real(r8) :: sc(mgncol,nlev)     ! schmidt number
+  real(r8) :: rhof(mgncol,nlev)   ! density correction factor for fallspeed
+
+  ! cloud fractions
+  real(r8) :: precip_frac(mgncol,nlev) ! precip fraction assuming maximum overlap
+  real(r8) :: cldm(mgncol,nlev)   ! cloud fraction
+  real(r8) :: icldm(mgncol,nlev)  ! ice cloud fraction
+  real(r8) :: lcldm(mgncol,nlev)  ! liq cloud fraction
+  real(r8) :: qsfm(mgncol,nlev)   ! subgrid cloud water saturation scaling factor
+
+  ! mass mixing ratios
+  real(r8) :: qcic(mgncol,nlev)   ! in-cloud cloud liquid
+  real(r8) :: qiic(mgncol,nlev)   ! in-cloud cloud ice
+  real(r8) :: qsic(mgncol,nlev)   ! in-precip snow
+  real(r8) :: qric(mgncol,nlev)   ! in-precip rain
+  real(r8) :: qgic(mgncol,nlev)   ! in-precip graupel/hail
+
+  ! number concentrations
+  real(r8) :: ncic(mgncol,nlev)   ! in-cloud droplet
+  real(r8) :: niic(mgncol,nlev)   ! in-cloud cloud ice
+  real(r8) :: nsic(mgncol,nlev)   ! in-precip snow
+  real(r8) :: nric(mgncol,nlev)   ! in-precip rain
+  real(r8) :: ngic(mgncol,nlev)   ! in-precip graupel/hail
+
+  ! Size distribution parameters for:
+  ! cloud ice
+  real(r8) :: lami(mgncol,nlev)   ! slope
+  real(r8) :: n0i(mgncol,nlev)    ! intercept
+  ! cloud liquid
+  real(r8) :: lamc(mgncol,nlev)   ! slope
+  real(r8) :: pgam(mgncol,nlev)   ! spectral width parameter
+  ! snow
+  real(r8) :: lams(mgncol,nlev)   ! slope
+  real(r8) :: n0s(mgncol,nlev)    ! intercept
+  ! rain
+  real(r8) :: lamr(mgncol,nlev)   ! slope
+  real(r8) :: n0r(mgncol,nlev)    ! intercept
+  ! graupel/hail
+  real(r8) :: lamg(mgncol,nlev)   ! slope
+  real(r8) :: n0g(mgncol,nlev)    ! intercept
+  real(r8) :: bgtmp               ! tmp fall speed parameter
+
+  ! Rates/tendencies due to:
+
+  ! Instantaneous snow melting
+  real(r8) :: minstsm(mgncol,nlev)    ! mass mixing ratio
+  real(r8) :: ninstsm(mgncol,nlev)    ! number concentration
+  ! Instantaneous graupel melting
+  real(r8) :: minstgm(mgncol,nlev)    ! mass mixing ratio
+  real(r8) :: ninstgm(mgncol,nlev)    ! number concentration
+
+  ! Instantaneous rain freezing
+  real(r8) :: minstrf(mgncol,nlev)    ! mass mixing ratio
+  real(r8) :: ninstrf(mgncol,nlev)    ! number concentration
+
+  ! deposition of cloud ice
+  real(r8) :: vap_dep(mgncol,nlev)    ! deposition from vapor to ice PMC 12/3/12
+  ! sublimation of cloud ice
+  real(r8) :: ice_sublim(mgncol,nlev) ! sublimation from ice to vapor PMC 12/3/12
+  ! vapor deposition onto
+  real(r8) :: vap_deps(mgncol,nlev) ! Vapor deposition onto snow.
+
+  ! ice nucleation
+  real(r8) :: nnuccd(mgncol,nlev) ! number rate from deposition/cond.-freezing
+  real(r8) :: mnuccd(mgncol,nlev) ! mass mixing ratio
+  ! freezing of cloud water
+  real(r8) :: mnuccc(mgncol,nlev) ! mass mixing ratio
+  real(r8) :: nnuccc(mgncol,nlev) ! number concentration
+  ! contact freezing of cloud water
+  real(r8) :: mnucct(mgncol,nlev) ! mass mixing ratio
+  real(r8) :: nnucct(mgncol,nlev) ! number concentration
+  ! deposition nucleation in mixed-phase clouds (from external scheme)
+  real(r8) :: mnudep(mgncol,nlev) ! mass mixing ratio
+  real(r8) :: nnudep(mgncol,nlev) ! number concentration
+  ! ice multiplication
+  real(r8) :: msacwi(mgncol,nlev) ! mass mixing ratio
+  real(r8) :: nsacwi(mgncol,nlev) ! number concentration
+  ! autoconversion of cloud droplets
+  real(r8) :: prc(mgncol,nlev)    ! mass mixing ratio
+  real(r8) :: nprc(mgncol,nlev)   ! number concentration (rain)
+  real(r8) :: nprc1(mgncol,nlev)  ! number concentration (cloud droplets)
+  ! self-aggregation of snow
+  real(r8) :: nsagg(mgncol,nlev)  ! number concentration
+  ! self-collection of rain
+  real(r8) :: nragg(mgncol,nlev)  ! number concentration
+  ! collection of droplets by snow
+  real(r8) :: psacws(mgncol,nlev)     ! mass mixing ratio
+  real(r8) :: npsacws(mgncol,nlev)    ! number concentration
+  ! collection of rain by snow
+  real(r8) :: pracs(mgncol,nlev)  ! mass mixing ratio
+  real(r8) :: npracs(mgncol,nlev) ! number concentration
+  ! freezing of rain
+  real(r8) :: mnuccr(mgncol,nlev) ! mass mixing ratio
+  real(r8) :: nnuccr(mgncol,nlev) ! number concentration
+  ! freezing of rain to form ice (mg add 4/26/13)
+  real(r8) :: mnuccri(mgncol,nlev)    ! mass mixing ratio
+  real(r8) :: nnuccri(mgncol,nlev)    ! number concentration
+  ! accretion of droplets by rain
+  real(r8) :: pra(mgncol,nlev)    ! mass mixing ratio
+  real(r8) :: npra(mgncol,nlev)   ! number concentration
+  ! autoconversion of cloud ice to snow
+  real(r8) :: prci(mgncol,nlev)   ! mass mixing ratio
+  real(r8) :: nprci(mgncol,nlev)  ! number concentration
+  ! accretion of cloud ice by snow
+  real(r8) :: prai(mgncol,nlev)   ! mass mixing ratio
+  real(r8) :: nprai(mgncol,nlev)  ! number concentration
+  ! evaporation of rain
+  real(r8) :: pre(mgncol,nlev)    ! mass mixing ratio
+  ! sublimation of snow
+  real(r8) :: prds(mgncol,nlev)   ! mass mixing ratio
+  ! number evaporation
+  real(r8) :: nsubi(mgncol,nlev)  ! cloud ice
+  real(r8) :: nsubc(mgncol,nlev)  ! droplet
+  real(r8) :: nsubs(mgncol,nlev)  ! snow
+  real(r8) :: nsubr(mgncol,nlev)  ! rain
+  ! bergeron process
+  real(r8) :: berg(mgncol,nlev)   ! mass mixing ratio (cloud ice)
+  real(r8) :: bergs(mgncol,nlev)  ! mass mixing ratio (snow)
+
+  !graupel/hail processes
+  real(r8) :: npracg(mgncol,nlev)  ! change n collection rain by graupel  (precipf)
+  real(r8) :: nscng(mgncol,nlev)   ! change n conversion to graupel due to collection droplets by snow (lcldm)
+  real(r8) :: ngracs(mgncol,nlev)  ! change n conversion to graupel due to collection rain by snow (precipf)
+  real(r8) :: nmultg(mgncol,nlev)  ! ice mult due to acc droplets by graupel  (lcldm)
+  real(r8) :: nmultrg(mgncol,nlev) ! ice mult due to acc rain by graupel  (precipf)
+  real(r8) :: npsacwg(mgncol,nlev) ! change n collection droplets by graupel (lcldm)
+
+  real(r8) :: psacr(mgncol,nlev)   ! conversion due to coll of snow by rain (precipf)
+  real(r8) :: pracg(mgncol,nlev)   ! change in q collection rain by graupel  (precipf)
+  real(r8) :: psacwg(mgncol,nlev)  ! change in q collection droplets by graupel (lcldm)
+  real(r8) :: pgsacw(mgncol,nlev)  ! conversion q to graupel due to collection droplets by snow  (lcldm)
+  real(r8) :: pgracs(mgncol,nlev)  ! conversion q to graupel due to collection rain by snow (precipf)
+  real(r8) :: prdg(mgncol,nlev)    ! dep of graupel (precipf)
+  real(r8) :: qmultg(mgncol,nlev)  ! change q due to ice mult droplets/graupel  (lcldm)
+  real(r8) :: qmultrg(mgncol,nlev) ! change q due to ice mult rain/graupel (precipf)
+
+
+  ! fallspeeds
+  ! number-weighted
+  real(r8) :: uns(mgncol,nlev)    ! snow
+  real(r8) :: unr(mgncol,nlev)    ! rain
+  real(r8) :: ung(mgncol,nlev)    ! graupel/hail
+
+  ! air density corrected fallspeed parameters
+  real(r8) :: arn(mgncol,nlev)    ! rain
+  real(r8) :: asn(mgncol,nlev)    ! snow
+  real(r8) :: agn(mgncol,nlev)    ! graupel
+  real(r8) :: acn(mgncol,nlev)    ! cloud droplet
+  real(r8) :: ain(mgncol,nlev)    ! cloud ice
+  real(r8) :: ajn(mgncol,nlev)    ! cloud small ice
+
+  ! Mass of liquid droplets used with external heterogeneous freezing.
+  real(r8) :: mi0l(mgncol,nlev)
+
+  ! saturation vapor pressures
+  real(r8) :: esl(mgncol,nlev)    ! liquid
+  real(r8) :: esi(mgncol,nlev)    ! ice
+  real(r8) :: esnA(mgncol,nlev)   ! checking for RH after rain evap
+
+  ! saturation vapor mixing ratios
+  real(r8) :: qvl(mgncol,nlev)    ! liquid
+  real(r8) :: qvi(mgncol,nlev)    ! ice
+  real(r8) :: qvnA(mgncol,nlev), qvnAI(mgncol,nlev) ! checking for RH after rain evap
+
+  ! relative humidity
+  real(r8) :: relhum(mgncol,nlev)
+
+  ! parameters for cloud water and cloud ice sedimentation calculations
+  real(r8) :: fc(mgncol,nlev)
+  real(r8) :: fnc(mgncol,nlev)
+  real(r8) :: fi(mgncol,nlev)
+  real(r8) :: fni(mgncol,nlev)
+  real(r8) :: fg(mgncol,nlev)
+  real(r8) :: fng(mgncol,nlev)
+  real(r8) :: fr(mgncol,nlev)
+  real(r8) :: fnr(mgncol,nlev)
+  real(r8) :: fs(mgncol,nlev)
+  real(r8) :: fns(mgncol,nlev)
+
+  real(r8) :: rthrsh     ! rain rate threshold for reflectivity calculation
+
+  ! dummy variables
+  real(r8) :: dum, dum1, dum2, dum3, dum4, qtmp
+  real(r8) :: dum1A(mgncol,nlev), dum2A(mgncol,nlev), dum3A(mgncol,nlev)
+  real(r8) :: dumni0, dumni0A2D(mgncol,nlev)
+  real(r8) :: dumns0, dumns0A2D(mgncol,nlev)
+  ! dummies for checking RH
+  real(r8) :: ttmpA(mgncol,nlev), qtmpAI(mgncol,nlev)
+  ! dummies for conservation check
+  real(r8) :: ratio, tmpnr,tmpp
+  real(r8) :: tmpfrz
+  ! dummies for in-cloud variables
+  real(r8) :: dumc(mgncol,nlev)   ! qc
+  real(r8) :: dumnc(mgncol,nlev)  ! nc
+  real(r8) :: dumi(mgncol,nlev)   ! qi
+  real(r8) :: dumni(mgncol,nlev)  ! ni
+  real(r8) :: dumr(mgncol,nlev)   ! rain mixing ratio
+  real(r8) :: dumnr(mgncol,nlev)  ! rain number concentration
+  real(r8) :: dums(mgncol,nlev)   ! snow mixing ratio
+  real(r8) :: dumns(mgncol,nlev)  ! snow number concentration
+  real(r8) :: dumg(mgncol,nlev)   ! graupel mixing ratio
+  real(r8) :: dumng(mgncol,nlev)  ! graupel number concentration
+  ! Array dummy variable
+  real(r8) :: dum_2D(mgncol,nlev)
+  real(r8) :: pdel_inv(mgncol,nlev)
+
+  ! loop array variables
+  ! "i" and "k" are column/level iterators for internal (MG) variables
+  ! "n" is used for other looping (currently just sedimentation)
+  integer i, k, n
+
+  integer mdust
+  integer :: precip_frac_method
+
+  ! Varaibles to scale fall velocity between small and regular ice regimes.
+  real(r8) :: irad
+  real(r8) :: ifrac
+
+  !Variables for accretion seeing autoconverted liquid
+  real(r8) :: rtmp(mgncol,nlev) ! dummy for rain + autoconversion
+  real(r8) :: ctmp(mgncol,nlev) ! dummy for liq - autoconversion
+  real(r8) :: ntmp(mgncol,nlev) ! dummy for liq - autoconversion number
+
+  ! Variables for height calculation (used in Implicit Fall Speed)
+  real(r8) :: zint(mgncol,nlev+1) ! interface height
+  real(r8) :: H   !Scale height
+
+  ! temporary local variables for asynchronous GPU run
+  ! ice
+  real(r8) :: prect_i(mgncol)
+  real(r8) :: tlat_i(mgncol,nlev)
+  real(r8) :: qvlat_i(mgncol,nlev)
+  real(r8) :: preci_i(mgncol)
+  ! liq
+  real(r8) :: prect_l(mgncol)
+  real(r8) :: tlat_l(mgncol,nlev)
+  real(r8) :: qvlat_l(mgncol,nlev)
+  ! rain
+  real(r8) :: prect_r(mgncol)
+  ! snow
+  real(r8) :: prect_s(mgncol)
+  real(r8) :: preci_s(mgncol)
+  ! graupel
+  real(r8) :: prect_g(mgncol)
+  real(r8) :: preci_g(mgncol)
+
+  ! number of sub-steps for loops over "n" (for sedimentation)
+  ! ice
+  integer nstep_i(mgncol)
+  real(r8) :: rnstep_i(mgncol)
+  ! liq
+  integer nstep_l(mgncol)
+  real(r8) :: rnstep_l(mgncol)
+  ! rain
+  integer nstep_r(mgncol)
+  real(r8) :: rnstep_r(mgncol)
+  ! snow
+  integer nstep_s(mgncol)
+  real(r8) :: rnstep_s(mgncol)
+  ! graupel
+  integer nstep_g(mgncol)
+  real(r8) :: rnstep_g(mgncol)
+
+  !cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+
+  ! Initialize scale height (H) for interface height calculation
+  ! needed for Implicit Fall Speed
+  H=0._r8
+
+  ! Return error message
+  errstring = ' '
+
+  ! Process inputs
+
+  ! assign variable deltat to deltatin
+  deltat  = deltatin
+  rdeltat = 1._r8 / deltat
+
+  if (trim(micro_mg_precip_frac_method) == 'in_cloud') then
+     precip_frac_method = MG_PRECIP_FRAC_INCLOUD
+  else if(trim(micro_mg_precip_frac_method) == 'max_overlap') then
+     precip_frac_method = MG_PRECIP_FRAC_OVERLAP
+  endif
+
+  !......................................................................
+  !       graupel/hail density set (Hail = 400, Graupel = 500 from M2005)
+  bgtmp=0._r8
+  rhogtmp=0._r8
+  if (do_hail) then
+     bgtmp = bh
+     rhogtmp = rhoh
+  end if
+  if (do_graupel) then
+     bgtmp = bg
+     rhogtmp = rhog
+  end if
+
+  ! set mdust as the number of dust bins for use later in contact freezing subroutine
+  mdust = size(rndst,3)
+
+  !$acc data copyin  (t,q,qcn,qin,ncn,nin,qrn,qsn,nrn,nsn,qgr,ngr,relvar,     &
+  !$acc               accre_enhan,p,pdel,pint,cldn,liqcldf,icecldf,qsatfac,   &
+  !$acc               naai,npccn,rndst,nacon,tnd_qsnow,tnd_nsnow,re_ice,      &
+  !$acc               frzimm,frzcnt,frzdep,mg_liq_props,mg_ice_props,         &
+  !$acc               mg_rain_props,mg_graupel_props,mg_hail_props,           &
+  !$acc               mg_snow_props,proc_rates)                               &
+  !$acc      copyout (qcsinksum_rate1ord,tlat,qvlat,qctend,qitend,nctend,     &
+  !$acc               nitend,qrtend,qstend,nrtend,nstend,qgtend,ngtend,       &
+  !$acc               effc,effc_fn,effi,sadice,sadsnow,prect,preci,           &
+  !$acc               nevapr,proc_rates%evapsnow,am_evp_st,prain,             &
+  !$acc               proc_rates%prodsnow,cmeout,                             &
+  !$acc               deffi,pgamrad,lamcrad,qsout,dsout,lflx,iflx,rflx,       &
+  !$acc               sflx,gflx,qrout,reff_rain,reff_snow,reff_grau,          &
+  !$acc               proc_rates%qcsevap,proc_rates%qisevap,proc_rates%qvres, &
+  !$acc               proc_rates%cmeitot,proc_rates%vtrmc,proc_rates%vtrmi,   &
+  !$acc               proc_rates%umr,proc_rates%ums,                          &
+  !$acc               proc_rates%umg,proc_rates%qgsedten,proc_rates%qcsedten, &
+  !$acc               proc_rates%qisedten,proc_rates%qrsedten,                &
+  !$acc               proc_rates%qssedten,proc_rates%pratot,                  &
+  !$acc               proc_rates%prctot,proc_rates%mnuccctot,                 &
+  !$acc               proc_rates%mnuccttot,proc_rates%msacwitot,              &
+  !$acc               proc_rates%psacwstot,proc_rates%bergstot,               &
+  !$acc               proc_rates%vapdepstot,proc_rates%bergtot,               &
+  !$acc               proc_rates%melttot,proc_rates%meltstot,                 &
+  !$acc               proc_rates%meltgtot,proc_rates%mnudeptot,               &
+  !$acc               proc_rates%homotot,                                     &
+  !$acc               proc_rates%qcrestot,proc_rates%prcitot,                 &
+  !$acc               proc_rates%praitot,proc_rates%qirestot,                 &
+  !$acc               proc_rates%mnuccrtot,proc_rates%mnuccritot,             &
+  !$acc               proc_rates%pracstot,proc_rates%meltsdttot,              &
+  !$acc               proc_rates%frzrdttot,proc_rates%mnuccdtot,              &
+  !$acc               proc_rates%pracgtot,proc_rates%psacwgtot,               &
+  !$acc               proc_rates%pgsacwtot,proc_rates%pgracstot,              &
+  !$acc               proc_rates%prdgtot,proc_rates%qmultgtot,                &
+  !$acc               proc_rates%qmultrgtot,proc_rates%psacrtot,              &
+  !$acc               proc_rates%npracgtot,proc_rates%nscngtot,               &
+  !$acc               proc_rates%ngracstot,proc_rates%nmultgtot,              &
+  !$acc               proc_rates%nmultrgtot,proc_rates%npsacwgtot,            &
+  !$acc               nrout,nsout,refl,arefl,                                 &
+  !$acc               areflz,frefl,csrfl,acsrfl,fcsrfl,refl10cm,reflz10cm,    &
+  !$acc               rercld,ncai,ncal,qrout2,qsout2,nrout2,nsout2,drout2,    &
+  !$acc               dsout2,freqs,freqr,nfice,qcrat,qgout,dgout,ngout,       &
+  !$acc               qgout2,ngout2,dgout2,freqg,prer_evap,                   &
+  !$acc               proc_rates%nnuccctot,proc_rates%nnuccttot,              &
+  !$acc               proc_rates%nnuccdtot,proc_rates%nnudeptot,              &
+  !$acc               proc_rates%nhomotot,proc_rates%nnuccrtot,               &
+  !$acc               proc_rates%nnuccritot,proc_rates%nsacwitot,             &
+  !$acc               proc_rates%npratot,proc_rates%npsacwstot,               &
+  !$acc               proc_rates%npraitot,proc_rates%npracstot,               &
+  !$acc               proc_rates%nprctot,proc_rates%nprcitot,                 &
+  !$acc               proc_rates%ncsedten,proc_rates%nisedten,                &
+  !$acc               proc_rates%nrsedten,proc_rates%nssedten,                &
+  !$acc               proc_rates%ngsedten,proc_rates%nmelttot,                &
+  !$acc               proc_rates%nmeltstot,proc_rates%nmeltgtot,              &
+  !$acc               proc_rates%nraggtot,proc_rates%scale_qc,                &
+  !$acc               proc_rates%scale_nc,proc_rates%scale_qr,                &
+  !$acc               proc_rates%scale_nr,proc_rates%amk_c,proc_rates%ank_c,  &
+  !$acc               proc_rates%amk_r,proc_rates%ank_r,proc_rates%amk,       &
+  !$acc               proc_rates%ank,proc_rates%amk_out,proc_rates%ank_out,   &
+  !$acc               proc_rates%qc_out_TAU,proc_rates%nc_out_TAU,            &
+  !$acc               proc_rates%qr_out_TAU,proc_rates%nr_out_TAU,            &
+  !$acc               proc_rates%qc_in_TAU,proc_rates%nc_in_TAU,              &
+  !$acc               proc_rates%qr_in_TAU,proc_rates%nr_in_TAU,              &
+  !$acc               proc_rates%lamc_out,proc_rates%lamr_out,                &
+  !$acc               proc_rates%pgam_out,proc_rates%n0r_out,                 &
+  !$acc               proc_rates%qctend_KK2000,proc_rates%nctend_KK2000,      &
+  !$acc               proc_rates%qrtend_KK2000,proc_rates%nrtend_KK2000,      &
+  !$acc               proc_rates%qctend_SB2001,proc_rates%nctend_SB2001,      &
+  !$acc               proc_rates%qrtend_SB2001,proc_rates%nrtend_SB2001,      &
+  !$acc               proc_rates%qctend_TAU,proc_rates%nctend_TAU,            &
+  !$acc               proc_rates%qrtend_TAU,proc_rates%nrtend_TAU,            &
+  !$acc               proc_rates%gmnnn_lmnnn_TAU)                             &
+  !$acc      create  (qc,qi,nc,ni,qr,qs,nr,ns,qg,ng,rho,dv,mu,sc,rhof,        &
+  !$acc               precip_frac,cldm,icldm,lcldm,qsfm,qcic,qiic,qsic,qric,  &
+  !$acc               qgic,ncic,niic,nsic,nric,ngic,lami,n0i,lamc,pgam,lams,  &
+  !$acc               n0s,lamr,n0r,lamg,n0g,minstsm,ninstsm,minstgm,ninstgm,  &
+  !$acc               minstrf,ninstrf,vap_dep,ice_sublim,vap_deps,nnuccd,     &
+  !$acc               mnuccd,mnuccc,nnuccc,mnucct,nnucct,mnudep,nnudep,       &
+  !$acc               msacwi,nsacwi,prc,nprc,nprc1,nsagg,nragg,psacws,        &
+  !$acc               npsacws,pracs,npracs,mnuccr,nnuccr,mnuccri,nnuccri,pra, &
+  !$acc               npra,prci,nprci,prai,nprai,pre,prds,nsubi,nsubc,nsubs,  &
+  !$acc               nsubr,berg,bergs,npracg,nscng,ngracs,nmultg,nmultrg,    &
+  !$acc               npsacwg,psacr,pracg,psacwg,pgsacw,pgracs,prdg,qmultg,   &
+  !$acc               qmultrg,uns,unr,ung,arn,asn,agn,acn,ain,ajn,mi0l,esl,   &
+  !$acc               esi,esnA,qvl,qvi,qvnA,qvnAI,relhum,fc,fnc,fi,fni,fg,    &
+  !$acc               fng,fr,fnr,fs,fns,dum1A,dum2A,dum3A,dumni0A2D,          &
+  !$acc               dumns0A2D,ttmpA,qtmpAI,dumc,dumnc,dumi,dumni,dumr,      &
+  !$acc               dumnr,dums,dumns,dumg,dumng,dum_2D,pdel_inv,rtmp,ctmp,  &
+  !$acc               ntmp,zint,nstep_i,rnstep_i,nstep_l,rnstep_l,nstep_r,    &
+  !$acc               rnstep_r,nstep_s,rnstep_s,nstep_g,rnstep_g,prect_i,     &
+  !$acc               tlat_i,qvlat_i,preci_i,prect_l,tlat_l,qvlat_l,prect_r,  &
+  !$acc               prect_s,preci_s,prect_g,preci_g)
+
+  ! Copies of input concentrations that may be changed internally.
+
+  !$acc parallel vector_length(VLENS) default(present)
+  !$acc loop gang vector collapse(2)
+  do k = 1,nlev
+     do i = 1,mgncol
+        qc(i,k) = qcn(i,k)
+        nc(i,k) = ncn(i,k)
+        qi(i,k) = qin(i,k)
+        ni(i,k) = nin(i,k)
+        qr(i,k) = qrn(i,k)
+        nr(i,k) = nrn(i,k)
+        qs(i,k) = qsn(i,k)
+        ns(i,k) = nsn(i,k)
+        qg(i,k) = qgr(i,k)
+        ng(i,k) = ngr(i,k)
+     end do
+  end do
+  !$acc end parallel
+
+  ! cldn: used to set cldm, unused for subcolumns
+  ! liqcldf: used to set lcldm, unused for subcolumns
+  ! icecldf: used to set icldm, unused for subcolumns
+
+  if (microp_uniform) then
+     ! subcolumns, set cloud fraction variables to one
+     ! if cloud water or ice is present, if not present
+     ! set to mincld (mincld used instead of zero, to prevent
+     ! possible division by zero errors).
+
+     !$acc parallel vector_length(VLENS) default(present)
+     !$acc loop gang vector collapse(2)
+     do k=1,nlev
+       do i=1,mgncol
+          if (qc(i,k) >= qsmall) then
+             lcldm(i,k) = 1._r8
+          else
+             lcldm(i,k) = mincld
+          end if
+
+          if (qi(i,k) >= qsmall) then
+             icldm(i,k) = 1._r8
+          else
+             icldm(i,k) = mincld
+          end if
+
+          cldm(i,k) = max(icldm(i,k), lcldm(i,k))
+          qsfm(i,k) = 1._r8
+        end do
+     end do
+     !$acc end parallel
+  else
+     ! get cloud fraction, check for minimum
+
+     !$acc parallel vector_length(VLENS) default(present)
+     !$acc loop gang vector collapse(2)
+     do k=1,nlev
+        do i=1,mgncol
+          cldm(i,k) = max(cldn(i,k),mincld)
+          lcldm(i,k) = max(liqcldf(i,k),mincld)
+          icldm(i,k) = max(icecldf(i,k),mincld)
+          qsfm(i,k) = qsatfac(i,k)
+        end do
+     end do
+     !$acc end parallel
+  end if
+
+  ! Initialize local variables
+
+  ! local physical properties
+
+  !$acc parallel vector_length(VLENS) default(present)
+  !$acc loop gang vector collapse(2)
+  do k=1,nlev
+     do i=1,mgncol
+        rho(i,k) = p(i,k)/(r*t(i,k))
+        dv(i,k) = 8.794E-5_r8 * t(i,k)**1.81_r8 / p(i,k)
+        mu(i,k) = 1.496E-6_r8 * t(i,k)**1.5_r8 / (t(i,k) + 120._r8)
+        sc(i,k) = mu(i,k)/(rho(i,k)*dv(i,k))
+
+        ! air density adjustment for fallspeed parameters
+        ! includes air density correction factor to the
+        ! power of 0.54 following Heymsfield and Bansemer 2007
+
+        rhof(i,k)=(rhosu/rho(i,k))**0.54_r8
+
+        arn(i,k)=ar*rhof(i,k)
+        asn(i,k)=as*rhof(i,k)
+        ! Hail use ah*rhof graupel use ag*rhof
+        ! Note that do_hail and do_graupel can't both be true
+        if (do_hail) then
+           agn(i,k) = ah*rhof(i,k)
+        end if
+        if (do_graupel) then
+           agn(i,k) = ag*rhof(i,k)
+        end if
+        acn(i,k)=g*rhow/(18._r8*mu(i,k))
+        ain(i,k)=ai*(rhosu/rho(i,k))**0.35_r8
+        ajn(i,k)=aj*(rhosu/rho(i,k))**0.35_r8
+     end do
+  end do
+  !$acc end parallel
+
+  !cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+  ! Get humidity and saturation vapor pressures
+
+  call qsat_water(t, p, esl, qvl, mgncol*nlev)
+  call qsat_ice(t, p, esi, qvi, mgncol*nlev)
+
+  !$acc parallel vector_length(VLENS) default(present)
+  !$acc loop gang vector collapse(2)
+  do k=1,nlev
+     do i=1,mgncol
+        ! make sure when above freezing that esi=esl, not active yet
+        if (t(i,k) >= tmelt) then
+           esi(i,k)=esl(i,k)
+           qvi(i,k)=qvl(i,k)
+        else
+           ! Scale the water saturation values to reflect subgrid scale
+           ! ice cloud fraction, where ice clouds begin forming at a
+           ! gridbox average relative humidity of rhmini (not 1).
+           !
+           ! NOTE: For subcolumns and other non-subgrid clouds, qsfm willi
+           ! be 1.
+           qvi(i,k) = qsfm(i,k) * qvi(i,k)
+           esi(i,k) = qsfm(i,k) * esi(i,k)
+           qvl(i,k) = qsfm(i,k) * qvl(i,k)
+           esl(i,k) = qsfm(i,k) * esl(i,k)
+        end if
+
+        relhum(i,k) = q(i,k) / max(qvl(i,k), qsmall)
+
+     end do
+  end do
+  !$acc end parallel
+
+  ! initialize microphysics output
+
+  !$acc parallel vector_length(VLENS) default(present)
+  !$acc loop gang vector collapse(2)
+  do k=1,nlev
+     do i=1,mgncol
+        proc_rates%qcsevap(i,k)            = 0._r8
+        proc_rates%qisevap(i,k)            = 0._r8
+        proc_rates%qvres(i,k)              = 0._r8
+        proc_rates%cmeitot(i,k)            = 0._r8
+        proc_rates%vtrmc(i,k)              = 0._r8
+        proc_rates%vtrmi(i,k)              = 0._r8
+        proc_rates%qcsedten(i,k)           = 0._r8
+        proc_rates%qisedten(i,k)           = 0._r8
+        proc_rates%qrsedten(i,k)           = 0._r8
+        proc_rates%qssedten(i,k)           = 0._r8
+        proc_rates%qgsedten(i,k)           = 0._r8
+
+        proc_rates%pratot(i,k)             = 0._r8
+        proc_rates%prctot(i,k)             = 0._r8
+        proc_rates%mnuccctot(i,k)          = 0._r8
+        proc_rates%mnuccttot(i,k)          = 0._r8
+        proc_rates%msacwitot(i,k)          = 0._r8
+        proc_rates%psacwstot(i,k)          = 0._r8
+        proc_rates%bergstot(i,k)           = 0._r8
+        proc_rates%vapdepstot(i,k)         = 0._r8
+        proc_rates%bergtot(i,k)            = 0._r8
+        proc_rates%melttot(i,k)            = 0._r8
+
+        proc_rates%mnudeptot(i,k)          = 0._r8
+        proc_rates%meltstot(i,k)           = 0._r8
+        proc_rates%meltgtot(i,k)           = 0._r8
+        proc_rates%homotot(i,k)            = 0._r8
+        proc_rates%qcrestot(i,k)           = 0._r8
+        proc_rates%prcitot(i,k)            = 0._r8
+        proc_rates%praitot(i,k)            = 0._r8
+        proc_rates%qirestot(i,k)           = 0._r8
+        proc_rates%mnuccrtot(i,k)          = 0._r8
+        proc_rates%mnuccritot(i,k)         = 0._r8
+        proc_rates%pracstot(i,k)           = 0._r8
+        proc_rates%meltsdttot(i,k)         = 0._r8
+        proc_rates%frzrdttot(i,k)          = 0._r8
+        proc_rates%mnuccdtot(i,k)          = 0._r8
+        proc_rates%psacrtot(i,k)           = 0._r8
+        proc_rates%pracgtot(i,k)           = 0._r8
+        proc_rates%psacwgtot(i,k)          = 0._r8
+        proc_rates%pgsacwtot(i,k)          = 0._r8
+        proc_rates%pgracstot(i,k)          = 0._r8
+        proc_rates%prdgtot(i,k)            = 0._r8
+        proc_rates%qmultgtot(i,k)          = 0._r8
+        proc_rates%qmultrgtot(i,k)         = 0._r8
+        proc_rates%npracgtot(i,k)          = 0._r8
+        proc_rates%nscngtot(i,k)           = 0._r8
+        proc_rates%ngracstot(i,k)          = 0._r8
+        proc_rates%nmultgtot(i,k)          = 0._r8
+        proc_rates%nmultrgtot(i,k)         = 0._r8
+        proc_rates%npsacwgtot(i,k)         = 0._r8
+
+        proc_rates%nnuccctot(i,k)          = 0._r8
+        proc_rates%nnuccttot(i,k)          = 0._r8
+        proc_rates%nnuccdtot(i,k)          = 0._r8
+        proc_rates%nnudeptot(i,k)          = 0._r8
+        proc_rates%nhomotot(i,k)           = 0._r8
+        proc_rates%nnuccrtot(i,k)          = 0._r8
+        proc_rates%nnuccritot(i,k)         = 0._r8
+        proc_rates%nsacwitot(i,k)          = 0._r8
+        proc_rates%npratot(i,k)            = 0._r8
+        proc_rates%npsacwstot(i,k)         = 0._r8
+        proc_rates%npraitot(i,k)           = 0._r8
+        proc_rates%npracstot(i,k)          = 0._r8
+        proc_rates%nprctot(i,k)            = 0._r8
+        proc_rates%nraggtot(i,k)           = 0._r8
+        proc_rates%nprcitot(i,k)           = 0._r8
+        proc_rates%ncsedten(i,k)           = 0._r8
+        proc_rates%nisedten(i,k)           = 0._r8
+        proc_rates%nrsedten(i,k)           = 0._r8
+        proc_rates%nssedten(i,k)           = 0._r8
+        proc_rates%ngsedten(i,k)           = 0._r8
+        proc_rates%nmelttot(i,k)           = 0._r8
+        proc_rates%nmeltstot(i,k)          = 0._r8
+        proc_rates%nmeltgtot(i,k)          = 0._r8
+
+!need to zero these out to be totally switchable (for conservation)
+        psacr(i,k)              = 0._r8
+        pracg(i,k)              = 0._r8
+        psacwg(i,k)             = 0._r8
+        pgsacw(i,k)             = 0._r8
+        pgracs(i,k)             = 0._r8
+        prdg(i,k)               = 0._r8
+        qmultg(i,k)             = 0._r8
+        qmultrg(i,k)            = 0._r8
+        npracg(i,k)             = 0._r8
+        nscng(i,k)              = 0._r8
+        ngracs(i,k)             = 0._r8
+        nmultg(i,k)             = 0._r8
+        nmultrg(i,k)            = 0._r8
+        npsacwg(i,k)            = 0._r8
+        prc(i,k)                = 0._r8
+        nprc(i,k)               = 0._r8
+        nprc1(i,k)              = 0._r8
+        pra(i,k)                = 0._r8
+        npra(i,k)               = 0._r8
+        n0i(i,k)                = 0._r8
+        lami(i,k)               = 0._r8
+        n0s(i,k)                = 0._r8
+        lams(i,k)               = 0._r8
+        ninstsm(i,k)            = 0._r8
+        ninstgm(i,k)            = 0._r8
+        psacws(i,k)             = 0._r8
+        pracs(i,k)              = 0._r8
+        bergs(i,k)              = 0._r8
+        prds(i,k)               = 0._r8
+     end do
+  end do
+  !$acc end parallel
+
+  !$acc parallel vector_length(VLENS) default(present)
+  !$acc loop gang vector collapse(2)
+  do k=1,nlev+1
+     do i=1,mgncol
+        rflx(i,k)               = 0._r8
+        sflx(i,k)               = 0._r8
+        lflx(i,k)               = 0._r8
+        iflx(i,k)               = 0._r8
+        gflx(i,k)               = 0._r8
+        zint(i,k)               = 0._r8
+     end do
+  end do
+  !$acc end parallel
+
+  ! initialize precip at surface
+
+  !$acc parallel vector_length(VLENS) default(present)
+  !$acc loop gang vector
+  do i=1,mgncol
+     prect(i)                   = 0._r8
+     preci(i)                   = 0._r8
+     prect_i(i)                 = 0._r8
+     preci_i(i)                 = 0._r8
+     prect_l(i)                 = 0._r8
+     prect_r(i)                 = 0._r8
+     prect_s(i)                 = 0._r8
+     preci_s(i)                 = 0._r8
+     prect_g(i)                 = 0._r8
+     preci_g(i)                 = 0._r8
+  end do
+  !$acc end parallel
+
+  !$acc parallel vector_length(VLENS) default(present)
+  !$acc loop gang vector collapse(2)
+  do k=1,nlev
+     do i=1,mgncol
+        ! initialize precip output
+        qrout(i,k)              = 0._r8
+        qsout(i,k)              = 0._r8
+        nrout(i,k)              = 0._r8
+        nsout(i,k)              = 0._r8
+        qgout(i,k)              = 0._r8
+        ngout(i,k)              = 0._r8
+
+        ! initialize rain size
+        rercld(i,k)             = 0._r8
+
+        qcsinksum_rate1ord(i,k) = 0._r8
+
+        ! initialize variables for trop_mozart
+        nevapr(i,k)             = 0._r8
+        prer_evap(i,k)          = 0._r8
+        proc_rates%evapsnow(i,k)           = 0._r8
+        am_evp_st(i,k)          = 0._r8
+        prain(i,k)              = 0._r8
+        proc_rates%prodsnow(i,k)           = 0._r8
+        cmeout(i,k)             = 0._r8
+
+        precip_frac(i,k)        = mincld
+        lamc(i,k)               = 0._r8
+        lamg(i,k)               = 0._r8
+
+        ! Interim variables for accretion
+        rtmp(i,k)               = 0._r8
+        ctmp(i,k)               = 0._r8
+        ntmp(i,k)               = 0._r8
+
+        ! initialize microphysical tendencies
+        tlat(i,k)               = 0._r8
+        qvlat(i,k)              = 0._r8
+        qctend(i,k)             = 0._r8
+        qitend(i,k)             = 0._r8
+        qstend(i,k)             = 0._r8
+        qrtend(i,k)             = 0._r8
+        nctend(i,k)             = 0._r8
+        nitend(i,k)             = 0._r8
+        nrtend(i,k)             = 0._r8
+        nstend(i,k)             = 0._r8
+        qgtend(i,k)             = 0._r8
+        ngtend(i,k)             = 0._r8
+
+        ! initialize in-cloud and in-precip quantities to zero
+        qcic(i,k)               = 0._r8
+        qiic(i,k)               = 0._r8
+        qsic(i,k)               = 0._r8
+        qric(i,k)               = 0._r8
+        qgic(i,k)               = 0._r8
+
+        ncic(i,k)               = 0._r8
+        niic(i,k)               = 0._r8
+        nsic(i,k)               = 0._r8
+        nric(i,k)               = 0._r8
+        ngic(i,k)               = 0._r8
+     end do
+  end do
+  !$acc end parallel
+
+  !$acc parallel vector_length(VLENS) default(present)
+  !$acc loop gang vector collapse(2)
+  do k=1,nlev
+     do i=1,mgncol
+        ! initialize vapor_deposition
+        vap_dep(i,k)            = 0._r8
+        vap_deps(i,k)           = 0._r8
+
+        ! initialize precip fallspeeds to zero
+        proc_rates%ums(i,k)     = 0._r8
+        uns(i,k)                = 0._r8
+        proc_rates%umr(i,k)     = 0._r8
+        unr(i,k)                = 0._r8
+        proc_rates%umg(i,k)     = 0._r8
+        ung(i,k)                = 0._r8
+
+        ! initialize limiter for output
+        qcrat(i,k)              = 1._r8
+
+        ! Many outputs have to be initialized here at the top to work around
+        ! ifort problems, even if they are always overwritten later.
+        effc(i,k)               = 10._r8
+        lamcrad(i,k)            = 0._r8
+        pgamrad(i,k)            = 0._r8
+        effc_fn(i,k)            = 10._r8
+        effi(i,k)               = 25._r8
+        effi(i,k)               = effi(i,k)*micro_mg_effi_factor
+        sadice(i,k)             = 0._r8
+        sadsnow(i,k)            = 0._r8
+        deffi(i,k)              = 50._r8
+
+        qrout2(i,k)             = 0._r8
+        nrout2(i,k)             = 0._r8
+        drout2(i,k)             = 0._r8
+        qsout2(i,k)             = 0._r8
+        nsout2(i,k)             = 0._r8
+        dsout(i,k)              = 0._r8
+        dsout2(i,k)             = 0._r8
+        qgout2(i,k)             = 0._r8
+        ngout2(i,k)             = 0._r8
+        freqg(i,k)              = 0._r8
+        freqr(i,k)              = 0._r8
+        freqs(i,k)              = 0._r8
+
+        reff_rain(i,k)          = 0._r8
+        reff_snow(i,k)          = 0._r8
+        reff_grau(i,k)          = 0._r8
+
+        refl(i,k)               = -9999._r8
+        arefl(i,k)              = 0._r8
+        areflz(i,k)             = 0._r8
+        frefl(i,k)              = 0._r8
+        csrfl(i,k)              = 0._r8
+        acsrfl(i,k)             = 0._r8
+        fcsrfl(i,k)             = 0._r8
+
+        refl10cm(i,k)           = -9999._r8
+        reflz10cm(i,k)          =  0._r8
+
+        ncal(i,k)               = 0._r8
+        ncai(i,k)               = 0._r8
+        nfice(i,k)              = 0._r8
+
+        pdel_inv(i,k)           = 1._r8/pdel(i,k)
+        tlat_i(i,k)             = 0._r8
+        qvlat_i(i,k)            = 0._r8
+        tlat_l(i,k)             = 0._r8
+        qvlat_l(i,k)            = 0._r8
+
+        nnudep(i,k)             = 0._r8
+        mnudep(i,k)             = 0._r8
+        nragg(i,k)              = 0._r8
+
+        proc_rates%qctend_KK2000(i,k) = 0._r8
+        proc_rates%nctend_KK2000(i,k) = 0._r8
+        proc_rates%qrtend_KK2000(i,k) = 0._r8
+        proc_rates%nrtend_KK2000(i,k) = 0._r8
+        proc_rates%lamc_out(i,k)      = 0._r8
+        proc_rates%lamr_out(i,k)      = 0._r8
+        proc_rates%pgam_out(i,k)      = 0._r8
+        proc_rates%n0r_out(i,k)       = 0._r8
+     end do
+  end do
+  !$acc end parallel
+
+  if (trim(warm_rain) == 'sb2001') then
+     !$acc parallel vector_length(VLENS) default(present)
+     !$acc loop gang vector collapse(2)
+     do k=1,nlev
+        do i=1,mgncol
+           proc_rates%qctend_SB2001(i,k) = 0._r8
+           proc_rates%nctend_SB2001(i,k) = 0._r8
+           proc_rates%qrtend_SB2001(i,k) = 0._r8
+           proc_rates%nrtend_SB2001(i,k) = 0._r8
+        end do
+     end do
+     !$acc end parallel
+  end if
+
+  if (trim(warm_rain) == 'tau' .or. trim(warm_rain) == 'emulated') then
+     !$acc parallel vector_length(VLENS) default(present)
+     !$acc loop gang vector collapse(2)
+     do k=1,nlev
+        do i=1,mgncol
+           proc_rates%qctend_TAU(i,k) = 0._r8
+           proc_rates%nctend_TAU(i,k) = 0._r8
+           proc_rates%qrtend_TAU(i,k) = 0._r8
+           proc_rates%nrtend_TAU(i,k) = 0._r8
+           proc_rates%qc_out_TAU(i,k) = 0._r8
+           proc_rates%nc_out_TAU(i,k) = 0._r8
+           proc_rates%qr_out_TAU(i,k) = 0._r8
+           proc_rates%nr_out_TAU(i,k) = 0._r8
+           proc_rates%qc_in_TAU(i,k) = 0._r8
+           proc_rates%nc_in_TAU(i,k) = 0._r8
+           proc_rates%qr_in_TAU(i,k) = 0._r8
+           proc_rates%nr_in_TAU(i,k) = 0._r8
+           proc_rates%gmnnn_lmnnn_TAU(i,k) = 0._r8
+        end do
+     end do
+     !$acc end parallel
+  end if
+
+  !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+  ! droplet activation
+  ! get provisional droplet number after activation. This is used for
+  ! all microphysical process calculations, for consistency with update of
+  ! droplet mass before microphysics
+
+  ! calculate potential for droplet activation if cloud water is present
+  ! tendency from activation (npccn) is read in from companion routine
+
+  ! output activated liquid and ice (convert from #/kg -> #/m3)
+  !--------------------------------------------------
+
+  !$acc parallel vector_length(VLENS) default(present)
+  !$acc loop gang vector collapse(2)
+  do k=1,nlev
+     do i=1,mgncol
+        if (qc(i,k) >= qsmall) then
+           nc(i,k) = max(nc(i,k) + npccn(i,k)*deltat, 0._r8)
+           ncal(i,k) = npccn(i,k)
+        else
+           ncal(i,k) = 0._r8
+        end if
+
+        if (t(i,k) < icenuct) then
+           ncai(i,k) = naai(i,k)*deltat*rho(i,k)
+        else
+           ncai(i,k) = 0._r8
+        end if
+
+  !===============================================
+
+  ! ice nucleation if activated nuclei exist at t<-5C AND rhmini + 5%
+  !
+  ! NOTE: If using gridbox average values, condensation will not occur until rh=1,
+  ! so the threshold seems like it should be 1.05 and not rhmini + 0.05. For subgrid
+  ! clouds (using rhmini and qsfacm), the relhum has already been adjusted, and thus
+  ! the nucleation threshold should also be 1.05 and not rhmini + 0.05.
+  !-------------------------------------------------------
+
+        if (do_cldice) then
+           if (icenuc_rh_off) then
+              if (naai(i,k) > 0._r8 .and. t(i,k) < icenuct) then
+                 !if NAAI > 0. then set numice = naai (as before)
+                 !note: this is gridbox averaged
+                 nnuccd(i,k) = naai(i,k)*icldm(i,k)
+                 nnuccd(i,k) = max(nnuccd(i,k),0._r8)
+
+                 !Calc mass of new particles using new crystal mass...
+                 !also this will be multiplied by mtime as nnuccd is...
+                 mnuccd(i,k) = nnuccd(i,k) * mi0
+              else
+                 nnuccd(i,k) = 0._r8
+                 mnuccd(i,k) = 0._r8
+              end if
+           else
+              if (naai(i,k) > 0._r8 .and. t(i,k) < icenuct .and. &
+                 relhum(i,k)*esl(i,k)/esi(i,k) > 1.05_r8) then
+                 !if NAAI > 0. then set numice = naai (as before)
+                 !note: this is gridbox averaged
+                 nnuccd(i,k) = naai(i,k)*icldm(i,k)
+                 nnuccd(i,k) = max(nnuccd(i,k),0._r8)
+
+                 !Calc mass of new particles using new crystal mass...
+                 !also this will be multiplied by mtime as nnuccd is...
+                 mnuccd(i,k) = nnuccd(i,k) * mi0
+              else
+                 nnuccd(i,k) = 0._r8
+                 mnuccd(i,k) = 0._r8
+              end if
+           end if
+        end if
+     end do
+  end do
+  !$acc end parallel
+
+  !=============================================================================
+
+  !$acc parallel vector_length(VLENS) default(present)
+  !$acc loop gang vector collapse(2)
+  do k=1,nlev
+     do i=1,mgncol
+        ! calculate instantaneous precip processes (melting and homogeneous freezing)
+        ! melting of snow at +2 C
+        if (t(i,k) > snowmelt) then
+           if (qs(i,k) > 0._r8) then
+              ! make sure melting snow doesn't reduce temperature below threshold
+              dum = -xlf/cpp*qs(i,k)
+              if (t(i,k)+dum < snowmelt) then
+                 dum = (t(i,k)-snowmelt)*cpp/xlf
+                 dum = dum/qs(i,k)
+                 dum = max(0._r8,dum)
+                 dum = min(1._r8,dum)
+              else
+                 dum = 1._r8
+              end if
+
+              minstsm(i,k) = dum*qs(i,k)
+              ninstsm(i,k) = dum*ns(i,k)
+
+              dum1=-xlf*minstsm(i,k)*rdeltat
+              tlat(i,k)=tlat(i,k)+dum1
+              proc_rates%meltsdttot(i,k)=proc_rates%meltsdttot(i,k) + dum1
+              proc_rates%meltstot(i,k)=minstsm(i,k)*rdeltat
+
+              qs(i,k) = max(qs(i,k) - minstsm(i,k), 0._r8)
+              ns(i,k) = max(ns(i,k) - ninstsm(i,k), 0._r8)
+              qr(i,k) = max(qr(i,k) + minstsm(i,k), 0._r8)
+              nr(i,k) = max(nr(i,k) + ninstsm(i,k), 0._r8)
+           end if
+        end if
+
+        ! melting of graupel at +2 C
+
+        if (t(i,k) > snowmelt) then
+           if (qg(i,k) > 0._r8) then
+
+              ! make sure melting graupel doesn't reduce temperature below threshold
+              dum = -xlf/cpp*qg(i,k)
+              if (t(i,k)+dum < snowmelt) then
+                 dum = (t(i,k)-snowmelt)*cpp/xlf
+                 dum = dum/qg(i,k)
+                 dum = max(0._r8,dum)
+                 dum = min(1._r8,dum)
+              else
+                 dum = 1._r8
+              end if
+
+              minstgm(i,k) = dum*qg(i,k)
+              ninstgm(i,k) = dum*ng(i,k)
+
+              dum1=-xlf*minstgm(i,k)*rdeltat
+              tlat(i,k)=tlat(i,k)+dum1
+              proc_rates%meltsdttot(i,k)=proc_rates%meltsdttot(i,k) + dum1
+              proc_rates%meltgtot(i,k)=minstgm(i,k)*rdeltat
+
+              qg(i,k) = max(qg(i,k) - minstgm(i,k), 0._r8)
+              ng(i,k) = max(ng(i,k) - ninstgm(i,k), 0._r8)
+              qr(i,k) = max(qr(i,k) + minstgm(i,k), 0._r8)
+              nr(i,k) = max(nr(i,k) + ninstgm(i,k), 0._r8)
+           end if
+        end if
+
+        ! freezing of rain at -5 C
+
+        if (t(i,k) < rainfrze) then
+
+           if (qr(i,k) > 0._r8) then
+
+              ! make sure freezing rain doesn't increase temperature above threshold
+              dum = xlf/cpp*qr(i,k)
+              if (t(i,k)+dum > rainfrze) then
+                 dum = -(t(i,k)-rainfrze)*cpp/xlf
+                 dum = dum/qr(i,k)
+                 dum = max(0._r8,dum)
+                 dum = min(1._r8,dum)
+              else
+                 dum = 1._r8
+              end if
+
+              minstrf(i,k) = dum*qr(i,k)
+              ninstrf(i,k) = dum*nr(i,k)
+
+              ! heating tendency
+              dum1 = xlf*minstrf(i,k)*rdeltat
+              tlat(i,k)=tlat(i,k)+dum1
+              proc_rates%frzrdttot(i,k)=proc_rates%frzrdttot(i,k) + dum1
+
+              qr(i,k) = max(qr(i,k) - minstrf(i,k), 0._r8)
+              nr(i,k) = max(nr(i,k) - ninstrf(i,k), 0._r8)
+
+              ! freeze rain to graupel not snow.
+              if(do_hail.or.do_graupel) then
+                 qg(i,k) = max(qg(i,k) + minstrf(i,k), 0._r8)
+                 ng(i,k) = max(ng(i,k) + ninstrf(i,k), 0._r8)
+              else
+                 qs(i,k) = max(qs(i,k) + minstrf(i,k), 0._r8)
+                 ns(i,k) = max(ns(i,k) + ninstrf(i,k), 0._r8)
+              end if
+           end if
+        end if
+     end do
+  end do
+  !$acc end parallel
+
+  !$acc parallel vector_length(VLENS) default(present)
+  !$acc loop gang vector collapse(2)
+  do k=1,nlev
+    do i=1,mgncol
+        ! obtain in-cloud values of cloud water/ice mixing ratios and number concentrations
+        !-------------------------------------------------------
+        ! for microphysical process calculations
+        ! units are kg/kg for mixing ratio, 1/kg for number conc
+
+        if (qc(i,k).ge.qsmall) then
+           ! limit in-cloud values to 0.005 kg/kg
+           qcic(i,k)=min(qc(i,k)/lcldm(i,k),5.e-3_r8)
+           ncic(i,k)=max(nc(i,k)/lcldm(i,k),0._r8)
+
+           ! specify droplet concentration
+           if (nccons) then
+              ncic(i,k)=ncnst/rho(i,k)
+           end if
+        else
+           qcic(i,k)=0._r8
+           ncic(i,k)=0._r8
+        end if
+
+        if (qi(i,k).ge.qsmall) then
+           ! limit in-cloud values to 0.005 kg/kg
+           qiic(i,k)=min(qi(i,k)/icldm(i,k),5.e-3_r8)
+           niic(i,k)=max(ni(i,k)/icldm(i,k),0._r8)
+
+           ! switch for specification of cloud ice number
+           if (nicons) then
+              niic(i,k)=ninst/rho(i,k)
+           end if
+        else
+           qiic(i,k)=0._r8
+           niic(i,k)=0._r8
+        end if
+
+  !========================================================================
+
+  ! for sub-columns cldm has already been set to 1 if cloud
+  ! water or ice is present, so precip_frac will be correctly set below
+  ! and nothing extra needs to be done here
+
+        precip_frac(i,k) = cldm(i,k)
+     end do
+  end do
+  !$acc end parallel
+
+  if (precip_frac_method == MG_PRECIP_FRAC_INCLOUD) then
+     !$acc parallel vector_length(VLENS) default(present)
+     !$acc loop gang vector
+     do i=1,mgncol
+        !$acc loop seq
+        do k=2,nlev
+           if (qc(i,k) < qsmall .and. qi(i,k) < qsmall) then
+              precip_frac(i,k) = precip_frac(i,k-1)
+           end if
+        end do
+     end do
+     !$acc end parallel
+  else if (precip_frac_method == MG_PRECIP_FRAC_OVERLAP) then
+     ! calculate precip fraction based on maximum overlap assumption
+
+     ! if rain or snow mix ratios are smaller than threshold,
+     ! then leave precip_frac as cloud fraction at current level
+
+     !$acc parallel vector_length(VLENS) default(present)
+     !$acc loop gang vector
+     do i=1,mgncol
+        !$acc loop seq
+        do k=2,nlev
+           if (qr(i,k-1) >= qsmall .or. qs(i,k-1) >= qsmall .or. qg(i,k-1) >= qsmall) then
+              precip_frac(i,k)=max(precip_frac(i,k-1),precip_frac(i,k))
+           end if
+        end do
+     end do
+     !$acc end parallel
+  end if
+
+  !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+  ! get size distribution parameters based on in-cloud cloud water
+  ! these calculations also ensure consistency between number and mixing ratio
+  !cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+
+  ! cloud liquid
+  !-------------------------------------------
+  call size_dist_param_liq(mg_liq_props, qcic, ncic, rho, pgam, lamc, mgncol, nlev)
+
+
+  !$acc parallel vector_length(VLENS) default(present)
+  !$acc loop gang vector collapse(2)
+  do k=1,nlev
+     do i=1,mgncol
+        ! assign qric based on prognostic qr, using assumed precip fraction
+        ! note: this could be moved above for consistency with qcic and qiic calculations
+        qric(i,k) = qr(i,k)/precip_frac(i,k)
+        nric(i,k) = nr(i,k)/precip_frac(i,k)
+
+        ! limit in-precip mixing ratios to 10 g/kg
+        qric(i,k)=min(qric(i,k),0.01_r8)
+
+        ! add autoconversion to precip from above to get provisional rain mixing ratio
+        ! and number concentration (qric and nric)
+
+        if (qric(i,k).lt.qsmall) then
+           qric(i,k)=0._r8
+           nric(i,k)=0._r8
+        end if
+
+        ! make sure number concentration is a positive number to avoid
+        ! taking root of negative later
+
+        nric(i,k)=max(nric(i,k),0._r8)
+     end do
+  end do
+  !$acc end parallel
+
+  ! get size distribution parameters for rain
+  !......................................................................
+
+  call size_dist_param_basic(mg_rain_props, qric, nric, lamr, mgncol, nlev, n0=n0r)
+
+  ! Save off size distribution parameters for output
+  !$acc parallel vector_length(VLENS) default(present)
+  !$acc loop gang vector collapse(2)
+  do k=1,nlev
+     do i=1,mgncol
+        proc_rates%pgam_out(i,k)=pgam(i,k)
+        proc_rates%n0r_out(i,k)=n0r(i,k)
+        proc_rates%lamc_out(i,k)=lamc(i,k)
+        proc_rates%lamr_out(i,k)=lamr(i,k)
+     end do
+  end do
+  !$acc end parallel
+
+  !========================================================================
+  ! autoconversion of cloud liquid water to rain
+  ! formula from Khrouditnov and Kogan (2000), modified for sub-grid distribution of qc
+  ! minimum qc of 1 x 10^-8 prevents floating point error
+
+  call kk2000_liq_autoconversion(microp_uniform, qcic, ncic, rho, relvar, &
+                      proc_rates%qctend_KK2000, proc_rates%nrtend_KK2000, &
+                      proc_rates%nctend_KK2000, micro_mg_autocon_fact, &
+                      micro_mg_autocon_nd_exp, micro_mg_autocon_lwp_exp, &
+                      mgncol*nlev)
+
+  ! Write to pumas tendency arrays if kk2000 is active, otherwise just record diagnostics
+
+  if ( trim(warm_rain) == 'kk2000' ) then
+     !$acc parallel vector_length(VLENS) default(present)
+     !$acc loop gang vector collapse(2)
+     do k=1,nlev
+        do i=1,mgncol
+           prc(i,k)=proc_rates%qctend_KK2000(i,k)
+           nprc1(i,k)=proc_rates%nctend_KK2000(i,k)
+           nprc(i,k)=proc_rates%nrtend_KK2000(i,k)
+           proc_rates%qrtend_KK2000(i,k)=-proc_rates%qctend_KK2000(i,k)
+        end do
+     end do
+     !$acc end parallel
+  end if
+
+  if ( trim(warm_rain) == 'tau' ) then
+     call pumas_stochastic_collect_tau_tend(deltatin,t,rho,qcn,qrn,qcic,ncic,qric, &
+                                      nric,lcldm,precip_frac,pgam,lamc,n0r,lamr,   &
+                                      proc_rates%qc_out_TAU,proc_rates%nc_out_TAU, &
+                                      proc_rates%qr_out_TAU,proc_rates%nr_out_TAU, &
+                                      qctend,nctend,qrtend,nrtend, &
+                                      proc_rates%qctend_TAU,proc_rates%nctend_TAU, &
+                                      proc_rates%qrtend_TAU,proc_rates%nrtend_TAU, &
+                                      proc_rates%scale_qc,proc_rates%scale_nc, &
+                                      proc_rates%scale_qr,proc_rates%scale_nr, &
+                                      proc_rates%amk_c,proc_rates%ank_c, &
+                                      proc_rates%amk_r,proc_rates%ank_r, &
+                                      proc_rates%amk, proc_rates%ank, &
+                                      proc_rates%amk_out, proc_rates%ank_out, &
+                                      proc_rates%gmnnn_lmnnn_TAU,mgncol,nlev)
+
+     !$acc parallel vector_length(VLENS) default(present)
+     !$acc loop gang vector collapse(2)
+     do k=1,nlev
+        do i=1,mgncol
+           proc_rates%qc_in_TAU(i,k)=qcic(i,k)
+           proc_rates%nc_in_TAU(i,k)=ncic(i,k)
+           proc_rates%qr_in_TAU(i,k)=qric(i,k)
+           proc_rates%nr_in_TAU(i,k)=nric(i,k)
+           ! PUMAS expects prc and nprc1 (cloud rates) are positive
+           prc(i,k)= -proc_rates%qctend_TAU(i,k)
+           nprc1(i,k)= -proc_rates%nctend_TAU(i,k)
+
+           ! PUMAS expects nprc to be positive. Negative nrtend_TAU is from self collection, so put it into nragg
+           if ( proc_rates%nrtend_TAU(i,k) > 0._r8 ) then
+              nprc(i,k)= proc_rates%nrtend_TAU(i,k)
+           else
+              nragg(i,k) = proc_rates%nrtend_TAU(i,k)
+           end if
+        end do
+     end do
+     !$acc end parallel
+
+  else if (trim(warm_rain) == 'emulated') then
+     ! JS - 08/22/2023: this code block only works on CPU
+
+     !$acc update self(qcic,ncic,qric,nric,rho,lcldm,precip_frac, &
+     !$acc             proc_rates%qctend_TAU,proc_rates%qrtend_TAU, &
+     !$acc             proc_rates%nctend_TAU,proc_rates%nrtend_TAU, &
+     !$acc             qc,nc,qr,nr,prc,nprc1,nprc,nragg)
+
+     do k=1,nlev
+        call tau_emulated_cloud_rain_interactions(qcic(1:mgncol,k), ncic(1:mgncol,k), &
+                                                  qric(1:mgncol,k), nric(1:mgncol,k), &
+                                                  pgam(1:mgncol,k), lamc(1:mgncol,k), &
+                                                  lamr(1:mgncol,k), n0r(1:mgncol,k), &
+                                                  rho(1:mgncol,k), lcldm(1:mgncol,k), &
+                                                  precip_frac(1:mgncol,k), mgncol, qsmall_emulator, &
+                                                  proc_rates%qctend_TAU(1:mgncol,k), &
+                                                  proc_rates%qrtend_TAU(1:mgncol,k), &
+                                                  proc_rates%nctend_TAU(1:mgncol,k), &
+                                                  proc_rates%nrtend_TAU(1:mgncol,k))
+
+        call ML_fixer_calc(mgncol, deltatin, qcic(1:mgncol,k), ncic(1:mgncol,k), &
+                           qric(1:mgncol,k), nric(1:mgncol,k), &
+                           proc_rates%qctend_TAU(1:mgncol,k),&
+                           proc_rates%nctend_TAU(1:mgncol,k), &
+                           proc_rates%qrtend_TAU(1:mgncol,k), &
+                           proc_rates%nrtend_TAU(1:mgncol,k), &
+                           proc_rates%ML_fixer(1:mgncol,k), &
+                           proc_rates%QC_fixer(1:mgncol,k), &
+                           proc_rates%NC_fixer(1:mgncol,k), &
+                           proc_rates%QR_fixer(1:mgncol,k), &
+                           proc_rates%NR_fixer(1:mgncol,k))
+
+        ! PUMAS expects prc and nprc1 (cloud rates) are positive and grid-box averaged
+        do i=1,mgncol
+           prc(i,k)= -proc_rates%qctend_TAU(i,k)*lcldm(i,k)
+           nprc1(i,k)= -proc_rates%nctend_TAU(i,k)*lcldm(i,k)
+        end do
+
+        ! PUMAS expects nprc to be positive. Negative nrtend_TAU is from self
+        ! collection, so put it into nragg. Also make it all precip-averaged
+        do i=1,mgncol
+           if (proc_rates%nrtend_TAU(i,k).gt.0._r8) then
+              nprc(i,k)= proc_rates%nrtend_TAU(i,k)*precip_frac(i,k)
+           else
+              nragg(i,k)= proc_rates%nrtend_TAU(i,k)*precip_frac(i,k)
+           end if
+        end do
+
+     end do
+
+     !$acc update device(proc_rates%qctend_TAU,proc_rates%qrtend_TAU, &
+     !$acc               proc_rates%nctend_TAU,proc_rates%nrtend_TAU, &
+     !$acc               prc,nprc1,nprc,nragg)
+
+  end if
+
+  ! Alternative autoconversion
+  if (trim(warm_rain) == 'sb2001') then
+     call sb2001v2_liq_autoconversion(pgam,qcic,ncic,qric,rho,relvar, &
+                                      proc_rates%qctend_SB2001, &
+                                      proc_rates%nrtend_SB2001, &
+                                      proc_rates%nctend_SB2001, &
+                                      mgncol*nlev)
+
+     !$acc parallel vector_length(VLENS) default(present)
+     !$acc loop gang vector collapse(2)
+     do k=1,nlev
+        do i=1,mgncol
+           prc(i,k)=proc_rates%qctend_SB2001(i,k)
+           nprc(i,k)=proc_rates%nrtend_SB2001(i,k)
+           nprc1(i,k)=proc_rates%nctend_SB2001(i,k)
+           proc_rates%qrtend_SB2001(i,k)= -proc_rates%qctend_SB2001(i,k)
+        end do
+     end do
+     !$acc end parallel
+  end if
+
+  ! Get size distribution parameters for cloud ice
+  call size_dist_param_basic(mg_ice_props, qiic, niic, lami, mgncol, nlev, n0=n0i)
+
+  !.......................................................................
+  ! Autoconversion of cloud ice to snow
+  ! similar to Ferrier (1994)
+  if (do_cldice) then
+     call ice_autoconversion(t, qiic, lami, n0i, dcs, prci, nprci, mgncol*nlev)
+  else
+     ! Add in the particles that we have already converted to snow, and
+     ! don't do any further autoconversion of ice.
+
+     !$acc parallel vector_length(VLENS) default(present)
+     !$acc loop gang vector collapse(2)
+     do k=1,nlev
+        do i=1,mgncol
+           prci(i,k)  = tnd_qsnow(i,k) / cldm(i,k)
+           nprci(i,k) = tnd_nsnow(i,k) / cldm(i,k)
+        end do
+     end do
+     !$acc end parallel
+  end if
+
+  ! note, currently we don't have this
+  ! inside the do_cldice block, should be changed later
+  ! assign qsic based on prognostic qs, using assumed precip fraction
+
+  !$acc parallel vector_length(VLENS) default(present)
+  !$acc loop gang vector collapse(2)
+  do k=1,nlev
+     do i=1,mgncol
+        qsic(i,k) = qs(i,k)/precip_frac(i,k)
+        nsic(i,k) = ns(i,k)/precip_frac(i,k)
+
+        ! limit in-precip mixing ratios to 10 g/kg
+        qsic(i,k)=min(qsic(i,k),0.01_r8)
+
+        ! if precip mix ratio is zero so should number concentration
+        if (qsic(i,k) < qsmall) then
+           qsic(i,k)=0._r8
+           nsic(i,k)=0._r8
+        end if
+
+        ! make sure number concentration is a positive number to avoid
+        ! taking root of negative later
+        nsic(i,k)=max(nsic(i,k),0._r8)
+
+        ! also do this for graupel, which is assumed to be 'precip_frac'
+        qgic(i,k) = qg(i,k)/precip_frac(i,k)
+        ngic(i,k) = ng(i,k)/precip_frac(i,k)
+
+        ! limit in-precip mixing ratios to 10 g/kg
+        qgic(i,k)=min(qgic(i,k),0.01_r8)
+
+        ! if precip mix ratio is zero so should number concentration
+        if (qgic(i,k) < qsmall) then
+           qgic(i,k)=0._r8
+           ngic(i,k)=0._r8
+        end if
+
+        ! make sure number concentration is a positive number to avoid
+        ! taking root of negative later
+        ngic(i,k)=max(ngic(i,k),0._r8)
+     end do
+  end do
+  !$acc end parallel
+
+  !$acc parallel vector_length(VLENS) default(present)
+  !$acc loop gang vector collapse(2)
+  do k=1,nlev
+     do i=1,mgncol
+        if (lamr(i,k) >= qsmall) then
+           dum_2D(i,k)= lamr(i,k)**br
+           ! provisional rain number and mass weighted mean fallspeed (m/s)
+           unr(i,k) = min(arn(i,k)*gamma_br_plus1/dum_2D(i,k),9.1_r8*rhof(i,k))
+           proc_rates%umr(i,k) = min(arn(i,k)*gamma_br_plus4/(6._r8*dum_2D(i,k)),9.1_r8*rhof(i,k))
+        else
+           proc_rates%umr(i,k) = 0._r8
+           unr(i,k) = 0._r8
+        end if
+     end do
+  end do
+  !$acc end parallel
+
+  !......................................................................
+  ! snow
+  call size_dist_param_basic(mg_snow_props, qsic, nsic, lams, mgncol, nlev, n0=n0s)
+
+  !$acc parallel vector_length(VLENS) default(present)
+  !$acc loop gang vector collapse(2)
+  do k=1,nlev
+     do i=1,mgncol
+        if (ifs_sed) then
+           if (lams(i,k) > 0._r8) then
+              proc_rates%ums(i,k) = 1._r8
+              uns(i,k) = 1._r8
+           else
+              proc_rates%ums(i,k) = 0._r8
+              uns(i,k) = 0._r8
+           end if
+        else
+           if (lams(i,k) > 0._r8) then
+              dum_2D(i,k) = lams(i,k)**bs
+              ! provisional snow number and mass weighted mean fallspeed (m/s)
+              proc_rates%ums(i,k) = min(asn(i,k)*gamma_bs_plus4/(6._r8*dum_2D(i,k)),1.2_r8*rhof(i,k))
+              proc_rates%ums(i,k) = proc_rates%ums(i,k)*micro_mg_vtrms_factor
+              uns(i,k) = min(asn(i,k)*gamma_bs_plus1/dum_2D(i,k),1.2_r8*rhof(i,k))
+           else
+              proc_rates%ums(i,k) = 0._r8
+              uns(i,k) = 0._r8
+           end if
+        end if
+     end do
+  end do
+  !$acc end parallel
+
+  !  graupel/hail size distributions and properties
+
+  if (do_hail) then
+     call size_dist_param_basic(mg_hail_props, qgic, ngic, lamg, mgncol, nlev, n0=n0g)
+  end if
+  if (do_graupel) then
+     call size_dist_param_basic(mg_graupel_props, qgic, ngic, lamg, mgncol, nlev, n0=n0g)
+  end if
+
+  !$acc parallel vector_length(VLENS) default(present)
+  !$acc loop gang vector collapse(2)
+  do k=1,nlev
+     do i=1,mgncol
+        if (lamg(i,k) > 0._r8) then
+           dum_2D(i,k) = lamg(i,k)**bgtmp
+           ! provisional graupel/hail number and mass weighted mean fallspeed (m/s)
+           proc_rates%umg(i,k) = min(agn(i,k)*gamma_bg_plus4/(6._r8*dum_2D(i,k)),20._r8*rhof(i,k))
+           ung(i,k) = min(agn(i,k)*gamma_bg_plus1/dum_2D(i,k),20._r8*rhof(i,k))
+        else
+           proc_rates%umg(i,k) = 0._r8
+           ung(i,k) = 0._r8
+        end if
+     end do
+  end do
+  !$acc end parallel
+
+  if (do_cldice) then
+     if (.not. use_hetfrz_classnuc) then
+        ! heterogeneous freezing of cloud water via Bigg, 1953
+        !----------------------------------------------
+        call immersion_freezing(microp_uniform, t, pgam, lamc, qcic, ncic, relvar, mnuccc, nnuccc, mgncol*nlev)
+
+        ! make sure number of droplets frozen does not exceed available ice nuclei concentration
+        ! this prevents 'runaway' droplet freezing
+
+        !$acc parallel vector_length(VLENS) default(present)
+        !$acc loop gang vector collapse(2)
+        do k=1,nlev
+           do i=1,mgncol
+              if (qcic(i,k).ge.qsmall .and. t(i,k).lt.269.15_r8 .and. &
+                   nnuccc(i,k)*lcldm(i,k).gt.nnuccd(i,k)) then
+                 ! scale mixing ratio of droplet freezing with limit
+                 mnuccc(i,k)=mnuccc(i,k)*(nnuccd(i,k)/(nnuccc(i,k)*lcldm(i,k)))
+                 nnuccc(i,k)=nnuccd(i,k)/lcldm(i,k)
+              end if
+           end do
+        end do
+        !$acc end parallel
+
+        call contact_freezing(microp_uniform, t, p, rndst, nacon, pgam, lamc, qcic, ncic, &
+                              relvar, mnucct, nnucct, mgncol*nlev, mdust)
+     else
+        ! Mass of droplets frozen is the average droplet mass, except
+        ! with two limiters: concentration must be at least 1/cm^3, and
+        ! mass must be at least the minimum defined above.
+
+        !$acc parallel vector_length(VLENS) default(present)
+        !$acc loop gang vector collapse(2)
+        do k=1,nlev
+           do i=1,mgncol
+              mi0l(i,k) = qcic(i,k)/max(ncic(i,k), 1.0e6_r8/rho(i,k))
+              mi0l(i,k) = max(mi0l_min, mi0l(i,k))
+              if (qcic(i,k) >= qsmall) then
+                 nnuccc(i,k) = frzimm(i,k)*1.0e6_r8/rho(i,k)
+                 mnuccc(i,k) = nnuccc(i,k)*mi0l(i,k)
+                 nnucct(i,k) = frzcnt(i,k)*1.0e6_r8/rho(i,k)
+                 mnucct(i,k) = nnucct(i,k)*mi0l(i,k)
+                 nnudep(i,k) = frzdep(i,k)*1.0e6_r8/rho(i,k)
+                 mnudep(i,k) = nnudep(i,k)*mi0
+              else
+                 nnuccc(i,k) = 0._r8
+                 mnuccc(i,k) = 0._r8
+                 nnucct(i,k) = 0._r8
+                 mnucct(i,k) = 0._r8
+                 nnudep(i,k) = 0._r8
+                 mnudep(i,k) = 0._r8
+              end if
+           end do
+        end do
+        !$acc end parallel
+     end if
+  else
+     !$acc parallel vector_length(VLENS) default(present)
+     !$acc loop gang vector collapse(2)
+     do k=1,nlev
+        do i=1,mgncol
+           mnuccc(i,k)=0._r8
+           nnuccc(i,k)=0._r8
+           mnucct(i,k)=0._r8
+           nnucct(i,k)=0._r8
+           mnudep(i,k)=0._r8
+           nnudep(i,k)=0._r8
+        end do
+     end do
+     !$acc end parallel
+  end if
+
+
+  call snow_self_aggregation(t, rho, asn, rhosn, qsic, nsic, nsagg, mgncol*nlev)
+
+  call accrete_cloud_water_snow(t, rho, asn, uns, mu, qcic, ncic, qsic, pgam, &
+                                lamc, lams, n0s, psacws, npsacws, mgncol*nlev)
+
+  !$acc parallel vector_length(VLENS) default(present)
+  !$acc loop gang vector collapse(2)
+  do k=1,nlev
+     do i=1,mgncol
+        psacws(i,k) = psacws(i,k)*micro_mg_iaccr_factor
+        npsacws(i,k) = npsacws(i,k)*micro_mg_iaccr_factor
+     end do
+  end do
+  !$acc end parallel
+
+  if (do_cldice) then
+     call secondary_ice_production(t, psacws, msacwi, nsacwi, mgncol*nlev)
+  else
+     !$acc parallel vector_length(VLENS) default(present)
+     !$acc loop gang vector collapse(2)
+     do k=1,nlev
+        do i=1,mgncol
+           nsacwi(i,k) = 0.0_r8
+           msacwi(i,k) = 0.0_r8
+        end do
+     end do
+     !$acc end parallel
+  end if
+
+  call accrete_rain_snow(t, rho, proc_rates%umr, proc_rates%ums, unr, uns, qric, qsic, lamr, &
+                         n0r, lams, n0s, pracs, npracs, mgncol*nlev)
+
+  call heterogeneous_rain_freezing(t, qric, nric, lamr, mnuccr, nnuccr, mgncol*nlev)
+
+  if (trim(warm_rain) == 'sb2001') then
+     call sb2001v2_accre_cld_water_rain(qcic, ncic, qric, rho, relvar, pra, npra, mgncol*nlev)
+     !$acc parallel vector_length(VLENS) default(present)
+     !$acc loop gang vector collapse(2)
+     do k=1,nlev
+        do i=1,mgncol
+           proc_rates%nctend_SB2001(i,k)=proc_rates%nctend_SB2001(i,k)+npra(i,k)
+           proc_rates%qctend_SB2001(i,k)=proc_rates%qctend_SB2001(i,k)+pra(i,k)
+           proc_rates%nrtend_SB2001(i,k)=proc_rates%nrtend_SB2001(i,k)+npra(i,k)  !Sign should be same as prc?
+           proc_rates%qrtend_SB2001(i,k)=proc_rates%qrtend_SB2001(i,k)-pra(i,k)
+        end do
+     end do
+     !$acc end parallel
+  end if
+
+  if (trim(warm_rain) == 'kk2000') then
+     !$acc parallel vector_length(VLENS) default(present)
+     !$acc loop gang vector collapse(2)
+     do k = 1,nlev
+        do i = 1,mgncol
+           rtmp(i,k) = qric(i,k)
+           ctmp(i,k) = qcic(i,k)
+           ntmp(i,k) = ncic(i,k)
+
+           !Option: include recently autoconverted rain (prc, nprc) in accretion
+           if (accre_sees_auto) then
+              rtmp(i,k) = rtmp(i,k) + prc(i,k)*deltat
+              ctmp(i,k) = ctmp(i,k) - prc(i,k)*deltat
+              ntmp(i,k) = ntmp(i,k) - nprc(i,k)*deltat
+           endif
+        end do
+     end do
+     !$acc end parallel
+
+     call accrete_cloud_water_rain(microp_uniform,rtmp,ctmp,ntmp,relvar, &
+                                   accre_enhan,pra,npra,mgncol*nlev)
+
+     !$acc parallel vector_length(VLENS) default(present)
+     !$acc loop gang vector collapse(2)
+     do k = 1,nlev
+        do i = 1,mgncol
+           proc_rates%nctend_KK2000(i,k)=proc_rates%nctend_KK2000(i,k)+npra(i,k)
+           proc_rates%qctend_KK2000(i,k)=proc_rates%qctend_KK2000(i,k)+pra(i,k)
+           proc_rates%nrtend_KK2000(i,k)=proc_rates%nrtend_KK2000(i,k)+npra(i,k)  !Sign consistent with prc,nprc
+           proc_rates%qrtend_KK2000(i,k)=proc_rates%qrtend_KK2000(i,k)-pra(i,k)
+        end do
+     end do
+     !$acc end parallel
+  endif
+
+  !$acc parallel vector_length(VLENS) default(present)
+  !$acc loop gang vector collapse(2)
+  do k=1,nlev
+     do i=1,mgncol
+        pra(i,k) = pra(i,k)*micro_mg_accre_enhan_fact
+        npra(i,k) = npra(i,k)*micro_mg_accre_enhan_fact
+     end do
+  end do
+  !$acc end parallel
+
+  if (trim(warm_rain) == 'kk2000' .or. trim(warm_rain) == 'sb2001') then
+     call self_collection_rain(rho, qric, nric, nragg, mgncol*nlev)
+  end if
+
+  if (do_cldice) then
+     call accrete_cloud_ice_snow(t, rho, asn, qiic, niic, qsic, lams, n0s, prai, nprai, mgncol*nlev)
+  else
+     !$acc parallel vector_length(VLENS) default(present)
+     !$acc loop gang vector collapse(2)
+     do k=1,nlev
+        do i=1,mgncol
+           prai(i,k) = 0._r8
+           nprai(i,k) = 0._r8
+        end do
+     end do
+     !$acc end parallel
+  end if
+
+  call bergeron_process_snow(t, rho, dv, mu, sc, qvl, qvi, asn, qcic, qsic, lams, n0s, bergs, mgncol*nlev)
+  !$acc parallel vector_length(VLENS) default(present)
+  !$acc loop gang vector collapse(2)
+  do k=1,nlev
+     do i=1,mgncol
+        bergs(i,k)=bergs(i,k)*micro_mg_berg_eff_factor
+     end do
+  end do
+  !$acc end parallel
+
+
+  call vapor_deposition_onto_snow(t, q, qs, ns, precip_frac, rho, dv, qvl, &
+      qvi, asn, mu, sc, vap_deps, mgncol*nlev)
+
+
+  if (do_cldice) then
+     call ice_deposition_sublimation(t, q, qi, ni, icldm, rho, dv, qvl, qvi, &
+                                     berg, vap_dep, ice_sublim, mgncol*nlev)
+     !$acc parallel vector_length(VLENS) default(present)
+     !$acc loop gang vector collapse(2)
+     do k=1,nlev
+        do i=1,mgncol
+           berg(i,k)=berg(i,k)*micro_mg_berg_eff_factor
+           if (ice_sublim(i,k) < 0._r8 .and. qi(i,k) > qsmall .and. icldm(i,k) > mincld) then
+              nsubi(i,k) = sublim_factor*ice_sublim(i,k) / qi(i,k) * ni(i,k) / icldm(i,k)
+           else
+              nsubi(i,k) = 0._r8
+           end if
+
+           ! bergeron process should not reduce nc unless
+           ! all ql is removed (which is handled elsewhere)
+           !in fact, nothing in this entire file makes nsubc nonzero.
+           nsubc(i,k) = 0._r8
+
+        end do
+     end do
+     !$acc end parallel
+  end if !do_cldice
+
+! Process rate calls for graupel
+!===================================================================
+
+  if (do_hail.or.do_graupel) then
+     call graupel_collecting_snow(qsic, qric, proc_rates%umr, proc_rates%ums, rho, &
+                                  lamr, n0r, lams, n0s, psacr, mgncol*nlev)
+
+     call graupel_collecting_cld_water(qgic, qcic, ncic, rho, n0g, lamg, bgtmp, agn, psacwg, npsacwg, mgncol*nlev)
+
+     !$acc parallel vector_length(VLENS) default(present)
+     !$acc loop gang vector collapse(2)
+     do k=1,nlev
+        do i=1,mgncol
+           psacwg(i,k) = psacwg(i,k)*micro_mg_iaccr_factor
+           npsacwg(i,k) = npsacwg(i,k)*micro_mg_iaccr_factor
+        end do
+     end do
+     !$acc end parallel
+
+     call graupel_riming_liquid_snow(psacws, qsic, qcic, nsic, rho, rhosn, rhogtmp, asn, &
+                                     lams, n0s, deltat, pgsacw, nscng, mgncol*nlev)
+
+     call graupel_collecting_rain(qric, qgic, proc_rates%umg, proc_rates%umr, ung, unr, rho, n0r, &
+                                  lamr, n0g, lamg, pracg, npracg, mgncol*nlev)
+
+     !$acc parallel vector_length(VLENS) default(present)
+     !$acc loop gang vector collapse(2)
+     do k=1,nlev
+        do i=1,mgncol
+           pracg(i,k) = pracg(i,k)*micro_mg_iaccr_factor
+           npracg(i,k) = npracg(i,k)*micro_mg_iaccr_factor
+        end do
+     end do
+     !$acc end parallel
+
+!AG note: Graupel rain riming snow changes
+!    pracs, npracs, (accretion of rain by snow)  psacr (collection of snow by rain)
+
+     call graupel_rain_riming_snow(pracs, npracs, psacr, qsic, qric, nric, nsic, &
+                                   n0s, lams, n0r, lamr, deltat, pgracs, ngracs, mgncol*nlev)
+
+     call graupel_rime_splintering(t, qcic, qric, qgic, psacwg, pracg, qmultg, nmultg, qmultrg, nmultrg,mgncol*nlev)
+
+
+     call evaporate_sublimate_precip_graupel(t, rho, dv, mu, sc, q, qvl, qvi, lcldm, precip_frac, arn, asn, agn, &
+                                             bgtmp, qcic, qiic, qric, qsic, qgic, lamr, n0r, lams, n0s, lamg, n0g, &
+                                             pre, prds, prdg, am_evp_st, mgncol*nlev, evap_rhthrsh_ifs)
+  else
+     ! Routine without Graupel (original)
+     call evaporate_sublimate_precip(t, rho, dv, mu, sc, q, qvl, qvi, lcldm, precip_frac, arn, asn, qcic, qiic, &
+                                     qric, qsic, lamr, n0r, lams, n0s, pre, prds, am_evp_st, mgncol*nlev, evap_rhthrsh_ifs)
+  end if ! end do_graupel/hail loop
+
+! scale precip evaporation to match IFS 'new' version (option 2)
+  if (evap_scl_ifs) then
+     !$acc parallel vector_length(VLENS) default(present)
+     !$acc loop gang vector collapse(2)
+     do k=1,nlev
+        do i=1,mgncol
+           pre(i,k)= 0.15_r8 * pre(i,k)
+        end do
+     end do
+     !$acc end parallel
+  end if
+
+  !$acc parallel vector_length(VLENS) default(present)
+  !$acc loop gang vector collapse(2)
+  do k=1,nlev
+     do i=1,mgncol
+        ! conservation to ensure no negative values of cloud water/precipitation
+        ! in case microphysical process rates are large
+        !===================================================================
+
+        ! note: for check on conservation, processes are multiplied by omsm
+        ! to prevent problems due to round off error
+
+        ! conservation of qc
+        !-------------------------------------------------------------------
+        dum = ((prc(i,k)+pra(i,k)+mnuccc(i,k)+mnucct(i,k)+msacwi(i,k)+ &
+             psacws(i,k)+bergs(i,k)+qmultg(i,k)+psacwg(i,k)+pgsacw(i,k))*lcldm(i,k)+ &
+             berg(i,k))*deltat
+        if (dum.gt.qc(i,k)) then
+           ratio = qc(i,k)*rdeltat/((prc(i,k)+pra(i,k)+mnuccc(i,k)+mnucct(i,k)+ &
+                msacwi(i,k)+psacws(i,k)+bergs(i,k)+qmultg(i,k)+psacwg(i,k)+pgsacw(i,k))*lcldm(i,k)+&
+                berg(i,k))*omsm
+           qmultg(i,k)=qmultg(i,k)*ratio
+           psacwg(i,k)=psacwg(i,k)*ratio
+           pgsacw(i,k)=pgsacw(i,k)*ratio
+           prc(i,k) = prc(i,k)*ratio
+           pra(i,k) = pra(i,k)*ratio
+           mnuccc(i,k) = mnuccc(i,k)*ratio
+           mnucct(i,k) = mnucct(i,k)*ratio
+           msacwi(i,k) = msacwi(i,k)*ratio
+           psacws(i,k) = psacws(i,k)*ratio
+           bergs(i,k) = bergs(i,k)*ratio
+           berg(i,k) = berg(i,k)*ratio
+           qcrat(i,k) = ratio
+        else
+           qcrat(i,k) = 1._r8
+        end if
+        !PMC 12/3/12: ratio is also frac of step w/ liquid.
+        !thus we apply berg for "ratio" of timestep and vapor
+        !deposition for the remaining frac of the timestep.
+        if (qc(i,k) >= qsmall) then
+           vap_dep(i,k) = vap_dep(i,k)*(1._r8-qcrat(i,k))
+           vap_deps(i,k) = vap_deps(i,k)*(1._r8-qcrat(i,k))
+        end if
+
+        !=================================================================
+        ! apply limiter to ensure that ice/snow sublimation and rain evap
+        ! don't push conditions into supersaturation, and ice deposition/nucleation don't
+        ! push conditions into sub-saturation
+        ! note this is done after qc conservation since we don't know how large
+        ! vap_dep is before then
+        ! estimates are only approximate since other process terms haven't been limited
+        ! for conservation yet
+
+        ! first limit ice deposition/nucleation vap_dep + mnuccd + vap_deps
+        mnuccd(i,k) = max(0._r8,mnuccd(i,k))
+        vap_dep(i,k) = max(0._r8,vap_dep(i,k))
+        vap_deps(i,k) = max(0._r8,vap_deps(i,k))
+
+        dum1 = vap_dep(i,k) + mnuccd(i,k) + vap_deps(i,k)
+        if (dum1 > 1.e-20_r8) then
+           dum = (q(i,k)-qvi(i,k))/(1._r8 + xxls_squared*qvi(i,k)/(cpp*rv*t(i,k)**2))*rdeltat
+           dum = max(dum,0._r8)
+           if (dum1 > dum) then
+              ! Allocate the limited "dum" tendency to mnuccd and vap_dep
+              ! processes. Don't divide by cloud fraction; these are grid-
+              ! mean rates.
+              mnuccd(i,k) = dum*mnuccd(i,k)/dum1
+              vap_dep(i,k) = dum*vap_dep(i,k)/dum1
+              vap_deps(i,k) = dum*vap_deps(i,k)/dum1
+
+           end if
+        end if
+     end do
+  end do
+  !$acc end parallel
+
+  !$acc parallel vector_length(VLENS) default(present)
+  !$acc loop gang vector collapse(2)
+  do k=1,nlev
+     do i=1,mgncol
+        !===================================================================
+        ! conservation of nc
+        !-------------------------------------------------------------------
+        dum = (nprc1(i,k)+npra(i,k)+nnuccc(i,k)+nnucct(i,k)+ &
+               npsacws(i,k)-nsubc(i,k)+npsacwg(i,k))*lcldm(i,k)*deltat
+
+        if (dum.gt.nc(i,k)) then
+           ratio = nc(i,k)*rdeltat/((nprc1(i,k)+npra(i,k)+nnuccc(i,k)+nnucct(i,k)+&
+                   npsacws(i,k)-nsubc(i,k)+npsacwg(i,k))*lcldm(i,k))*omsm
+           npsacwg(i,k) = npsacwg(i,k)*ratio
+           nprc1(i,k)   = nprc1(i,k)*ratio
+           npra(i,k)    = npra(i,k)*ratio
+           nnuccc(i,k)  = nnuccc(i,k)*ratio
+           nnucct(i,k)  = nnucct(i,k)*ratio
+           npsacws(i,k) = npsacws(i,k)*ratio
+           nsubc(i,k)   = nsubc(i,k)*ratio
+        end if
+        mnuccri(i,k)=0._r8
+        nnuccri(i,k)=0._r8
+
+        if (do_cldice) then
+           ! freezing of rain to produce ice if mean rain size is smaller than Dcs
+           if (lamr(i,k) > qsmall) then
+              if (1._r8/lamr(i,k) < Dcs) then
+                 mnuccri(i,k)=mnuccr(i,k)
+                 nnuccri(i,k)=nnuccr(i,k)
+                 mnuccr(i,k)=0._r8
+                 nnuccr(i,k)=0._r8
+              end if
+           end if
+        end if
+     end do
+  end do
+  !$acc end parallel
+
+  !$acc parallel vector_length(VLENS) default(present)
+  !$acc loop gang vector collapse(2)
+  do k=1,nlev
+     do i=1,mgncol
+        ! conservation of rain mixing ratio
+        !-------------------------------------------------------------------
+        dum = ((-pre(i,k)+pracs(i,k)+mnuccr(i,k)+mnuccri(i,k) &
+             +qmultrg(i,k)+pracg(i,k)+pgracs(i,k))*precip_frac(i,k)- &
+             (pra(i,k)+prc(i,k))*lcldm(i,k))*deltat
+        ! note that qrtend is included below because of instantaneous freezing/melt
+        if (dum.gt.qr(i,k).and. &
+             (-pre(i,k)+pracs(i,k)+mnuccr(i,k)+mnuccri(i,k)+qmultrg(i,k)+pracg(i,k)+pgracs(i,k)).ge.qsmall) then
+           ratio = (qr(i,k)*rdeltat+(pra(i,k)+prc(i,k))*lcldm(i,k))/   &
+                precip_frac(i,k)/(-pre(i,k)+pracs(i,k)+mnuccr(i,k)+mnuccri(i,k) &
+                +qmultrg(i,k)+pracg(i,k)+pgracs(i,k))*omsm
+           qmultrg(i,k)= qmultrg(i,k)*ratio
+           pracg(i,k)=pracg(i,k)*ratio
+           pgracs(i,k)=pgracs(i,k)*ratio
+           pre(i,k)=pre(i,k)*ratio
+           pracs(i,k)=pracs(i,k)*ratio
+           mnuccr(i,k)=mnuccr(i,k)*ratio
+           mnuccri(i,k)=mnuccri(i,k)*ratio
+        end if
+
+        ! conservation of rain number
+        !-------------------------------------------------------------------
+        ! Add evaporation of rain number.
+        if (pre(i,k) < 0._r8) then
+           nsubr(i,k) = pre(i,k)*nr(i,k)/qr(i,k)
+        else
+           nsubr(i,k) = 0._r8
+        end if
+
+        dum = ((-nsubr(i,k)+npracs(i,k)+nnuccr(i,k)+nnuccri(i,k)-nragg(i,k)+npracg(i,k)+ngracs(i,k)) &
+             *precip_frac(i,k)- nprc(i,k)*lcldm(i,k))*deltat
+
+        ! Added a check to trap for division by zero errors
+
+        tmpnr = -nsubr(i,k)+npracs(i,k)+nnuccr(i,k)+nnuccri(i,k)-nragg(i,k)+npracg(i,k)+ngracs(i,k)
+        tmpp  = nr(i,k)*rdeltat + nprc(i,k)*lcldm(i,k)
+
+        if (dum.gt.nr(i,k) .and. tmpnr.gt.0._r8 .and. tmpp.gt.0._r8 .and. precip_frac(i,k).gt.0._r8) then
+           ratio = (nr(i,k)*rdeltat+nprc(i,k)*lcldm(i,k))/precip_frac(i,k)/ &
+                (-nsubr(i,k)+npracs(i,k)+nnuccr(i,k)+nnuccri(i,k)-nragg(i,k)+npracg(i,k)+ngracs(i,k))*omsm
+
+           npracg(i,k)=npracg(i,k)*ratio
+           ngracs(i,k)=ngracs(i,k)*ratio
+           nragg(i,k)=nragg(i,k)*ratio
+           npracs(i,k)=npracs(i,k)*ratio
+           nnuccr(i,k)=nnuccr(i,k)*ratio
+           nsubr(i,k)=nsubr(i,k)*ratio
+           nnuccri(i,k)=nnuccri(i,k)*ratio
+        end if
+     end do
+  end do
+  !$acc end parallel
+
+  if (do_cldice) then
+     !$acc parallel vector_length(VLENS) default(present)
+     !$acc loop gang vector collapse(2)
+     do k=1,nlev
+        do i=1,mgncol
+           ! conservation of qi
+           !-------------------------------------------------------------------
+           dum = ((-mnuccc(i,k)-mnucct(i,k)-mnudep(i,k)-msacwi(i,k)-qmultg(i,k))*lcldm(i,k)+(prci(i,k)+ &
+                prai(i,k))*icldm(i,k)+(-qmultrg(i,k)-mnuccri(i,k))*precip_frac(i,k) &
+                -ice_sublim(i,k)-vap_dep(i,k)-berg(i,k)-mnuccd(i,k))*deltat
+           if (dum.gt.qi(i,k)) then
+              ratio = (qi(i,k)*rdeltat+vap_dep(i,k)+berg(i,k)+mnuccd(i,k)+ &
+                   (mnuccc(i,k)+mnucct(i,k)+mnudep(i,k)+msacwi(i,k)+qmultg(i,k))*lcldm(i,k)+ &
+                   (qmultrg(i,k)+mnuccri(i,k))*precip_frac(i,k))/ &
+                   ((prci(i,k)+prai(i,k))*icldm(i,k)-ice_sublim(i,k))*omsm
+              prci(i,k) = prci(i,k)*ratio
+              prai(i,k) = prai(i,k)*ratio
+              ice_sublim(i,k) = ice_sublim(i,k)*ratio
+           end if
+
+           ! conservation of ni
+           !-------------------------------------------------------------------
+           if (use_hetfrz_classnuc) then
+              tmpfrz = nnuccc(i,k)
+           else
+              tmpfrz = 0._r8
+           end if
+           dum = ((-nnucct(i,k)-tmpfrz-nnudep(i,k)-nsacwi(i,k)-nmultg(i,k))*lcldm(i,k)+(nprci(i,k)+ &
+                nprai(i,k)-nsubi(i,k))*icldm(i,k)+(-nmultrg(i,k)-nnuccri(i,k))*precip_frac(i,k)- &
+                nnuccd(i,k))*deltat
+           if (dum.gt.ni(i,k)) then
+              ratio = (ni(i,k)*rdeltat+nnuccd(i,k)+ &
+                 (nnucct(i,k)+tmpfrz+nnudep(i,k)+nsacwi(i,k)+nmultg(i,k))*lcldm(i,k)+ &
+                 (nnuccri(i,k)+nmultrg(i,k))*precip_frac(i,k))/ &
+                 ((nprci(i,k)+nprai(i,k)-nsubi(i,k))*icldm(i,k))*omsm
+              nprci(i,k) = nprci(i,k)*ratio
+              nprai(i,k) = nprai(i,k)*ratio
+              nsubi(i,k) = nsubi(i,k)*ratio
+           end if
+        end do
+     end do
+     !$acc end parallel
+  end if
+
+  !$acc parallel vector_length(VLENS) default(present)
+  !$acc loop gang vector collapse(2)
+  do k=1,nlev
+     do i=1,mgncol
+        ! conservation of snow mixing ratio
+        !-------------------------------------------------------------------
+        if (do_hail .or. do_graupel) then
+        ! NOTE: mnuccr is moved to graupel when active
+        ! psacr is a positive value, but a loss for snow
+        !HM: psacr is positive in dum (two negatives)
+           dum = (-(prds(i,k)+pracs(i,k)-psacr(i,k))*precip_frac(i,k)-(prai(i,k)+prci(i,k))*icldm(i,k) &
+             -(bergs(i,k)+psacws(i,k))*lcldm(i,k) - vap_deps(i,k))*deltat
+        else
+           dum = (-(prds(i,k)+pracs(i,k)+mnuccr(i,k))*precip_frac(i,k)-(prai(i,k)+prci(i,k))*icldm(i,k) &
+             -(bergs(i,k)+psacws(i,k))*lcldm(i,k) - vap_deps(i,k))*deltat
+        end if
+        if (dum.gt.qs(i,k).and.(psacr(i,k)-prds(i,k)).ge.qsmall) then
+           if (do_hail .or. do_graupel) then
+              ratio = (qs(i,k)*rdeltat+(prai(i,k)+prci(i,k))*icldm(i,k)+ &
+                   (bergs(i,k)+psacws(i,k))*lcldm(i,k)+vap_deps(i,k)+pracs(i,k)*precip_frac(i,k))/ &
+                   precip_frac(i,k)/(psacr(i,k)-prds(i,k))*omsm
+              psacr(i,k)=psacr(i,k)*ratio
+           else
+              ratio = (qs(i,k)*rdeltat+(prai(i,k)+prci(i,k))*icldm(i,k)+ &
+                   (bergs(i,k)+psacws(i,k))*lcldm(i,k)+vap_deps(i,k)+(pracs(i,k)+mnuccr(i,k))*precip_frac(i,k))/ &
+                   precip_frac(i,k)/(-prds(i,k))*omsm
+           end if
+           prds(i,k)=prds(i,k)*ratio
+        end if
+
+        ! conservation of snow number
+        !-------------------------------------------------------------------
+        ! calculate loss of number due to sublimation
+        ! for now neglect sublimation of ns
+        nsubs(i,k)=0._r8
+        if (do_hail .or. do_graupel) then
+           dum = ((-nsagg(i,k)-nsubs(i,k)+ngracs(i,k))*precip_frac(i,k)-nprci(i,k)*icldm(i,k)+nscng(i,k)*lcldm(i,k))*deltat
+        else
+           dum = ((-nsagg(i,k)-nsubs(i,k)-nnuccr(i,k))*precip_frac(i,k)-nprci(i,k)*icldm(i,k))*deltat
+        end if
+        if (dum.gt.ns(i,k)) then
+           if (do_hail .or. do_graupel) then
+              ratio = (ns(i,k)*rdeltat+nprci(i,k)*icldm(i,k))/precip_frac(i,k)/ &
+                   (-nsubs(i,k)-nsagg(i,k)+ngracs(i,k)+lcldm(i,k)/precip_frac(i,k)*nscng(i,k))*omsm
+              nscng(i,k)=nscng(i,k)*ratio
+              ngracs(i,k)=ngracs(i,k)*ratio
+           else
+              ratio = (ns(i,k)*rdeltat+nnuccr(i,k)* &
+                   precip_frac(i,k)+nprci(i,k)*icldm(i,k))/precip_frac(i,k)/ &
+                   (-nsubs(i,k)-nsagg(i,k))*omsm
+           endif
+           nsubs(i,k)=nsubs(i,k)*ratio
+           nsagg(i,k)=nsagg(i,k)*ratio
+        end if
+     end do
+  end do
+  !$acc end parallel
+
+! Graupel Conservation Checks
+!-------------------------------------------------------------------
+
+  if (do_hail.or.do_graupel) then
+     ! conservation of graupel mass
+     !-------------------------------------------------------------------
+     !$acc parallel vector_length(VLENS) default(present)
+     !$acc loop gang vector collapse(2)
+     do k=1,nlev
+        do i=1,mgncol
+           dum= ((-pracg(i,k)-pgracs(i,k)-prdg(i,k)-psacr(i,k)-mnuccr(i,k))*precip_frac(i,k) &
+                + (-psacwg(i,k)-pgsacw(i,k))*lcldm(i,k))*deltat
+           if (dum.gt.qg(i,k)) then
+              ! note: prdg is always negative (like prds), so it needs to be subtracted in ratio
+              ratio = (qg(i,k)*rdeltat + (pracg(i,k)+pgracs(i,k)+psacr(i,k)+mnuccr(i,k))*precip_frac(i,k) &
+                       + (psacwg(i,k)+pgsacw(i,k))*lcldm(i,k)) / ((-prdg(i,k))*precip_frac(i,k)) * omsm
+              prdg(i,k)= prdg(i,k)*ratio
+           end if
+        end do
+     end do
+     !$acc end parallel
+     ! conservation of graupel number: not needed, no sinks
+     !-------------------------------------------------------------------
+  end if
+
+  !$acc parallel vector_length(VLENS) default(present)
+  !$acc loop gang vector collapse(2)
+  do k=1,nlev
+     do i=1,mgncol
+        ! next limit ice and snow sublimation and rain evaporation
+        ! get estimate of q and t at end of time step
+        ! don't include other microphysical processes since they haven't
+        ! been limited via conservation checks yet
+        qtmpAI(i,k)=q(i,k)-(ice_sublim(i,k)+vap_dep(i,k)+mnuccd(i,k)+vap_deps(i,k)+ &
+                (pre(i,k)+prds(i,k)+prdg(i,k))*precip_frac(i,k))*deltat
+        ttmpA(i,k)=t(i,k)+((pre(i,k)*precip_frac(i,k))*xxlv+ &
+             ((prds(i,k)+prdg(i,k))*precip_frac(i,k)+vap_dep(i,k)+vap_deps(i,k)+ice_sublim(i,k)+mnuccd(i,k))*xxls)*deltat/cpp
+     end do
+  end do
+  !$acc end parallel
+
+  ! use rhw to allow ice supersaturation
+  call qsat_water(ttmpA, p, esnA, qvnAI, mgncol*nlev)
+
+  !$acc parallel vector_length(VLENS) default(present)
+  !$acc loop gang vector collapse(2)
+  do k=1,nlev
+     do i=1,mgncol
+        if ((pre(i,k)+prds(i,k)+prdg(i,k))*precip_frac(i,k)+ice_sublim(i,k) < -1.e-20_r8) then
+           ! modify ice/precip evaporation rate if q > qsat
+           if (qtmpAI(i,k) > qvnAI(i,k)) then
+              dum1A(i,k)=pre(i,k)*precip_frac(i,k)/((pre(i,k)+prds(i,k)+prdg(i,k))*precip_frac(i,k)+ice_sublim(i,k))
+              dum2A(i,k)=prds(i,k)*precip_frac(i,k)/((pre(i,k)+prds(i,k)+prdg(i,k))*precip_frac(i,k)+ice_sublim(i,k))
+              dum3A(i,k)=prdg(i,k)*precip_frac(i,k)/((pre(i,k)+prds(i,k)+prdg(i,k))*precip_frac(i,k)+ice_sublim(i,k))
+              ! recalculate q and t after vap_dep and mnuccd but without evap or sublim
+              ttmpA(i,k)=t(i,k)+((vap_dep(i,k)+vap_deps(i,k)+mnuccd(i,k))*xxls)*deltat/cpp
+              dum_2D(i,k)=q(i,k)-(vap_dep(i,k)+vap_deps(i,k)+mnuccd(i,k))*deltat
+           end if
+        end if
+     end do
+  end do
+  !$acc end parallel
+
+  ! use rhw to allow ice supersaturation
+  call qsat_water(ttmpA, p, esnA, qvnA, mgncol*nlev)
+
+  !$acc parallel vector_length(VLENS) default(present)
+  !$acc loop gang vector collapse(2)
+  do k=1,nlev
+     do i=1,mgncol
+        if ((pre(i,k)+prds(i,k)+prdg(i,k))*precip_frac(i,k)+ice_sublim(i,k) < -1.e-20_r8) then
+           ! modify ice/precip evaporation rate if q > qsat
+           if (qtmpAI(i,k) > qvnAI(i,k)) then
+              dum=(dum_2D(i,k)-qvnA(i,k))/(1._r8 + xxlv_squared*qvnA(i,k)/(cpp*rv*ttmpA(i,k)**2))
+              dum=min(dum,0._r8)
+              ! modify rates if needed, divide by precip_frac to get local (in-precip) value
+              pre(i,k)=dum*dum1A(i,k)*rdeltat/precip_frac(i,k)
+           end if
+        end if
+     end do
+  end do
+  !$acc end parallel
+
+  ! do separately using RHI for prds and ice_sublim
+  call qsat_ice(ttmpA, p, esnA, qvnA, mgncol*nlev)
+
+  !$acc parallel vector_length(VLENS) default(present)
+  !$acc loop gang vector collapse(2)
+  do k=1,nlev
+     do i=1,mgncol
+        if ((pre(i,k)+prds(i,k)+prdg(i,k))*precip_frac(i,k)+ice_sublim(i,k) < -1.e-20_r8) then
+           ! modify ice/precip evaporation rate if q > qsat
+           if (qtmpAI(i,k) > qvnAI(i,k)) then
+              dum=(dum_2D(i,k)-qvnA(i,k))/(1._r8 + xxls_squared*qvnA(i,k)/(cpp*rv*ttmpA(i,k)**2))
+              dum=min(dum,0._r8)
+              ! modify rates if needed, divide by precip_frac to get local (in-precip) value
+              prds(i,k) = dum*dum2A(i,k)*rdeltat/precip_frac(i,k)
+              prdg(i,k) = dum*dum3A(i,k)*rdeltat/precip_frac(i,k)
+              ! don't divide ice_sublim by cloud fraction since it is grid-averaged
+              dum1A(i,k) = (1._r8-dum1A(i,k)-dum2A(i,k)-dum3A(i,k))
+              ice_sublim(i,k) = dum*dum1A(i,k)*rdeltat
+           end if
+        end if
+
+        ! get tendencies due to microphysical conversion processes
+        !==========================================================
+        ! note: tendencies are multiplied by appropriate cloud/precip
+        ! fraction to get grid-scale values
+        ! note: vap_dep is already grid-average values
+
+        ! The net tendencies need to be added to rather than overwritten,
+        ! because they may have a value already set for instantaneous
+        ! melting/freezing.
+        qvlat(i,k) = qvlat(i,k)-(pre(i,k)+prds(i,k))*precip_frac(i,k)-&
+             vap_dep(i,k)-vap_deps(i,k)-ice_sublim(i,k)-mnuccd(i,k)-mnudep(i,k)*lcldm(i,k) &
+             -prdg(i,k)*precip_frac(i,k)
+        tlat(i,k) = tlat(i,k)+((pre(i,k)*precip_frac(i,k))*xxlv+ &
+             ((prds(i,k)+prdg(i,k))*precip_frac(i,k)+vap_dep(i,k)+vap_deps(i,k)+ice_sublim(i,k)+ &
+             mnuccd(i,k)+mnudep(i,k)*lcldm(i,k))*xxls+ &
+             ((bergs(i,k)+psacws(i,k)+mnuccc(i,k)+mnucct(i,k)+msacwi(i,k)+psacwg(i,k)+ &
+             qmultg(i,k)+pgsacw(i,k))*lcldm(i,k)+ &
+             (mnuccr(i,k)+pracs(i,k)+mnuccri(i,k)+pracg(i,k)+pgracs(i,k)+qmultrg(i,k))*precip_frac(i,k)+ &
+             berg(i,k))*xlf)
+        qctend(i,k) = qctend(i,k)+ &
+             (-pra(i,k)-prc(i,k)-mnuccc(i,k)-mnucct(i,k)-msacwi(i,k)- &
+             psacws(i,k)-bergs(i,k)-qmultg(i,k)-psacwg(i,k)-pgsacw(i,k))*lcldm(i,k)-berg(i,k)
+
+        if (do_cldice) then
+           qitend(i,k) = qitend(i,k)+ &
+                (mnuccc(i,k)+mnucct(i,k)+mnudep(i,k)+msacwi(i,k)+qmultg(i,k))*lcldm(i,k)+(-prci(i,k)- &
+                prai(i,k))*icldm(i,k)+vap_dep(i,k)+berg(i,k)+ice_sublim(i,k)+ &
+                mnuccd(i,k)+(mnuccri(i,k)+qmultrg(i,k))*precip_frac(i,k)
+        end if
+
+        qrtend(i,k) = qrtend(i,k)+ &
+             (pra(i,k)+prc(i,k))*lcldm(i,k)+(pre(i,k)-pracs(i,k)- &
+             mnuccr(i,k)-mnuccri(i,k)-qmultrg(i,k)-pracg(i,k)-pgracs(i,k))*precip_frac(i,k)
+
+        if (do_hail.or.do_graupel) then
+           qgtend(i,k) = qgtend(i,k) + (pracg(i,k)+pgracs(i,k)+prdg(i,k)+psacr(i,k)+mnuccr(i,k))*precip_frac(i,k) &
+                + (psacwg(i,k)+pgsacw(i,k))*lcldm(i,k)
+           qstend(i,k) = qstend(i,k)+ &
+                (prai(i,k)+prci(i,k))*icldm(i,k)+(psacws(i,k)+bergs(i,k))*lcldm(i,k)+(prds(i,k)+ &
+                pracs(i,k)-psacr(i,k))*precip_frac(i,k)+vap_deps(i,k)
+        else
+           !necessary since mnuccr moved to graupel
+           qstend(i,k) = qstend(i,k)+ &
+                (prai(i,k)+prci(i,k))*icldm(i,k)+(psacws(i,k)+bergs(i,k))*lcldm(i,k)+(prds(i,k)+ &
+                pracs(i,k)+mnuccr(i,k))*precip_frac(i,k)+vap_deps(i,k)
+        end if
+     end do
+  end do
+  !$acc end parallel
+
+  !$acc parallel vector_length(VLENS) default(present)
+  !$acc loop gang vector collapse(2)
+  do k=1,nlev
+     do i=1,mgncol
+        cmeout(i,k) = vap_dep(i,k) + ice_sublim(i,k) + mnuccd(i,k) + vap_deps(i,k)
+        ! add output for cmei (accumulate)
+        proc_rates%cmeitot(i,k) = vap_dep(i,k) + ice_sublim(i,k) + mnuccd(i,k) + vap_deps(i,k)
+        !-------------------------------------------------------------------
+        ! evaporation/sublimation is stored here as positive term
+        ! Add to evapsnow via prdg
+        proc_rates%evapsnow(i,k) = (-prds(i,k)-prdg(i,k))*precip_frac(i,k)
+        nevapr(i,k) = -pre(i,k)*precip_frac(i,k)
+        prer_evap(i,k) = -pre(i,k)*precip_frac(i,k)
+        ! change to make sure prain is positive: do not remove snow from
+        ! prain used for wet deposition
+        prain(i,k) = (pra(i,k)+prc(i,k))*lcldm(i,k)+(-pracs(i,k)- &
+             mnuccr(i,k)-mnuccri(i,k))*precip_frac(i,k)
+        if (do_hail .or. do_graupel) then
+           proc_rates%prodsnow(i,k) = (prai(i,k)+prci(i,k))*icldm(i,k)+(psacws(i,k)+bergs(i,k))*lcldm(i,k)+(&
+                pracs(i,k))*precip_frac(i,k)+vap_deps(i,k)
+        else
+           proc_rates%prodsnow(i,k) = (prai(i,k)+prci(i,k))*icldm(i,k)+(psacws(i,k)+bergs(i,k))*lcldm(i,k)+(&
+                pracs(i,k)+mnuccr(i,k))*precip_frac(i,k)+vap_deps(i,k)
+        end if
+        ! following are used to calculate 1st order conversion rate of cloud water
+        !    to rain and snow (1/s), for later use in aerosol wet removal routine
+        ! previously, wetdepa used (prain/qc) for this, and the qc in wetdepa may be smaller than the qc
+        !    used to calculate pra, prc, ... in this routine
+        ! qcsinksum_rate1ord = { rate of direct transfer of cloud water to rain & snow }
+        !                      (no cloud ice or bergeron terms)
+        qcsinksum_rate1ord(i,k) = (pra(i,k)+prc(i,k)+psacws(i,k)+psacwg(i,k)+pgsacw(i,k))*lcldm(i,k)
+        ! Avoid zero/near-zero division.
+        qcsinksum_rate1ord(i,k) = qcsinksum_rate1ord(i,k) / &
+             max(qc(i,k),1.0e-30_r8)
+     end do
+  end do
+  !$acc end parallel
+
+  !$acc parallel vector_length(VLENS) default(present)
+  !$acc loop gang vector collapse(2)
+  do k=1,nlev
+     do i=1,mgncol
+        ! microphysics output, note this is grid-averaged
+        proc_rates%pratot(i,k)     = pra(i,k)*lcldm(i,k)
+        proc_rates%prctot(i,k)     = prc(i,k)*lcldm(i,k)
+        proc_rates%mnuccctot(i,k)  = mnuccc(i,k)*lcldm(i,k)
+        proc_rates%mnudeptot(i,k)  = mnudep(i,k)*lcldm(i,k)
+        proc_rates%mnuccttot(i,k)  = mnucct(i,k)*lcldm(i,k)
+        proc_rates%msacwitot(i,k)  = msacwi(i,k)*lcldm(i,k)
+        proc_rates%psacwstot(i,k)  = psacws(i,k)*lcldm(i,k)
+        proc_rates%bergstot(i,k)   = bergs(i,k)*lcldm(i,k)
+        proc_rates%vapdepstot(i,k) = vap_deps(i,k)
+        proc_rates%bergtot(i,k)    = berg(i,k)
+        proc_rates%prcitot(i,k)    = prci(i,k)*icldm(i,k)
+        proc_rates%praitot(i,k)    = prai(i,k)*icldm(i,k)
+        proc_rates%mnuccdtot(i,k)  = mnuccd(i,k)*icldm(i,k)
+        proc_rates%pracstot(i,k)   = pracs(i,k)*precip_frac(i,k)
+        proc_rates%mnuccrtot(i,k)  = mnuccr(i,k)*precip_frac(i,k)
+        proc_rates%mnuccritot(i,k) = mnuccri(i,k)*precip_frac(i,k)
+        proc_rates%psacrtot(i,k)   = psacr(i,k)*precip_frac(i,k)
+        proc_rates%pracgtot(i,k)   = pracg(i,k)*precip_frac(i,k)
+        proc_rates%psacwgtot(i,k)  = psacwg(i,k)*lcldm(i,k)
+        proc_rates%pgsacwtot(i,k)  = pgsacw(i,k)*lcldm(i,k)
+        proc_rates%pgracstot(i,k)  = pgracs(i,k)*precip_frac(i,k)
+        proc_rates%prdgtot(i,k)    = prdg(i,k)*precip_frac(i,k)
+        proc_rates%qmultgtot(i,k)  = qmultg(i,k)*lcldm(i,k)
+        proc_rates%qmultrgtot(i,k) = qmultrg(i,k)*precip_frac(i,k)
+        proc_rates%npracgtot(i,k)  = npracg(i,k)*precip_frac(i,k)
+        proc_rates%nscngtot(i,k)   = nscng(i,k)*lcldm(i,k)
+        proc_rates%ngracstot(i,k)  = ngracs(i,k)*precip_frac(i,k)
+        proc_rates%nmultgtot(i,k)  = nmultg(i,k)*lcldm(i,k)
+        proc_rates%nmultrgtot(i,k) = nmultrg(i,k)*precip_frac(i,k)
+        proc_rates%npsacwgtot(i,k) = npsacwg(i,k)*lcldm(i,k)
+
+        proc_rates%nnuccctot(i,k) = nnuccc(i,k)*lcldm(i,k)
+        proc_rates%nnuccttot(i,k) = nnucct(i,k)*lcldm(i,k)
+        proc_rates%nnuccdtot(i,k) = nnuccd(i,k)*icldm(i,k)
+        proc_rates%nnudeptot(i,k) = nnudep(i,k)*lcldm(i,k)
+        proc_rates%nnuccrtot(i,k) = nnuccr(i,k)*precip_frac(i,k)
+        proc_rates%nnuccritot(i,k) = nnuccri(i,k)*precip_frac(i,k)
+        proc_rates%nsacwitot(i,k) = nsacwi(i,k)*lcldm(i,k)
+        proc_rates%npratot(i,k) = npra(i,k)*lcldm(i,k)
+        proc_rates%npsacwstot(i,k) = npsacws(i,k)*lcldm(i,k)
+        proc_rates%npraitot(i,k) = nprai(i,k)*icldm(i,k)
+        proc_rates%npracstot(i,k) = npracs(i,k)*precip_frac(i,k)
+        proc_rates%nprctot(i,k) = nprc(i,k)*lcldm(i,k)
+        proc_rates%nraggtot(i,k) = nragg(i,k)*precip_frac(i,k)
+        proc_rates%nprcitot(i,k) = nprci(i,k)*icldm(i,k)
+        proc_rates%nmeltstot(i,k) = ninstsm(i,k)/deltat
+        proc_rates%nmeltgtot(i,k) = ninstgm(i,k)/deltat
+     end do
+  end do
+  !$acc end parallel
+
+  !$acc parallel vector_length(VLENS) default(present)
+  !$acc loop gang vector collapse(2)
+  do k=1,nlev
+     do i=1,mgncol
+        nctend(i,k) = nctend(i,k)+&
+           (-nnuccc(i,k)-nnucct(i,k)-npsacws(i,k)+nsubc(i,k) &
+           -npra(i,k)-nprc1(i,k)-npsacwg(i,k))*lcldm(i,k)
+
+        if (do_cldice) then
+           if (use_hetfrz_classnuc) then
+              tmpfrz = nnuccc(i,k)
+           else
+              tmpfrz = 0._r8
+           end if
+           nitend(i,k) = nitend(i,k)+ nnuccd(i,k)+ &
+                (nnucct(i,k)+tmpfrz+nnudep(i,k)+nsacwi(i,k)+nmultg(i,k))*lcldm(i,k)+(nsubi(i,k)-nprci(i,k)- &
+                nprai(i,k))*icldm(i,k)+(nnuccri(i,k)+nmultrg(i,k))*precip_frac(i,k)
+        end if
+
+        if(do_graupel.or.do_hail) then
+           nstend(i,k) = nstend(i,k)+(nsubs(i,k)+ &
+                nsagg(i,k)-ngracs(i,k))*precip_frac(i,k)+nprci(i,k)*icldm(i,k)-nscng(i,k)*lcldm(i,k)
+           ngtend(i,k) = ngtend(i,k)+nscng(i,k)*lcldm(i,k)+(ngracs(i,k)+nnuccr(i,k))*precip_frac(i,k)
+        else
+           !necessary since mnuccr moved to graupel
+           nstend(i,k) = nstend(i,k)+(nsubs(i,k)+ &
+                nsagg(i,k)+nnuccr(i,k))*precip_frac(i,k)+nprci(i,k)*icldm(i,k)
+        end if
+
+        nrtend(i,k) = nrtend(i,k)+ &
+             nprc(i,k)*lcldm(i,k)+(nsubr(i,k)-npracs(i,k)-nnuccr(i,k) &
+             -nnuccri(i,k)+nragg(i,k)-npracg(i,k)-ngracs(i,k))*precip_frac(i,k)
+
+        !-----------------------------------------------------
+        ! convert rain/snow q and N for output to history, note,
+        ! output is for gridbox average
+
+        qrout(i,k) = qr(i,k)
+        nrout(i,k) = nr(i,k) * rho(i,k)
+        qsout(i,k) = qs(i,k)
+        nsout(i,k) = ns(i,k) * rho(i,k)
+        qgout(i,k) = qg(i,k)
+        ngout(i,k) = ng(i,k) * rho(i,k)
+     end do
+  end do
+  !$acc end parallel
+
+  ! calculate n0r and lamr from rain mass and number
+  ! divide by precip fraction to get in-precip (local) values of
+  ! rain mass and number, divide by rhow to get rain number in kg^-1
+  call size_dist_param_basic(mg_rain_props, qric, nric, lamr, mgncol, nlev, n0=n0r)
+
+  ! Calculate rercld
+  ! calculate mean size of combined rain and cloud water
+  call calc_rercld(lamr, n0r, lamc, pgam, qric, qcic, ncic, rercld, mgncol*nlev)
+
+  ! Assign variables back to start-of-timestep values
+  ! Some state variables are changed before the main microphysics loop
+  ! to make "instantaneous" adjustments. Afterward, we must move those changes
+  ! back into the tendencies.
+  ! These processes:
+  !  - Droplet activation (npccn, impacts nc)
+  !  - Instantaneous snow melting  (minstsm/ninstsm, impacts qr/qs/nr/ns)
+  !  - Instantaneous rain freezing (minstfr/ninstrf, impacts qr/qs/nr/ns)
+  !================================================================================
+  ! Re-apply droplet activation tendency
+
+  !$acc parallel vector_length(VLENS) default(present)
+  !$acc loop gang vector collapse(2)
+  do k=1,nlev
+     do i=1,mgncol
+        nc(i,k) = ncn(i,k)
+        nctend(i,k) = nctend(i,k) + npccn(i,k)
+        ! Re-apply rain freezing and snow melting.
+        dum_2D(i,k) = qs(i,k)
+        qs(i,k)     = qsn(i,k)
+        qstend(i,k) = qstend(i,k) + (dum_2D(i,k)-qs(i,k))*rdeltat
+
+        dum_2D(i,k) = ns(i,k)
+        ns(i,k)     = nsn(i,k)
+        nstend(i,k) = nstend(i,k) + (dum_2D(i,k)-ns(i,k))*rdeltat
+
+        dum_2D(i,k) = qr(i,k)
+        qr(i,k)     = qrn(i,k)
+        qrtend(i,k) = qrtend(i,k) + (dum_2D(i,k)-qr(i,k))*rdeltat
+
+        dum_2D(i,k) = nr(i,k)
+        nr(i,k)     = nrn(i,k)
+        nrtend(i,k) = nrtend(i,k) + (dum_2D(i,k)-nr(i,k))*rdeltat
+
+        ! Re-apply graupel freezing/melting
+        dum_2D(i,k) = qg(i,k)
+        qg(i,k)     = qgr(i,k)
+        qgtend(i,k) = qgtend(i,k) + (dum_2D(i,k)-qg(i,k))*rdeltat
+
+        dum_2D(i,k) = ng(i,k)
+        ng(i,k)     = ngr(i,k)
+        ngtend(i,k) = ngtend(i,k) + (dum_2D(i,k)-ng(i,k))*rdeltat
+        !.............................................................................
+        !================================================================================
+        ! modify to include snow. in prain & evap (diagnostic here: for wet dep)
+        nevapr(i,k) = nevapr(i,k) + proc_rates%evapsnow(i,k)
+        prain(i,k) = prain(i,k) + proc_rates%prodsnow(i,k)
+     end do
+  end do
+  !$acc end parallel
+
+  !$acc parallel vector_length(VLENS) default(present)
+  !$acc loop gang vector collapse(2)
+  do k=1,nlev
+     do i=1,mgncol
+        ! calculate sedimentation for cloud water and ice
+        ! and Graupel (mg3)
+        !================================================================================
+        ! update in-cloud cloud mixing ratio and number concentration
+        ! with microphysical tendencies to calculate sedimentation, assign to dummy vars
+        ! note: these are in-cloud values***, hence we divide by cloud fraction
+        dumc(i,k)  = (qc(i,k)+qctend(i,k)*deltat)/lcldm(i,k)
+        dumi(i,k)  = (qi(i,k)+qitend(i,k)*deltat)/icldm(i,k)
+        dumnc(i,k) = max((nc(i,k)+nctend(i,k)*deltat)/lcldm(i,k),0._r8)
+        dumni(i,k) = max((ni(i,k)+nitend(i,k)*deltat)/icldm(i,k),0._r8)
+
+        dumr(i,k)  = (qr(i,k)+qrtend(i,k)*deltat)/precip_frac(i,k)
+        dumnr(i,k) = max((nr(i,k)+nrtend(i,k)*deltat)/precip_frac(i,k),0._r8)
+        dums(i,k)  = (qs(i,k)+qstend(i,k)*deltat)/precip_frac(i,k)
+        dumns(i,k) = max((ns(i,k)+nstend(i,k)*deltat)/precip_frac(i,k),0._r8)
+
+        dumg(i,k)  = (qg(i,k)+qgtend(i,k)*deltat)/precip_frac(i,k)
+        dumng(i,k) = max((ng(i,k)+ngtend(i,k)*deltat)/precip_frac(i,k),0._r8)
+
+        ! switch for specification of droplet and crystal number
+        if (ngcons) then
+           dumng(i,k)=ngnst/rho(i,k)
+        end if
+
+        ! switch for specification of droplet and crystal number
+        if (nccons) then
+           dumnc(i,k)=ncnst/rho(i,k)
+        end if
+
+        ! switch for specification of cloud ice number
+        if (nicons) then
+           dumni(i,k)=ninst/rho(i,k)
+        end if
+
+        ! switch for specification of constant number
+        if (nscons) then
+            dumns(i,k)=nsnst/rho(i,k)
+        end if
+
+        ! switch for specification of constant number
+        if (nrcons) then
+            dumnr(i,k)=nrnst/rho(i,k)
+        end if
+     end do
+  end do
+  !$acc end parallel
+
+  ! obtain new slope parameter to avoid possible singularity
+  call size_dist_param_basic(mg_ice_props, dumi, dumni, lami, mgncol, nlev)
+  call size_dist_param_liq(mg_liq_props, dumc, dumnc, rho, pgam, lamc, mgncol, nlev)
+
+  ! fallspeed for rain
+  call size_dist_param_basic(mg_rain_props, dumr, dumnr, lamr, mgncol, nlev)
+  ! fallspeed for snow
+  call size_dist_param_basic(mg_snow_props, dums, dumns, lams, mgncol, nlev)
+  ! fallspeed for graupel
+  if (do_hail) then
+     call size_dist_param_basic(mg_hail_props, dumg, dumng, lamg, mgncol, nlev)
+  end if
+  if (do_graupel) then
+     call size_dist_param_basic(mg_graupel_props, dumg, dumng, lamg, mgncol, nlev)
+  end if
+
+  if ( do_implicit_fall ) then
+!    calculate interface height for implicit sedimentation
+!    uses Hypsometric equation
+
+     !$acc parallel vector_length(VLENS) default(present)
+     !$acc loop gang vector
+     do i=1,mgncol
+        zint(i,nlev+1)=0._r8
+        !$acc loop seq
+        do k = nlev,1,-1
+           H = r*t(i,k)/g*log(pint(i,k+1)/pint(i,k))
+           zint(i,k)=zint(i,k+1)+H
+        enddo
+     enddo
+     !$acc end parallel
+  end if
+
+  !$acc parallel vector_length(VLENS) default(present) async(LQUEUE)
+  !$acc loop gang vector collapse(2)
+  do k=1,nlev
+     do i=1,mgncol
+        ! calculate number and mass weighted fall velocity for droplets and cloud ice
+        !-------------------------------------------------------------------
+        if (dumc(i,k).ge.qsmall) then
+           dum1 = 4._r8+bc+pgam(i,k)
+           dum2 = pgam(i,k)+4._r8
+           proc_rates%vtrmc(i,k)=acn(i,k)*gamma(dum1)/(lamc(i,k)**bc*gamma(dum2))
+           ! Following ifs, no condensate sedimentation
+           if (ifs_sed) then
+              fc(i,k)  = 0._r8
+              fnc(i,k) = 0._r8
+           else
+              dum3     = 1._r8+bc+pgam(i,k)
+              dum4     = pgam(i,k)+1._r8
+              fc(i,k)  = g*rho(i,k)*proc_rates%vtrmc(i,k)
+              fnc(i,k) = g*rho(i,k)* &
+                   acn(i,k)*gamma(dum3)/ &
+                   (lamc(i,k)**bc*gamma(dum4))
+           end if
+        else
+           fc(i,k) = 0._r8
+           fnc(i,k)= 0._r8
+        end if
+
+        ! redefine dummy variables - sedimentation is calculated over grid-scale
+        ! quantities to ensure conservation
+        dumc(i,k) = (qc(i,k)+qctend(i,k)*deltat)
+        dumnc(i,k) = max((nc(i,k)+nctend(i,k)*deltat),0._r8)
+        if (dumc(i,k).lt.qsmall) dumnc(i,k)=0._r8
+     end do
+  end do
+  !$acc end parallel
+
+  !$acc parallel vector_length(VLENS) default(present) async(IQUEUE)
+  !$acc loop gang vector collapse(2)
+  do k=1,nlev
+     do i=1,mgncol
+        ! calculate number and mass weighted fall velocity for cloud ice
+        if (dumi(i,k).ge.qsmall) then
+           proc_rates%vtrmi(i,k)=min(ain(i,k)*gamma_bi_plus4/(6._r8*lami(i,k)**bi), &
+                1.2_r8*rhof(i,k))
+           proc_rates%vtrmi(i,k)=proc_rates%vtrmi(i,k)*micro_mg_vtrmi_factor
+
+           fi(i,k) = g*rho(i,k)*proc_rates%vtrmi(i,k)
+           fni(i,k) = g*rho(i,k)* &
+                min(ain(i,k)*gamma_bi_plus1/lami(i,k)**bi,1.2_r8*rhof(i,k))
+
+           ! adjust the ice fall velocity for smaller (r < 20 um) ice
+           ! particles (blend over 8-20 um)
+           irad = 1.5_r8 / lami(i,k) * 1e6_r8
+           ifrac = min(1._r8, max(0._r8, (irad - 18._r8) / 2._r8))
+
+           if (ifrac .lt. 1._r8) then
+              proc_rates%vtrmi(i,k) = ifrac * proc_rates%vtrmi(i,k) + &
+                 (1._r8 - ifrac) * &
+                 min(ajn(i,k)*gamma_bj_plus4/(6._r8*lami(i,k)**bj), &
+                 1.2_r8*rhof(i,k))
+              proc_rates%vtrmi(i,k)=proc_rates%vtrmi(i,k)*micro_mg_vtrmi_factor
+
+              fi(i,k)  = g*rho(i,k)*proc_rates%vtrmi(i,k)
+              fni(i,k) = ifrac * fni(i,k) + &
+                 (1._r8 - ifrac) * &
+                 g*rho(i,k)* &
+                 min(ajn(i,k)*gamma_bj_plus1/lami(i,k)**bj,1.2_r8*rhof(i,k))
+           end if
+
+           ! Fix ice fall speed following IFS microphysics
+           if (ifs_sed) then
+              fi(i,k)=g*rho(i,k)*0.1_r8
+              fni(i,k)=g*rho(i,k)*0.1_r8
+           end if
+        else
+           fi(i,k) = 0._r8
+           fni(i,k)= 0._r8
+        end if
+
+        ! redefine dummy variables - sedimentation is calculated over grid-scale
+        ! quantities to ensure conservation
+        dumi(i,k) = (qi(i,k)+qitend(i,k)*deltat)
+        dumni(i,k) = max((ni(i,k)+nitend(i,k)*deltat),0._r8)
+        if (dumi(i,k).lt.qsmall) dumni(i,k)=0._r8
+     end do
+  end do
+  !$acc end parallel
+
+  !$acc parallel vector_length(VLENS) default(present) async(RQUEUE)
+  !$acc loop gang vector
+  do i=1,mgncol
+     !$acc loop seq
+     do k=1,nlev
+        if (lamr(i,k).ge.qsmall) then
+           qtmp = lamr(i,k)**br
+           ! 'final' values of number and mass weighted mean fallspeed for rain (m/s)
+           unr(i,k) = min(arn(i,k)*gamma_br_plus1/qtmp,9.1_r8*rhof(i,k))
+           fnr(i,k) = g*rho(i,k)*unr(i,k)
+           proc_rates%umr(i,k) = min(arn(i,k)*gamma_br_plus4/(6._r8*qtmp),9.1_r8*rhof(i,k))
+           fr(i,k) = g*rho(i,k)*proc_rates%umr(i,k)
+        else
+           fr(i,k)=0._r8
+           fnr(i,k)=0._r8
+        end if
+
+        ! Fallspeed correction to ensure non-zero if rain in the column
+        ! from updated Morrison (WRFv3.3) and P3 schemes
+        ! If fallspeed exists at a higher level, apply it below to eliminate
+        if (precip_fall_corr) then
+           if (k.gt.2) then
+              if (fr(i,k).lt.1.e-10_r8) then
+                 fr(i,k)=fr(i,k-1)
+                 fnr(i,k)=fnr(i,k-1)
+              end if
+           end if
+        end if
+
+        ! redefine dummy variables - sedimentation is calculated over grid-scale
+        ! quantities to ensure conservation
+        dumr(i,k) = (qr(i,k)+qrtend(i,k)*deltat)
+        dumnr(i,k) = max((nr(i,k)+nrtend(i,k)*deltat),0._r8)
+        if (dumr(i,k).lt.qsmall) dumnr(i,k)=0._r8
+     end do
+  end do
+  !$acc end parallel
+
+  !$acc parallel vector_length(VLENS) default(present) async(SQUEUE)
+  !$acc loop gang vector
+  do i=1,mgncol
+     !$acc loop seq
+     do k=1,nlev
+        if (lams(i,k).ge.qsmall) then
+           qtmp = lams(i,k)**bs
+           ! 'final' values of number and mass weighted mean fallspeed for snow (m/s)
+           proc_rates%ums(i,k) = min(asn(i,k)*gamma_bs_plus4/(6._r8*qtmp),1.2_r8*rhof(i,k))
+           proc_rates%ums(i,k) = proc_rates%ums(i,k)*micro_mg_vtrms_factor
+
+           fs(i,k)  = g*rho(i,k)*proc_rates%ums(i,k)
+           uns(i,k) = min(asn(i,k)*gamma_bs_plus1/qtmp,1.2_r8*rhof(i,k))
+           fns(i,k) = g*rho(i,k)*uns(i,k)
+           ! Fix fallspeed for snow
+           if (ifs_sed) then
+              proc_rates%ums(i,k) = 1._r8
+              uns(i,k) = 1._r8
+            end if
+        else
+           fs(i,k)=0._r8
+           fns(i,k)=0._r8
+        end if
+
+        if (precip_fall_corr) then
+           if (k.gt.2) then
+              if (fs(i,k).lt.1.e-10_r8) then
+                 fs(i,k)=fs(i,k-1)
+                 fns(i,k)=fns(i,k-1)
+              end if
+           end if
+        end if
+
+        ! redefine dummy variables - sedimentation is calculated over grid-scale
+        ! quantities to ensure conservation
+        dums(i,k) = (qs(i,k)+qstend(i,k)*deltat)
+        dumns(i,k) = max((ns(i,k)+nstend(i,k)*deltat),0._r8)
+        if (dums(i,k).lt.qsmall) dumns(i,k)=0._r8
+     end do
+  end do
+  !$acc end parallel
+
+  !$acc parallel vector_length(VLENS) default(present) async(GQUEUE)
+  !$acc loop gang vector
+  do i=1,mgncol
+     !$acc loop seq
+     do k=1,nlev
+        if (lamg(i,k).ge.qsmall) then
+           qtmp = lamg(i,k)**bgtmp
+           ! 'final' values of number and mass weighted mean fallspeed for graupel (m/s)
+           proc_rates%umg(i,k) = min(agn(i,k)*gamma_bg_plus4/(6._r8*qtmp),20._r8*rhof(i,k))
+           fg(i,k) = g*rho(i,k)*proc_rates%umg(i,k)
+           ung(i,k) = min(agn(i,k)*gamma_bg_plus1/qtmp,20._r8*rhof(i,k))
+           fng(i,k) = g*rho(i,k)*ung(i,k)
+        else
+           fg(i,k)=0._r8
+           fng(i,k)=0._r8
+        end if
+
+        if (precip_fall_corr) then
+           if (k.gt.2) then
+              if (fg(i,k).lt.1.e-10_r8) then
+                 fg(i,k)=fg(i,k-1)
+                 fng(i,k)=fng(i,k-1)
+              end if
+           end if
+        end if
+
+        ! redefine dummy variables - sedimentation is calculated over grid-scale
+        ! quantities to ensure conservation
+        dumg(i,k) = (qg(i,k)+qgtend(i,k)*deltat)
+        dumng(i,k) = max((ng(i,k)+ngtend(i,k)*deltat),0._r8)
+        if (dumg(i,k).lt.qsmall) dumng(i,k)=0._r8
+     end do
+  end do
+  !$acc end parallel
+
+! ----------------------------------------------
+! Sedimentation
+! ----------------------------------------------
+
+if ( do_implicit_fall ) then
+
+! Implicit Sedimentation calculation: from Guo et al, 2021, GFDL version.
+
+  !$acc parallel vector_length(VLENS) default(present) async(LQUEUE)
+  !$acc loop gang vector collapse(2)
+  do k=1,nlev
+     do i=1,mgncol
+        fc(i,k)  = vfac_drop * fc(i,k)/g/rho(i,k)
+        fnc(i,k) = vfac_drop * fnc(i,k)/g/rho(i,k)
+     end do
+  end do
+  !$acc end parallel
+
+  !$acc parallel vector_length(VLENS) default(present) async(IQUEUE)
+  !$acc loop gang vector collapse(2)
+  do k=1,nlev
+     do i=1,mgncol
+        fi(i,k)  = vfac_ice  * fi(i,k)/g/rho(i,k)
+        fni(i,k) = vfac_ice  * fni(i,k)/g/rho(i,k)
+     end do
+  end do
+  !$acc end parallel
+
+  !$acc parallel vector_length(VLENS) default(present) async(RQUEUE)
+  !$acc loop gang vector collapse(2)
+  do k=1,nlev
+     do i=1,mgncol
+        fr(i,k)  = vfactor * fr(i,k)/g/rho(i,k)
+        fnr(i,k) = vfactor * fnr(i,k)/g/rho(i,k)
+     end do
+  end do
+  !$acc end parallel
+
+  !$acc parallel vector_length(VLENS) default(present) async(SQUEUE)
+  !$acc loop gang vector collapse(2)
+  do k=1,nlev
+     do i=1,mgncol
+        fs(i,k)  = vfactor * fs(i,k)/g/rho(i,k)
+        fns(i,k) = vfactor * fns(i,k)/g/rho(i,k)
+     end do
+  end do
+  !$acc end parallel
+
+  !$acc parallel vector_length(VLENS) default(present) async(GQUEUE)
+  !$acc loop gang vector collapse(2)
+  do k=1,nlev
+     do i=1,mgncol
+        fg(i,k)  = vfactor * fg(i,k)/g/rho(i,k)
+        fng(i,k) = vfactor * fng(i,k)/g/rho(i,k)
+     end do
+  end do
+  !$acc end parallel
+
+  ! cloud water mass sedimentation
+
+  call Sedimentation_implicit(mgncol,nlev,deltat,zint,pdel,dumc,fc,.FALSE.,qctend, &
+                              LQUEUE,xflx=lflx,qxsedten=proc_rates%qcsedten,prect=prect_l)
+
+  ! cloud water number sedimentation
+  call Sedimentation_implicit(mgncol,nlev,deltat,zint,pdel,dumnc,fnc,.FALSE.,nctend, &
+                              LQUEUE,qxsedten=proc_rates%ncsedten)
+
+  ! cloud ice mass sedimentation
+
+   call Sedimentation_implicit(mgncol,nlev,deltat,zint,pdel,dumi,fi,.FALSE.,qitend, &
+                               IQUEUE,xflx=iflx,qxsedten=proc_rates%qisedten,prect=prect_i,preci=preci_i)
+
+  ! cloud ice number sedimentation
+
+  call Sedimentation_implicit(mgncol,nlev,deltat,zint,pdel,dumni,fni,.FALSE.,nitend, &
+                              IQUEUE,qxsedten=proc_rates%nisedten)
+
+  ! rain water mass sedimentation
+
+  call Sedimentation_implicit(mgncol,nlev,deltat,zint,pdel,dumr,fr,.TRUE.,qrtend, &
+                              RQUEUE,xflx=rflx,qxsedten=proc_rates%qrsedten,prect=prect_r)
+
+  ! rain water number sedimentation
+
+  call Sedimentation_implicit(mgncol,nlev,deltat,zint,pdel,dumnr,fnr,.TRUE.,nrtend, &
+                              RQUEUE,qxsedten=proc_rates%nrsedten)
+
+  ! snow water mass sedimentation
+
+  call Sedimentation_implicit(mgncol,nlev,deltat,zint,pdel,dums,fs,.TRUE.,qstend, &
+                              SQUEUE,xflx=sflx,qxsedten=proc_rates%qssedten,prect=prect_s,preci=preci_s)
+
+  ! snow water number sedimentation
+
+  call Sedimentation_implicit(mgncol,nlev,deltat,zint,pdel,dumns,fns,.TRUE.,nstend, &
+                              SQUEUE,qxsedten=proc_rates%nssedten)
+
+  ! graupel mass sedimentation
+
+   call Sedimentation_implicit(mgncol,nlev,deltat,zint,pdel,dumg,fg,.TRUE.,qgtend, &
+                               GQUEUE,xflx=gflx,qxsedten=proc_rates%qgsedten,prect=prect_g,preci=preci_g)
+
+  ! graupel number sedimentation
+
+  call Sedimentation_implicit(mgncol,nlev,deltat,zint,pdel,dumng,fng,.TRUE.,ngtend, &
+                              GQUEUE,qxsedten=proc_rates%ngsedten)
+
+else
+
+! Explicit Sedimentation calculation
+
+  !$acc parallel vector_length(VLENS) default(present) async(IQUEUE)
+  !$acc loop gang vector
+  do i = 1, mgncol
+     nstep_i(i) = 1 + int( max( maxval( fi(i,:)*pdel_inv(i,:) ), maxval( fni(i,:)*pdel_inv(i,:) ) ) * deltat )
+     rnstep_i(i) = 1._r8/real(nstep_i(i))
+  end do
+  !$acc end parallel
+
+  ! ice mass sediment
+  call Sedimentation(mgncol,nlev,do_cldice,deltat,nstep_i,rnstep_i,fi,dumi,pdel_inv, &
+                     qitend,IQUEUE,qxsedten=proc_rates%qisedten,prect=prect_i,xflx=iflx,xxlx=xxls, &
+                     qxsevap=proc_rates%qisevap,tlat=tlat_i,qvlat=qvlat_i,xcldm=icldm,preci=preci_i)
+
+  ! ice number sediment
+  call Sedimentation(mgncol,nlev,do_cldice,deltat,nstep_i,rnstep_i,fni,dumni,pdel_inv, &
+                     nitend,IQUEUE,xcldm=icldm,qxsedten=proc_rates%nisedten)
+
+  !$acc parallel vector_length(VLENS) default(present) async(LQUEUE)
+  !$acc loop gang vector
+  do i = 1, mgncol
+     nstep_l(i) = 1 + int( max( maxval( fc(i,:)*pdel_inv(i,:) ), maxval( fnc(i,:)*pdel_inv(i,:) ) ) * deltat )
+     rnstep_l(i) = 1._r8/real(nstep_l(i))
+  end do
+  !$acc end parallel
+
+  ! liq mass sediment
+  call Sedimentation(mgncol,nlev,.TRUE.,deltat,nstep_l,rnstep_l,fc,dumc,pdel_inv, &
+                     qctend,LQUEUE,qxsedten=proc_rates%qcsedten,prect=prect_l,xflx=lflx,xxlx=xxlv, &
+                     qxsevap=proc_rates%qcsevap,tlat=tlat_l,qvlat=qvlat_l,xcldm=lcldm)
+
+  ! liq number sediment
+  call Sedimentation(mgncol,nlev,.TRUE.,deltat,nstep_l,rnstep_l,fnc,dumnc,pdel_inv, &
+                     nctend,LQUEUE,xcldm=lcldm,qxsedten=proc_rates%ncsedten)
+
+  !$acc parallel vector_length(VLENS) default(present) async(RQUEUE)
+  !$acc loop gang vector
+  do i = 1, mgncol
+     nstep_r(i) = 1 + int( max( maxval( fr(i,:)*pdel_inv(i,:) ), maxval( fnr(i,:)*pdel_inv(i,:) ) ) * deltat )
+     rnstep_r(i) = 1._r8/real(nstep_r(i))
+  end do
+  !$acc end parallel
+
+  ! rain mass sediment
+  call Sedimentation(mgncol,nlev,.TRUE.,deltat,nstep_r,rnstep_r,fr,dumr,pdel_inv, &
+                     qrtend,RQUEUE,qxsedten=proc_rates%qrsedten,prect=prect_r,xflx=rflx)
+
+  ! rain number sediment
+  call Sedimentation(mgncol,nlev,.TRUE.,deltat,nstep_r,rnstep_r,fnr,dumnr,pdel_inv, &
+                     nrtend,RQUEUE,qxsedten=proc_rates%nrsedten)
+
+  !$acc parallel vector_length(VLENS) default(present) async(SQUEUE)
+  !$acc loop gang vector
+  do i = 1, mgncol
+     nstep_s(i) = 1 + int( max( maxval( fs(i,:)*pdel_inv(i,:) ), maxval( fns(i,:)*pdel_inv(i,:) ) ) * deltat )
+     rnstep_s(i) = 1._r8/real(nstep_s(i))
+  end do
+  !$acc end parallel
+
+  ! snow mass sediment
+  call Sedimentation(mgncol,nlev,.TRUE.,deltat,nstep_s,rnstep_s,fs,dums,pdel_inv, &
+                     qstend,SQUEUE,qxsedten=proc_rates%qssedten,prect=prect_s,xflx=sflx,preci=preci_s)
+
+  ! snow number sediment
+  call Sedimentation(mgncol,nlev,.TRUE.,deltat,nstep_s,rnstep_s,fns,dumns,pdel_inv, &
+                     nstend,SQUEUE,qxsedten=proc_rates%nssedten)
+
+  !$acc parallel vector_length(VLENS) default(present) async(GQUEUE)
+  !$acc loop gang vector
+  do i = 1, mgncol
+     nstep_g(i) = 1 + int( max( maxval( fg(i,:)*pdel_inv(i,:) ), maxval( fng(i,:)*pdel_inv(i,:) ) ) * deltat )
+     rnstep_g(i) = 1._r8/real(nstep_g(i))
+  end do
+  !$acc end parallel
+
+  ! graupel mass sediment
+  call Sedimentation(mgncol,nlev,.TRUE.,deltat,nstep_g,rnstep_g,fg,dumg,pdel_inv, &
+                     qgtend,GQUEUE,qxsedten=proc_rates%qgsedten,prect=prect_g,xflx=gflx,preci=preci_g)
+
+  ! graupel number sediment
+  call Sedimentation(mgncol,nlev,.TRUE.,deltat,nstep_g,rnstep_g,fng,dumng,pdel_inv, &
+                     ngtend,GQUEUE,qxsedten=proc_rates%ngsedten)
+
+end if
+! ----------------------------------------------
+! End Sedimentation
+! ----------------------------------------------
+
+  ! sum up the changes due to sedimentation process for different hydrometeors
+
+  !$acc parallel vector_length(VLENS) default(present) wait(IQUEUE,LQUEUE)
+  !$acc loop gang vector collapse(2)
+  do k=1,nlev
+     do i=1,mgncol
+        tlat(i,k)  = tlat(i,k) + tlat_i(i,k) + tlat_l(i,k)
+        qvlat(i,k) = qvlat(i,k) + qvlat_i(i,k) + qvlat_l(i,k)
+     end do
+  end do
+  !$acc end parallel
+
+  !$acc parallel vector_length(VLENS) wait(RQUEUE,SQUEUE,GQUEUE)
+  !$acc loop gang vector
+  do i=1,mgncol
+     prect(i)  = prect(i) + prect_i(i) + prect_l(i) + prect_r(i) + prect_s(i) + prect_g(i)
+     preci(i)  = preci(i) + preci_i(i) + preci_s(i) + preci_g(i)
+  end do
+  !$acc end parallel
+
+  !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+
+  ! get new update for variables that includes sedimentation tendency
+  ! note : here dum variables are grid-average, NOT in-cloud
+
+  !$acc parallel vector_length(VLENS) default(present)
+  !$acc loop gang vector collapse(2)
+  do k=1,nlev
+     do i=1,mgncol
+        dumc(i,k)  = max(qc(i,k)+qctend(i,k)*deltat,0._r8)
+        dumi(i,k)  = max(qi(i,k)+qitend(i,k)*deltat,0._r8)
+        dumnc(i,k) = max(nc(i,k)+nctend(i,k)*deltat,0._r8)
+        dumni(i,k) = max(ni(i,k)+nitend(i,k)*deltat,0._r8)
+
+        dumr(i,k)  = max(qr(i,k)+qrtend(i,k)*deltat,0._r8)
+        dumnr(i,k) = max(nr(i,k)+nrtend(i,k)*deltat,0._r8)
+        dums(i,k)  = max(qs(i,k)+qstend(i,k)*deltat,0._r8)
+        dumns(i,k) = max(ns(i,k)+nstend(i,k)*deltat,0._r8)
+        dumg(i,k)  = max(qg(i,k)+qgtend(i,k)*deltat,0._r8)
+        dumng(i,k) = max(ng(i,k)+ngtend(i,k)*deltat,0._r8)
+
+        ! switch for specification of droplet and crystal number
+        if (nccons) then
+           dumnc(i,k)=ncnst/rho(i,k)*lcldm(i,k)
+        end if
+
+        ! switch for specification of cloud ice number
+        if (nicons) then
+           dumni(i,k)=ninst/rho(i,k)*icldm(i,k)
+        end if
+
+        ! switch for specification of graupel number
+        if (ngcons) then
+           dumng(i,k)=ngnst/rho(i,k)*precip_frac(i,k)
+        end if
+
+        ! switch for specification of constant snow number
+        if (nscons) then
+            dumns(i,k)=nsnst/rho(i,k)
+        end if
+
+        ! switch for specification of constant rain number
+        if (nrcons) then
+            dumnr(i,k)=nrnst/rho(i,k)
+        end if
+
+        if (dumc(i,k).lt.qsmall) dumnc(i,k)=0._r8
+        if (dumi(i,k).lt.qsmall) dumni(i,k)=0._r8
+        if (dumr(i,k).lt.qsmall) dumnr(i,k)=0._r8
+        if (dums(i,k).lt.qsmall) dumns(i,k)=0._r8
+        if (dumg(i,k).lt.qsmall) dumng(i,k)=0._r8
+
+  ! calculate instantaneous processes (melting, homogeneous freezing)
+  !====================================================================
+  ! melting of snow at +2 C
+
+        if (t(i,k)+tlat(i,k)/cpp*deltat > snowmelt) then
+           if (dums(i,k) > 0._r8) then
+              ! make sure melting snow doesn't reduce temperature below threshold
+              dum = -xlf/cpp*dums(i,k)
+              if (t(i,k)+tlat(i,k)/cpp*deltat+dum.lt. snowmelt) then
+                 dum = (t(i,k)+tlat(i,k)/cpp*deltat-snowmelt)*cpp/xlf
+                 dum = dum/dums(i,k)
+                 dum = max(0._r8,dum)
+                 dum = min(1._r8,dum)
+              else
+                 dum = 1._r8
+              end if
+
+              qstend(i,k)=qstend(i,k)-dum*dums(i,k)*rdeltat
+              nstend(i,k)=nstend(i,k)-dum*dumns(i,k)*rdeltat
+              qrtend(i,k)=qrtend(i,k)+dum*dums(i,k)*rdeltat
+              nrtend(i,k)=nrtend(i,k)+dum*dumns(i,k)*rdeltat
+
+              dum1=-xlf*dum*dums(i,k)*rdeltat
+              tlat(i,k)=tlat(i,k)+dum1
+              proc_rates%meltsdttot(i,k)=proc_rates%meltsdttot(i,k) + dum1
+
+!STOPPED FIX FOR SNOW NUMBER
+!ensure that snow... number does not go negative with constant number set
+!necessary because dumng is updated above.
+              if (nscons .and. ((ns(i,k)+nstend(i,k)*deltat) .lt. 0._r8)) then
+                 nstend(i,k)=-ns(i,k)*rdeltat
+              end if
+           end if
+        end if
+
+  ! melting of graupel at +2 C
+
+        if (t(i,k)+tlat(i,k)/cpp*deltat > snowmelt) then
+           if (dumg(i,k) > 0._r8) then
+              ! make sure melting graupel doesn't reduce temperature below threshold
+              dum = -xlf/cpp*dumg(i,k)
+              if (t(i,k)+tlat(i,k)/cpp*deltat+dum .lt. snowmelt) then
+                 dum = (t(i,k)+tlat(i,k)/cpp*deltat-snowmelt)*cpp/xlf
+                 dum = dum/dumg(i,k)
+                 dum = max(0._r8,dum)
+                 dum = min(1._r8,dum)
+              else
+                 dum = 1._r8
+              end if
+
+              qgtend(i,k)=qgtend(i,k)-dum*dumg(i,k)*rdeltat
+              ngtend(i,k)=ngtend(i,k)-dum*dumng(i,k)*rdeltat
+              qrtend(i,k)=qrtend(i,k)+dum*dumg(i,k)*rdeltat
+              nrtend(i,k)=nrtend(i,k)+dum*dumng(i,k)*rdeltat
+
+              dum1=-xlf*dum*dumg(i,k)*rdeltat
+              tlat(i,k)=tlat(i,k)+dum1
+              proc_rates%meltsdttot(i,k)=proc_rates%meltsdttot(i,k) + dum1
+
+!ensure that graupel number does not go negative with constant number set
+!necessary because dumng is updated above.
+              if (ngcons .and. ((ng(i,k)+ngtend(i,k)*deltat) .lt. 0._r8)) then
+                 ngtend(i,k)=-ng(i,k)*rdeltat
+              end if
+           end if
+        end if
+     end do
+  end do
+  !$acc end parallel
+
+  ! get mean size of rain = 1/lamr, add frozen rain to either snow or cloud ice
+  ! depending on mean rain size
+  ! add to graupel if using that option....
+  call size_dist_param_basic(mg_rain_props, dumr, dumnr, lamr, mgncol, nlev)
+
+  !$acc parallel vector_length(VLENS) default(present)
+  !$acc loop gang vector collapse(2)
+  do k=1,nlev
+     do i=1,mgncol
+        ! freezing of rain at -5 C
+        if (t(i,k)+tlat(i,k)/cpp*deltat < rainfrze) then
+           if (dumr(i,k) > 0._r8) then
+              ! make sure freezing rain doesn't increase temperature above threshold
+              dum = xlf/cpp*dumr(i,k)
+              if (t(i,k)+tlat(i,k)/cpp*deltat+dum.gt.rainfrze) then
+                 dum = -(t(i,k)+tlat(i,k)/cpp*deltat-rainfrze)*cpp/xlf
+                 dum = dum/dumr(i,k)
+                 dum = max(0._r8,dum)
+                 dum = min(1._r8,dum)
+              else
+                 dum = 1._r8
+              end if
+
+              qrtend(i,k)=qrtend(i,k)-dum*dumr(i,k)*rdeltat
+              nrtend(i,k)=nrtend(i,k)-dum*dumnr(i,k)*rdeltat
+
+              if (lamr(i,k) < 1._r8/Dcs) then
+                 if (do_hail.or.do_graupel) then
+                    qgtend(i,k)=qgtend(i,k)+dum*dumr(i,k)*rdeltat
+                    ngtend(i,k)=ngtend(i,k)+dum*dumnr(i,k)*rdeltat
+                 else
+                    qstend(i,k)=qstend(i,k)+dum*dumr(i,k)*rdeltat
+                    nstend(i,k)=nstend(i,k)+dum*dumnr(i,k)*rdeltat
+                 end if
+              else
+                 qitend(i,k)=qitend(i,k)+dum*dumr(i,k)*rdeltat
+                 nitend(i,k)=nitend(i,k)+dum*dumnr(i,k)*rdeltat
+              end if
+
+              ! heating tendency
+              dum1 = xlf*dum*dumr(i,k)*rdeltat
+              proc_rates%frzrdttot(i,k)=proc_rates%frzrdttot(i,k) + dum1
+              tlat(i,k)=tlat(i,k)+dum1
+           end if
+        end if
+      end do
+   end do
+   !$acc end parallel
+
+   if (do_cldice) then
+      !$acc parallel vector_length(VLENS) default(present)
+      !$acc loop gang vector collapse(2)
+      do k=1,nlev
+        do i=1,mgncol
+           if (t(i,k)+tlat(i,k)/cpp*deltat > tmelt) then
+              if (dumi(i,k) > 0._r8) then
+                 ! limit so that melting does not push temperature below freezing
+                 !-----------------------------------------------------------------
+                 dum = -dumi(i,k)*xlf/cpp
+                 if (t(i,k)+tlat(i,k)/cpp*deltat+dum.lt.tmelt) then
+                    dum = (t(i,k)+tlat(i,k)/cpp*deltat-tmelt)*cpp/xlf
+                    dum = dum/dumi(i,k)
+                    dum = max(0._r8,dum)
+                    dum = min(1._r8,dum)
+                 else
+                    dum = 1._r8
+                 end if
+
+                 qctend(i,k)=qctend(i,k)+dum*dumi(i,k)*rdeltat
+
+                 ! for output
+                 proc_rates%melttot(i,k)=dum*dumi(i,k)*rdeltat
+
+                 ! assume melting ice produces droplet
+                 ! mean volume radius of 8 micron
+
+                 proc_rates%nmelttot(i,k)=3._r8*dum*dumi(i,k)*rdeltat/ &
+                      (4._r8*pi*5.12e-16_r8*rhow)
+                 nctend(i,k)=nctend(i,k)+proc_rates%nmelttot(i,k)
+
+                 qitend(i,k)=((1._r8-dum)*dumi(i,k)-qi(i,k))*rdeltat
+                 nitend(i,k)=((1._r8-dum)*dumni(i,k)-ni(i,k))*rdeltat
+                 tlat(i,k)=tlat(i,k)-xlf*dum*dumi(i,k)*rdeltat
+              end if
+           end if
+
+           ! homogeneously freeze droplets at -40 C
+           !-----------------------------------------------------------------
+
+           if (t(i,k)+tlat(i,k)/cpp*deltat < 233.15_r8) then
+              if (dumc(i,k) > 0._r8) then
+                 ! limit so that freezing does not push temperature above threshold
+                 dum = dumc(i,k)*xlf/cpp
+                 if (t(i,k)+tlat(i,k)/cpp*deltat+dum.gt.233.15_r8) then
+                    dum = -(t(i,k)+tlat(i,k)/cpp*deltat-233.15_r8)*cpp/xlf
+                    dum = dum/dumc(i,k)
+                    dum = max(0._r8,dum)
+                    dum = min(1._r8,dum)
+                 else
+                    dum = 1._r8
+                 end if
+
+                 qitend(i,k)=qitend(i,k)+dum*dumc(i,k)*rdeltat
+                 ! for output
+                 proc_rates%homotot(i,k)=dum*dumc(i,k)*rdeltat
+
+                 ! assume 25 micron mean volume radius of homogeneously frozen droplets
+                 ! consistent with size of detrained ice in stratiform.F90
+                 proc_rates%nhomotot(i,k)=dum*3._r8*dumc(i,k)/(4._r8*3.14_r8*micro_mg_homog_size**3._r8*500._r8)*rdeltat
+                 nitend(i,k)=nitend(i,k)+proc_rates%nhomotot(i,k)
+
+                 qctend(i,k)=((1._r8-dum)*dumc(i,k)-qc(i,k))*rdeltat
+                 nctend(i,k)=((1._r8-dum)*dumnc(i,k)-nc(i,k))*rdeltat
+                 tlat(i,k)=tlat(i,k)+xlf*dum*dumc(i,k)*rdeltat
+              end if
+           end if
+
+           ! ice number limiter
+           if (do_cldice .and. nitend(i,k).gt.0._r8.and.ni(i,k)+nitend(i,k)*deltat.gt.micro_mg_max_nicons*icldm(i,k)/rho(i,k)) then
+              nitend(i,k)=max(0._r8,(micro_mg_max_nicons*icldm(i,k)/rho(i,k)-ni(i,k))/deltat)
+           end if
+
+     ! remove any excess over-saturation, which is possible due to non-linearity when adding
+     ! together all microphysical processes
+     !-----------------------------------------------------------------
+     ! follow code similar to old CAM scheme
+
+           dum_2D(i,k)=q(i,k)+qvlat(i,k)*deltat
+           ttmpA(i,k)=t(i,k)+tlat(i,k)/cpp*deltat
+        end do
+     end do
+     !$acc end parallel
+
+     ! use rhw to allow ice supersaturation
+     call qsat_water(ttmpA, p, esnA, qvnA, mgncol*nlev)
+
+     !$acc parallel vector_length(VLENS) default(present)
+     !$acc loop gang vector collapse(2)
+     do k=1,nlev
+        do i=1,mgncol
+           if (dum_2D(i,k) > qvnA(i,k) .and. qvnA(i,k) > 0 .and. remove_supersat) then
+              ! expression below is approximate since there may be ice deposition
+              dum = (dum_2D(i,k)-qvnA(i,k))/(1._r8+xxlv_squared*qvnA(i,k)/(cpp*rv*ttmpA(i,k)**2))*rdeltat
+              ! add to output cme
+              cmeout(i,k) = cmeout(i,k)+dum
+              ! now add to tendencies, partition between liquid and ice based on temperature
+              if (ttmpA(i,k) > 268.15_r8) then
+                 dum1=0.0_r8
+                 ! now add to tendencies, partition between liquid and ice based on te
+                 !-------------------------------------------------------
+              else if (ttmpA(i,k) < 238.15_r8) then
+                 dum1=1.0_r8
+              else
+                 dum1=(268.15_r8-ttmpA(i,k))/30._r8
+              end if
+              dum = (dum_2D(i,k)-qvnA(i,k))/(1._r8+(xxls*dum1+xxlv*(1._r8-dum1))**2 &
+                    *qvnA(i,k)/(cpp*rv*ttmpA(i,k)**2))*rdeltat
+              qctend(i,k)=qctend(i,k)+dum*(1._r8-dum1)
+              ! for output
+              proc_rates%qcrestot(i,k)=dum*(1._r8-dum1)
+              qitend(i,k)=qitend(i,k)+dum*dum1
+              proc_rates%qirestot(i,k)=dum*dum1
+              qvlat(i,k)=qvlat(i,k)-dum
+              ! for output
+              proc_rates%qvres(i,k)=-dum
+              tlat(i,k)=tlat(i,k)+dum*(1._r8-dum1)*xxlv+dum*dum1*xxls
+           end if
+        end do
+     end do
+     !$acc end parallel
+  end if
+
+  ! calculate effective radius for pass to radiation code
+  !=========================================================
+  ! if no cloud water, default value is 10 micron for droplets,
+  ! 25 micron for cloud ice
+
+  ! update cloud variables after instantaneous processes to get effective radius
+  ! variables are in-cloud to calculate size dist parameters
+
+  !$acc parallel vector_length(VLENS) default(present)
+  !$acc loop gang vector collapse(2)
+  do k=1,nlev
+     do i=1,mgncol
+        dumc(i,k) = max(qc(i,k)+qctend(i,k)*deltat,0._r8)/lcldm(i,k)
+        dumi(i,k) = max(qi(i,k)+qitend(i,k)*deltat,0._r8)/icldm(i,k)
+        dumnc(i,k) = max(nc(i,k)+nctend(i,k)*deltat,0._r8)/lcldm(i,k)
+        dumni(i,k) = max(ni(i,k)+nitend(i,k)*deltat,0._r8)/icldm(i,k)
+
+        dumr(i,k) = max(qr(i,k)+qrtend(i,k)*deltat,0._r8)/precip_frac(i,k)
+        dumnr(i,k) = max(nr(i,k)+nrtend(i,k)*deltat,0._r8)/precip_frac(i,k)
+        dums(i,k) = max(qs(i,k)+qstend(i,k)*deltat,0._r8)/precip_frac(i,k)
+        dumns(i,k) = max(ns(i,k)+nstend(i,k)*deltat,0._r8)/precip_frac(i,k)
+        dumg(i,k) = max(qg(i,k)+qgtend(i,k)*deltat,0._r8)
+        dumng(i,k) = max(ng(i,k)+ngtend(i,k)*deltat,0._r8)
+
+        ! switch for specification of droplet and crystal number
+        if (nccons) then
+           dumnc(i,k)=ncnst/rho(i,k)
+        end if
+
+        ! switch for specification of cloud ice number
+        if (nicons) then
+           dumni(i,k)=ninst/rho(i,k)
+        end if
+
+        ! switch for specification of graupel number
+        if (ngcons) then
+           dumng(i,k)=ngnst/rho(i,k)*precip_frac(i,k)
+        end if
+
+        ! switch for specification of constant snow number
+        if (nscons) then
+            dumns(i,k)=nsnst/rho(i,k)
+        end if
+
+        ! switch for specification of constant rain number
+        if (nrcons) then
+            dumnr(i,k)=nrnst/rho(i,k)
+        end if
+
+        ! limit in-cloud mixing ratio to reasonable value of 5 g kg-1
+        dumc(i,k)=min(dumc(i,k),5.e-3_r8)
+        dumi(i,k)=min(dumi(i,k),5.e-3_r8)
+        ! limit in-precip mixing ratios
+        dumr(i,k)=min(dumr(i,k),10.e-3_r8)
+        dums(i,k)=min(dums(i,k),10.e-3_r8)
+        dumg(i,k)=min(dumg(i,k),10.e-3_r8)
+     end do
+  end do
+  !$acc end parallel
+
+  ! cloud ice effective radius
+  !-----------------------------------------------------------------
+  if (do_cldice) then
+     !$acc parallel vector_length(VLENS) default(present)
+     !$acc loop gang vector collapse(2)
+     do k=1,nlev
+        do i=1,mgncol
+           dum_2D(i,k) = dumni(i,k)
+        end do
+     end do
+     !$acc end parallel
+
+     call size_dist_param_basic(mg_ice_props, dumi, dumni, lami, mgncol, nlev, n0=dumni0A2D)
+
+     !$acc parallel vector_length(VLENS) default(present)
+     !$acc loop gang vector collapse(2)
+     do k=1,nlev
+        do i=1,mgncol
+           if (dumi(i,k).ge.qsmall) then
+              if (dumni(i,k) /=dum_2D(i,k)) then
+                 ! adjust number conc if needed to keep mean size in reasonable range
+                 nitend(i,k)=(dumni(i,k)*icldm(i,k)-ni(i,k))*rdeltat
+              end if
+              effi(i,k)   = 1.5_r8/lami(i,k)*1.e6_r8
+              effi(i,k)   = effi(i,k)*micro_mg_effi_factor
+
+              sadice(i,k) = 2._r8*pi*(lami(i,k)**(-3))*dumni0A2D(i,k)*rho(i,k)*1.e-2_r8  ! m2/m3 -> cm2/cm3
+           else
+              effi(i,k)   = 25._r8
+              effi(i,k)   = effi(i,k)*micro_mg_effi_factor
+
+              sadice(i,k) = 0._r8
+           end if
+           ! ice effective diameter for david mitchell's optics
+           deffi(i,k)=effi(i,k)*rhoi/rhows*2._r8
+        end do
+     end do
+     !$acc end parallel
+  else
+     !$acc parallel vector_length(VLENS) default(present)
+     !acc loop gang vector collapse(2)
+     do k=1,nlev
+        do i=1,mgncol
+           ! NOTE: If CARMA is doing the ice microphysics, then the ice effective
+           ! radius has already been determined from the size distribution.
+           effi(i,k)   = re_ice(i,k) * 1.e6_r8      ! m -> um
+           effi(i,k)   = effi(i,k)*micro_mg_effi_factor
+
+           deffi(i,k)  = effi(i,k) * 2._r8
+           sadice(i,k) = 4._r8*pi*(effi(i,k)**2)*ni(i,k)*rho(i,k)*1e-2_r8
+        end do
+     end do
+     !$acc end parallel
+  end if
+
+  ! cloud droplet effective radius
+  !-----------------------------------------------------------------
+
+  !$acc parallel vector_length(VLENS) default(present)
+  !$acc loop gang vector collapse(2)
+  do k=1,nlev
+     do i=1,mgncol
+        dum_2D(i,k) = dumnc(i,k)
+     end do
+  end do
+  !$acc end parallel
+
+  call size_dist_param_liq(mg_liq_props, dumc, dumnc, rho, pgam, lamc, mgncol, nlev)
+
+  !$acc parallel vector_length(VLENS) default(present)
+  !$acc loop gang vector collapse(2)
+  do k=1,nlev
+     do i=1,mgncol
+        if (dumc(i,k).ge.qsmall) then
+           ! switch for specification of droplet and crystal number
+           if (nccons) then
+              ! make sure nc is consistence with the constant N by adjusting tendency, need
+              ! to multiply by cloud fraction
+              ! note that nctend may be further adjusted below if mean droplet size is
+              ! out of bounds
+              nctend(i,k)=(ncnst/rho(i,k)*lcldm(i,k)-nc(i,k))*rdeltat
+           end if
+           if (dum_2D(i,k) /= dumnc(i,k)) then
+              ! adjust number conc if needed to keep mean size in reasonable range
+              nctend(i,k)=(dumnc(i,k)*lcldm(i,k)-nc(i,k))*rdeltat
+           end if
+
+           effc(i,k) = (pgam(i,k)+3._r8)/lamc(i,k)/2._r8*1.e6_r8
+           !assign output fields for shape here
+           lamcrad(i,k)=lamc(i,k)
+           pgamrad(i,k)=pgam(i,k)
+
+           ! recalculate effective radius for constant number, in order to separate
+           ! first and second indirect effects
+           !======================================
+           ! assume constant number of 10^8 kg-1
+           dumnc(i,k)=1.e8_r8
+        end if
+     end do
+  end do
+  !$acc end parallel
+
+  ! Pass in "false" adjust flag to prevent number from being changed within
+  ! size distribution subroutine.
+  call size_dist_param_liq(mg_liq_props, dumc, dumnc, rho, pgam, lamc, mgncol, nlev)
+
+  !$acc parallel vector_length(VLENS) default(present)
+  !$acc loop gang vector collapse(2)
+  do k =1,nlev
+     do i=1,mgncol
+        if (dumc(i,k).ge.qsmall) then
+           effc_fn(i,k) = (pgam(i,k)+3._r8)/lamc(i,k)/2._r8*1.e6_r8
+        else
+           effc(i,k) = 10._r8
+           lamcrad(i,k)=0._r8
+           pgamrad(i,k)=0._r8
+           effc_fn(i,k) = 10._r8
+        end if
+
+        ! recalculate 'final' rain size distribution parameters
+        ! to ensure that rain size is in bounds, adjust rain number if needed
+        dum_2D(i,k) = dumnr(i,k)
+     end do
+  end do
+  !$acc end parallel
+
+  call size_dist_param_basic(mg_rain_props, dumr, dumnr, lamr, mgncol, nlev, n0=n0r)
+
+  !$acc parallel vector_length(VLENS) default(present)
+  !$acc loop gang vector collapse(2)
+  do k=1,nlev
+     do i=1,mgncol
+        if (dumr(i,k).ge.qsmall) then
+           if (dum_2D(i,k) /= dumnr(i,k)) then
+              ! adjust number conc if needed to keep mean size in reasonable range
+              nrtend(i,k)=(dumnr(i,k)*precip_frac(i,k)-nr(i,k))*rdeltat
+           end if
+
+        end if
+
+        ! recalculate 'final' snow size distribution parameters
+        ! to ensure that snow size is in bounds, adjust snow number if needed
+        dum_2D(i,k) = dumns(i,k)
+     end do
+  end do
+  !$acc end parallel
+
+  call size_dist_param_basic(mg_snow_props, dums, dumns, lams, mgncol, nlev, n0=dumns0A2D)
+
+  !$acc parallel vector_length(VLENS) default(present)
+  !$acc loop gang vector collapse(2)
+  do k=1,nlev
+     do i=1,mgncol
+        if (dums(i,k).ge.qsmall) then
+
+           if (dum_2D(i,k) /= dumns(i,k)) then
+              ! adjust number conc if needed to keep mean size in reasonable range
+              nstend(i,k)=(dumns(i,k)*precip_frac(i,k)-ns(i,k))*rdeltat
+           end if
+
+           sadsnow(i,k) = 2._r8*pi*(lams(i,k)**(-3))*dumns0A2D(i,k)*rho(i,k)*1.e-2_r8  ! m2/m3 -> cm2/cm3
+
+        end if
+
+        ! recalculate 'final' graupel size distribution parameters
+        ! to ensure that  size is in bounds, addjust number if needed
+        dum_2D(i,k) = dumng(i,k)
+     end do
+  end do
+  !$acc end parallel
+
+  if (do_hail) then
+     call size_dist_param_basic(mg_hail_props, dumg, dumng, lamg, mgncol, nlev)
+  end if
+  if (do_graupel) then
+     call size_dist_param_basic(mg_graupel_props, dumg, dumng, lamg, mgncol, nlev)
+  end if
+
+  !$acc parallel vector_length(VLENS) default(present)
+  !$acc loop gang vector collapse(2)
+  do k=1,nlev
+     do i=1,mgncol
+        if (dumg(i,k).ge.qsmall) then
+           if (dum_2D(i,k) /= dumng(i,k)) then
+              ! adjust number conc if needed to keep mean size in reasonable range
+              ngtend(i,k)=(dumng(i,k)*precip_frac(i,k)-ng(i,k))*rdeltat
+           end if
+        end if
+
+        ! if updated q (after microphysics) is zero, then ensure updated n is also zero
+        !=================================================================================
+        if (qc(i,k)+qctend(i,k)*deltat.lt.qsmall) nctend(i,k)=-nc(i,k)*rdeltat
+        if (do_cldice .and. qi(i,k)+qitend(i,k)*deltat.lt.qsmall) nitend(i,k)=-ni(i,k)*rdeltat
+        if (qr(i,k)+qrtend(i,k)*deltat.lt.qsmall) nrtend(i,k)=-nr(i,k)*rdeltat
+        if (qs(i,k)+qstend(i,k)*deltat.lt.qsmall) nstend(i,k)=-ns(i,k)*rdeltat
+        if (qg(i,k)+qgtend(i,k)*deltat.lt.qsmall) ngtend(i,k)=-ng(i,k)*rdeltat
+
+  ! DO STUFF FOR OUTPUT:
+  !==================================================
+  ! qc and qi are only used for output calculations past here,
+  ! so add qctend and qitend back in one more time
+
+        qc(i,k) = qc(i,k) + qctend(i,k)*deltat
+        qi(i,k) = qi(i,k) + qitend(i,k)*deltat
+
+  ! averaging for snow and rain number and diameter
+  !--------------------------------------------------
+  ! drout2/dsout2:
+  ! diameter of rain and snow
+  ! dsout:
+  ! scaled diameter of snow (passed to radiation in CAM)
+  ! reff_rain/reff_snow:
+  ! calculate effective radius of rain and snow in microns for COSP using Eq. 9 of COSP v1.3 manual
+
+        ! avoid divide by zero in avg_diameter_vec
+        if (nrout(i,k) .eq. 0._r8) nrout(i,k)=1.e-34_r8
+     end do
+  end do
+  !$acc end parallel
+
+  ! The avg_diameter_vec call does the actual calculation; other diameter
+  ! outputs are just drout2 times constants.
+  call avg_diameter_vec(qrout,nrout,rho,rhow,drout2,mgncol*nlev)
+
+  !$acc parallel vector_length(VLENS) default(present)
+  !$acc loop gang vector collapse(2)
+  do k=1,nlev
+     do i=1,mgncol
+        if (qrout(i,k) .gt. 1.e-7_r8 .and. nrout(i,k) .gt. 0._r8) then
+           qrout2(i,k) = qrout(i,k) * precip_frac(i,k)
+           nrout2(i,k) = nrout(i,k) * precip_frac(i,k)
+           freqr(i,k) = precip_frac(i,k)
+           reff_rain(i,k)=1.5_r8*drout2(i,k)*1.e6_r8
+        else
+           qrout2(i,k) = 0._r8
+           nrout2(i,k) = 0._r8
+           drout2(i,k) = 0._r8
+           freqr(i,k) = 0._r8
+           reff_rain(i,k) = 0._r8
+        end if
+
+        ! avoid divide by zero in avg_diameter_vec
+        if (nsout(i,k) .eq. 0._r8) nsout(i,k) = 1.e-34_r8
+     end do
+  end do
+  !$acc end parallel
+
+  ! The avg_diameter_vec call does the actual calculation; other diameter
+  ! outputs are just dsout2 times constants.
+  call avg_diameter_vec(qsout, nsout, rho, rhosn,dsout2,mgncol*nlev)
+
+  !$acc parallel vector_length(VLENS) default(present)
+  !$acc loop gang vector collapse(2)
+  do k=1,nlev
+     do i=1,mgncol
+        if (qsout(i,k) .gt. 1.e-7_r8 .and. nsout(i,k) .gt. 0._r8) then
+           qsout2(i,k) = qsout(i,k) * precip_frac(i,k)
+           nsout2(i,k) = nsout(i,k) * precip_frac(i,k)
+           freqs(i,k) = precip_frac(i,k)
+           dsout(i,k)=3._r8*rhosn/rhows*dsout2(i,k)
+           reff_snow(i,k)=1.5_r8*dsout2(i,k)*1.e6_r8
+        else
+           dsout(i,k)  = 0._r8
+           qsout2(i,k) = 0._r8
+           nsout2(i,k) = 0._r8
+           dsout2(i,k) = 0._r8
+           freqs(i,k)  = 0._r8
+           reff_snow(i,k)=0._r8
+        end if
+
+        ! avoid divide by zero in avg_diameter_vec
+        if (ngout(i,k) .eq. 0._r8) ngout(i,k) = 1.e-34_r8
+     end do
+  end do
+  !$acc end parallel
+
+  ! The avg_diameter_vec call does the actual calculation; other diameter
+  ! outputs are just dgout2 times constants.
+  if (do_hail .or. do_graupel) then
+     call avg_diameter_vec(qgout, ngout, rho, rhogtmp, dgout2, mgncol*nlev)
+  else
+     ! need this if statement for MG2, where rhogtmp = 0
+
+     !$acc parallel vector_length(VLENS) default(present)
+     !$acc loop gang vector collapse(2)
+     do k=1,nlev
+        do i=1,mgncol
+           dgout2(i,k) = 0._r8
+        end do
+     end do
+     !$acc end parallel
+  end if
+
+  !$acc parallel vector_length(VLENS) default(present)
+  !$acc loop gang vector collapse(2)
+  do k=1,nlev
+     do i=1,mgncol
+        if (qgout(i,k) .gt. 1.e-7_r8 .and. ngout(i,k) .gt. 0._r8) then
+           qgout2(i,k) = qgout(i,k) * precip_frac(i,k)
+           ngout2(i,k) = ngout(i,k) * precip_frac(i,k)
+           freqg(i,k) = precip_frac(i,k)
+           dgout(i,k)=3._r8*rhogtmp/rhows*dgout2(i,k)
+           reff_grau(i,k)=1.5_r8*dgout2(i,k)*1.e6_r8
+        else
+           dgout(i,k)  = 0._r8
+           qgout2(i,k) = 0._r8
+           ngout2(i,k) = 0._r8
+           dgout2(i,k) = 0._r8
+           freqg(i,k)  = 0._r8
+           reff_grau(i,k)=0._r8
+        end if
+     end do
+  end do
+  !$acc end parallel
+
+  ! analytic radar reflectivity
+  !--------------------------------------------------
+  ! formulas from Matthew Shupe, NOAA/CERES
+  ! *****note: radar reflectivity is local (in-precip average)
+  ! units of mm^6/m^3
+
+  ! Min rain rate of 0.1 mm/hr
+  rthrsh=0.0001_r8/3600._r8
+
+  !$acc parallel vector_length(VLENS) default(present)
+  !$acc loop gang vector collapse(2)
+  do k=1,nlev
+     do i=1,mgncol
+        if (qc(i,k).ge.qsmall .and. (nc(i,k)+nctend(i,k)*deltat).gt.10._r8) then
+           dum=(qc(i,k)/lcldm(i,k)*rho(i,k)*1000._r8)**2 &
+                /(0.109_r8*(nc(i,k)+nctend(i,k)*deltat)/lcldm(i,k)*rho(i,k)/1.e6_r8)*lcldm(i,k)/precip_frac(i,k)
+        else
+           dum=0._r8
+        end if
+        if (qi(i,k).ge.qsmall) then
+           dum1=(qi(i,k)*rho(i,k)/icldm(i,k)*1000._r8/0.1_r8)**(1._r8/0.63_r8)*icldm(i,k)/precip_frac(i,k)
+        else
+           dum1=0._r8
+        end if
+        if (qsout(i,k).ge.qsmall) then
+           dum1=dum1+(qsout(i,k)*rho(i,k)*1000._r8/0.1_r8)**(1._r8/0.63_r8)
+        end if
+        refl(i,k)=dum+dum1
+
+        ! add rain to reflectivity (rain rate in mm/hr)
+        ! reflectivity (dum) is in DBz
+        ! New version Aircraft cloud values
+        !Z=a*R^b (R in mm/hr) from Comstock et al 2004
+
+        if (rflx(i,k+1).ge.rthrsh) then
+           dum=32._r8*(rflx(i,k+1)*3600._r8)**1.4_r8
+        else
+           ! don't include rain rate in R calculation for values less than 0.001 mm/hr
+           dum=0._r8
+        end if
+
+        ! add to refl
+        refl(i,k)=refl(i,k)+dum
+
+        !output reflectivity in Z.
+        areflz(i,k)=refl(i,k) * precip_frac(i,k)
+
+        ! convert back to DBz
+        if (refl(i,k).gt.minrefl) then
+           refl(i,k)=10._r8*dlog10(refl(i,k))
+        else
+           refl(i,k)=-9999._r8
+        end if
+
+        !set averaging flag
+        if (refl(i,k).gt.mindbz) then
+           arefl(i,k)=refl(i,k) * precip_frac(i,k)
+           frefl(i,k)=precip_frac(i,k)
+        else
+           arefl(i,k)=0._r8
+           areflz(i,k)=0._r8
+           frefl(i,k)=0._r8
+        end if
+
+        ! bound cloudsat reflectivity
+        csrfl(i,k)=min(csmax,refl(i,k))
+
+        !set averaging flag
+        if (csrfl(i,k).gt.csmin) then
+           acsrfl(i,k)=refl(i,k) * precip_frac(i,k)
+           fcsrfl(i,k)=precip_frac(i,k)
+        else
+           acsrfl(i,k)=0._r8
+           fcsrfl(i,k)=0._r8
+        end if
+     end do
+  end do
+  !$acc end parallel
+
+  ! 10cm analytic radar reflectivity (rain radar)
+  !--------------------------------------------------
+  ! Formula from Hugh Morrison
+  ! Ice dielectric correction from Smith 1984, Equation  10 and Snow correction from Smith 1984 Equation 14
+  ! Smith, Paul L. “Equivalent Radar Reflectivity Factors for Snow and Ice Particles.
+  !                ” Journal of Climate and Applied Meteorology 23, no. 8 (1984): 1258–60.
+  !                DOI:  10.1175/1520-0450(1984)023<1258:ERRFFS>2.0.CO;2
+
+  ! *****note: radar reflectivity is local (in-precip average)
+  ! units of mm^6/m^3
+
+  !$acc parallel vector_length(VLENS) default(present)
+  !$acc loop gang vector collapse(2)
+  do k=1,nlev
+     do i=1,mgncol
+
+        dum1  = minrefl10
+        dum2  = minrefl10
+        dum3  = minrefl10
+        dum4  = minrefl10
+        dum   = minrefl10
+
+!     Rain
+        if (lamr(i,k) > 0._r8) then
+           dum1 = rho(i,k)*n0r(i,k)*720._r8/lamr(i,k)**3/lamr(i,k)**3/lamr(i,k)
+           dum1 = max(dum1,minrefl10)
+        end if
+
+!     Ice
+        !  Add diaelectric factor from Smith 1984 equation 10
+        if (lami(i,k) > 0._r8) then
+           dum2= rho(i,k)*(0.176_r8/0.93_r8) * 720._r8*dumni0A2D(i,k)*(rhoi/900._r8)**2/lami(i,k)**7
+           dum2 = max(dum2,minrefl10)
+        endif
+
+!     Snow
+        if (lams(i,k) > 0._r8) then
+           dum3= rho(i,k)*(0.176_r8/0.93_r8) * 720._r8*dumns0A2D(i,k)*(rhosn/900._r8)**2/lams(i,k)**7._r8
+           dum3 = max(dum3,minrefl10)
+        endif
+
+!     Graupel
+        if (do_hail .or. do_graupel .and. lamg(i,k) > 0._r8) then
+          dum4= rho(i,k)*(0.176_r8/0.93_r8) * 720._r8*n0g(i,k)*(rhogtmp/900._r8)**2/lamg(i,k)**7._r8
+          dum4 =max(dum4,minrefl10)
+        end if
+
+        reflz10cm(i,k) = (dum1+dum2+dum3+dum4) * precip_frac(i,k)
+
+  ! Convert to dBz....
+
+        dum = reflz10cm(i,k)*1.e18_r8
+        refl10cm(i,k) = 10._r8*dlog10(dum)
+
+  !redefine fice here....
+
+        dum_2D(i,k) = qsout(i,k) + qrout(i,k) + qc(i,k) + qi(i,k)
+        dumi(i,k)   = qsout(i,k) + qi(i,k)
+        if (dumi(i,k) .gt. qsmall .and. dum_2D(i,k) .gt. qsmall) then
+           nfice(i,k) = min(dumi(i,k)/dum_2D(i,k),1._r8)
+        else
+           nfice(i,k) = 0._r8
+        end if
+
+     end do
+  end do
+  !$acc end parallel
+
+  !$acc end data
+
+end subroutine micro_pumas_tend
+
+!========================================================================
+!OUTPUT CALCULATIONS
+!========================================================================
+
+subroutine calc_rercld(lamr, n0r, lamc, pgam, qric, qcic, ncic, rercld, vlen)
+  integer,                   intent(in) :: vlen
+  real(r8), dimension(vlen), intent(in) :: lamr          ! rain size parameter (slope)
+  real(r8), dimension(vlen), intent(in) :: n0r           ! rain size parameter (intercept)
+  real(r8), dimension(vlen), intent(in) :: lamc          ! size distribution parameter (slope)
+  real(r8), dimension(vlen), intent(in) :: pgam          ! droplet size parameter
+  real(r8), dimension(vlen), intent(in) :: qric          ! in-cloud rain mass mixing ratio
+  real(r8), dimension(vlen), intent(in) :: qcic          ! in-cloud cloud liquid
+  real(r8), dimension(vlen), intent(in) :: ncic          ! in-cloud droplet number concentration
+
+  real(r8), dimension(vlen), intent(inout) :: rercld     ! effective radius calculation for rain + cloud
+
+  ! combined size of precip & cloud drops
+  real(r8) :: Atmp,tmp(vlen), pgamp1(vlen)
+
+  integer :: i
+
+  !$acc data create (tmp,pgamp1)
+
+  !$acc parallel vector_length(VLENS) default(present)
+  !$acc loop gang vector
+  do i=1,vlen
+     pgamp1(i) = pgam(i)+1._r8
+  end do
+  !$acc end parallel
+
+  call rising_factorial(pgamp1, 2, tmp, vlen)
+
+  !$acc parallel vector_length(VLENS) default(present)
+  !$acc loop gang vector
+  do i=1,vlen
+     ! Rain drops
+     if (lamr(i) > 0._r8) then
+        Atmp = n0r(i) * pi / (2._r8 * lamr(i)**3._r8)
+     else
+        Atmp = 0._r8
+     end if
+     ! Add cloud drops
+     if (lamc(i) > 0._r8) then
+        Atmp = Atmp + &
+             ncic(i) * pi * tmp(i) / (4._r8 * lamc(i)**2._r8)
+     end if
+     if (Atmp > 0._r8) then
+        rercld(i) = rercld(i) + 3._r8 *(qric(i) + qcic(i)) / (4._r8 * rhow * Atmp)
+     end if
+  end do
+  !$acc end parallel
+
+  !$acc end data
+end subroutine calc_rercld
+
+!========================================================================
+!2020-09-15: Follow John Dennis's version to generate a new interface
+!            to update tendency in the sedimentation loop;
+!2021-10-19: Separate the mass and ice sediment for each class;
+!========================================================================
+subroutine Sedimentation(mgncol,nlev,do_cldice,deltat,nstep,rnstep,fx,dumx,pdel_inv, &
+                         xxtend,queue,qxsedten,prect,xflx,xxlx,qxsevap,tlat,qvlat,xcldm,preci)
+
+   integer, intent(in)               :: mgncol,nlev
+   logical, intent(in)               :: do_cldice
+   real(r8),intent(in)               :: deltat
+   integer, intent(in)               :: nstep(mgncol)
+   real(r8), intent(in)              :: rnstep(mgncol)
+   real(r8), intent(in)              :: fx(mgncol,nlev)
+   real(r8), intent(inout)           :: dumx(mgncol,nlev)
+   real(r8), intent(in)              :: pdel_inv(mgncol,nlev)
+   real(r8), intent(inout)           :: xxtend(mgncol,nlev)
+   integer, intent(in)               :: queue
+   real(r8), intent(inout), optional :: qxsedten(mgncol,nlev)
+   real(r8), intent(inout), optional :: prect(mgncol)
+   real(r8), intent(inout), optional :: xflx(mgncol,nlev+1)
+   real(r8), intent(in)   , optional :: xxlx
+   real(r8), intent(inout), optional :: qxsevap(mgncol,nlev)
+   real(r8), intent(in)   , optional :: xcldm(mgncol,nlev)
+   real(r8), intent(inout), optional :: tlat(mgncol,nlev)
+   real(r8), intent(inout), optional :: qvlat(mgncol,nlev)
+   real(r8), intent(inout), optional :: preci(mgncol)
+
+   ! local variables
+   integer  :: i,k,n,nstepmax
+   real(r8) :: faltndx,rnstepmax,faltndqxe
+   real(r8) :: dum1(mgncol,nlev),faloutx(mgncol,0:nlev)
+   logical  :: present_tlat, present_qvlat, present_xcldm, present_qxsevap, &
+               present_prect, present_preci, present_qxsedten, present_xflx
+
+   present_tlat     = present(tlat)
+   present_qvlat    = present(qvlat)
+   present_xcldm    = present(xcldm)
+   present_qxsevap  = present(qxsevap)
+   present_preci    = present(preci)
+   present_prect    = present(prect)
+   present_qxsedten = present(qxsedten)
+   present_xflx     = present(xflx)
+
+   ! loop over sedimentation sub-time step to ensure stability
+   !==============================================================
+
+   !$acc enter data create (faloutx,dum1) async(queue)
+
+   !$acc parallel vector_length(VLENS) default(present) async(queue)
+   !$acc loop gang vector
+   do i = 1,mgncol
+      nstepmax = nstep(i)
+      rnstepmax = rnstep(i)
+
+      dum1(i,1) = 0._r8
+      if (present_xcldm) then
+         do k = 2,nlev
+            dum1(i,k) = xcldm(i,k)/xcldm(i,k-1)
+            dum1(i,k) = min(dum1(i,k),1._r8)
+         end do
+      else
+         do k=2,nlev
+            dum1(i,k) = 1._r8
+         end do
+      end if
+
+      !$acc loop seq
+      do n = 1,nstepmax
+         faloutx(i,0)  = 0._r8
+         if (do_cldice) then
+            do k=1,nlev
+               faloutx(i,k)  = fx(i,k)  * dumx(i,k)
+            end do
+         else
+            do k=1,nlev
+               faloutx(i,k)  = 0._r8
+            end do
+         end if
+
+         do k = 1,nlev
+            ! for cloud liquid and ice, if cloud fraction increases with height
+            ! then add flux from above to both vapor and cloud water of current level
+            ! this means that flux entering clear portion of cell from above evaporates
+            ! instantly
+            ! note: this is not an issue with precip, since we assume max overlap
+            faltndx = (faloutx(i,k) - dum1(i,k) * faloutx(i,k-1)) * pdel_inv(i,k)
+            ! add fallout terms to eulerian tendencies
+            xxtend(i,k) = xxtend(i,k) - faltndx * rnstepmax
+            ! sedimentation tendency for output
+            if (present_qxsedten) qxsedten(i,k) = qxsedten(i,k)-faltndx*rnstepmax
+            ! add terms to to evap/sub of cloud water
+            dumx(i,k) = dumx(i,k) - faltndx*deltat*rnstepmax
+
+            if (k>1) then
+               if (present_qxsevap .or. present_qvlat .or. present_tlat) then
+                  faltndqxe = (faloutx(i,k)-faloutx(i,k-1))*pdel_inv(i,k)
+                  ! for output
+                  if (present_qxsevap) qxsevap(i,k) = qxsevap(i,k) - (faltndqxe-faltndx)*rnstepmax
+                  if (present_qvlat) qvlat(i,k) = qvlat(i,k) - (faltndqxe-faltndx)*rnstepmax
+                  if (present_tlat) tlat(i,k) = tlat(i,k) + (faltndqxe-faltndx)*xxlx*rnstepmax
+               end if
+            end if
+
+            if (present_xflx) xflx(i,k+1) = xflx(i,k+1) + faloutx(i,k) / g * rnstepmax
+         end do
+
+         ! units below are m/s
+         ! sedimentation flux at surface is added to precip flux at surface
+         ! to get total precip (cloud + precip water) rate
+         if (present_prect) prect(i) = prect(i) + faloutx(i,nlev) / g * rnstepmax / 1000._r8
+         if (present_preci) preci(i) = preci(i) + faloutx(i,nlev) / g * rnstepmax / 1000._r8
+      end do  ! n loop of 1, nstep
+   end do  ! i loop of 1, mgncol
+   !$acc end parallel
+
+   !$acc exit data delete(faloutx,dum1) async(queue)
+end subroutine Sedimentation
+
+!========================================================================
+!2021-10-19: Add a new interface for the implicit sedimentation calculation;
+!            Separate number/mass sediment for each class;
+!========================================================================
+subroutine Sedimentation_implicit(mgncol,nlev,deltat,zint,pdel,dumx,fx,check_qsmall, &
+                                  xxtend,queue,xflx,qxsedten,prect,preci)
+
+   integer,  intent(in)              :: mgncol,nlev
+   real(r8), intent(in)              :: deltat
+   real(r8), intent(in)              :: zint(mgncol,nlev+1)
+   real(r8), intent(in)              :: pdel(mgncol,nlev)
+   real(r8), intent(in)              :: dumx(mgncol,nlev)
+   real(r8), intent(in)              :: fx(mgncol,nlev)
+   logical,  intent(in)              :: check_qsmall
+   real(r8), intent(inout)           :: xxtend(mgncol,nlev)
+   integer,  intent(in)              :: queue
+   real(r8), intent(inout), optional :: xflx(mgncol,nlev+1)
+   real(r8), intent(inout), optional :: qxsedten(mgncol,nlev)
+   real(r8), intent(inout), optional :: prect(mgncol)
+   real(r8), intent(inout), optional :: preci(mgncol)
+
+   ! Local variables
+   integer  :: i,k
+   real(r8) :: dum_2D(mgncol,nlev),flx(mgncol,nlev),precip(mgncol)
+   logical  :: present_preci, present_xflx, present_qxsedten, present_prect
+
+   present_preci = present(preci)
+   present_xflx = present(xflx)
+   present_qxsedten = present(qxsedten)
+   present_prect = present(prect)
+
+   !$acc enter data create (flx,dum_2D,precip) async(queue)
+
+   !$acc parallel vector_length(VLENS) default(present) async(queue)
+   !$acc loop gang vector collapse(2)
+   do k=1,nlev
+      do i=1,mgncol
+         dum_2D(i,k) = dumx(i,k)
+      enddo
+   enddo
+   !$acc end parallel
+
+   call implicit_fall ( deltat, mgncol, 1, nlev, zint, fx, pdel, dum_2D, precip, flx, queue)
+
+   !$acc parallel vector_length(VLENS) default(present) async(queue)
+   !$acc loop gang vector collapse(2)
+   do k=1,nlev
+      do i=1,mgncol
+         if ( check_qsmall ) then
+            !h1g, 2019-11-26, ensure numerical stability
+            if ( flx(i,k) .ge. qsmall .and. present_xflx ) xflx(i,k+1) = xflx(i,k+1) + flx(i,k) / g / deltat
+         else
+            if ( present_xflx ) xflx(i,k+1) = xflx(i,k+1) + flx(i,k) / g / deltat
+         end if
+         if ( present_qxsedten) qxsedten(i,k) = qxsedten(i,k) + (dum_2D(i,k) - dumx(i,k)) / deltat
+         xxtend(i,k) = xxtend(i,k) + (dum_2D(i,k) - dumx(i,k)) / deltat
+      enddo
+   enddo
+   !$acc end parallel
+
+   !$acc parallel vector_length(VLENS) default(present) async(queue)
+   !$acc loop gang vector
+   do i=1,mgncol
+      if ( precip(i) .ge. 0.0 ) then !h1g, 2019-11-26, ensure numerical stability
+         if ( present_prect ) prect(i) = prect(i) + precip(i) / g / deltat / 1000._r8
+         if ( present_preci ) preci(i) = preci(i) + precip(i) / g / deltat / 1000._r8
+      endif
+   enddo
+   !$acc end parallel
+
+   !$acc exit data delete(flx,dum_2D,precip) async(queue)
+
+end subroutine Sedimentation_implicit
+
+!========================================================================
+!UTILITIES
+!========================================================================
+
+
+pure subroutine micro_pumas_get_cols(ncol, nlev, top_lev, mgncol, mgcols, &
+     qcn, qin, qrn, qsn, qgr)
+
+  ! Determines which columns microphysics should operate over by
+  ! checking for non-zero cloud water/ice.
+
+  integer, intent(in) :: ncol      ! Number of columns with meaningful data
+  integer, intent(in) :: nlev      ! Number of levels to use
+  integer, intent(in) :: top_lev   ! Top level for microphysics
+  integer, intent(out) :: mgncol   ! Number of columns MG will use
+  integer, allocatable, intent(out) :: mgcols(:) ! column indices
+
+  real(r8), intent(in) :: qcn(:,:) ! cloud water mixing ratio (kg/kg)
+  real(r8), intent(in) :: qin(:,:) ! cloud ice mixing ratio (kg/kg)
+  real(r8), intent(in) :: qrn(:,:) ! rain mixing ratio (kg/kg)
+  real(r8), intent(in) :: qsn(:,:) ! snow mixing ratio (kg/kg)
+  real(r8), optional, intent(in) :: qgr(:,:) ! graupel mixing ratio (kg/kg)
+
+  integer :: lev_offset  ! top_lev - 1 (defined here for consistency)
+  logical :: ltrue(ncol) ! store tests for each column
+
+  integer :: i, ii ! column indices
+
+  if (allocated(mgcols)) deallocate(mgcols)
+
+  lev_offset = top_lev - 1
+
+  ! Using "any" along dimension 2 collapses across levels, but
+  ! not columns, so we know if water is present at any level
+  ! in each column.
+
+  ltrue = any(qcn(:ncol,top_lev:(nlev+lev_offset)) >= qsmall, 2)
+  ltrue = ltrue .or. any(qin(:ncol,top_lev:(nlev+lev_offset)) >= qsmall, 2)
+  ltrue = ltrue .or. any(qrn(:ncol,top_lev:(nlev+lev_offset)) >= qsmall, 2)
+  ltrue = ltrue .or. any(qsn(:ncol,top_lev:(nlev+lev_offset)) >= qsmall, 2)
+
+  if(present(qgr)) ltrue = ltrue .or. any(qgr(:ncol,top_lev:(nlev+lev_offset)) >= qsmall, 2)
+
+  ! Scan for true values to get a usable list of indices.
+
+  mgncol = count(ltrue)
+  allocate(mgcols(mgncol))
+  i = 0
+  do ii = 1,ncol
+     if (ltrue(ii)) then
+        i = i + 1
+        mgcols(i) = ii
+     end if
+  end do
+
+end subroutine micro_pumas_get_cols
+
+! =======================================================================
+! time - implicit monotonic scheme
+! developed by sj lin, 2016
+! =======================================================================
+
+subroutine implicit_fall (dt, mgncol, ktop, kbot, ze, vt, dp, q, precip, m1, queue)
+
+    implicit none
+
+    integer, intent (in) :: mgncol                                   ! Number of columns in MG
+    integer, intent (in) :: ktop,kbot                                ! Level range (top to bottom)
+    real(r8), intent (in) :: dt                                      ! Time step
+    real(r8), intent (in), dimension (mgncol,ktop:kbot+1) :: ze      ! Interface height (m)
+    real(r8), intent (in), dimension (mgncol,ktop:kbot) :: vt, dp    ! fall speed and pressure difference across level
+    real(r8), intent (inout), dimension (mgncol,ktop:kbot) :: q      ! mass
+    real(r8), intent (out), dimension (mgncol,ktop:kbot) :: m1       ! Surface Flux
+    real(r8), intent (out), dimension (mgncol) :: precip             ! Surface Precipitation
+    integer, intent (in) :: queue                                    ! Stream ID for GPU asynchronous run
+
+    ! Local variables
+    real(r8), dimension (mgncol,ktop:kbot) :: dz, qm, dd
+    integer :: i,k
+
+    !$acc enter data create (dz,qm,dd) async(queue)
+
+    !$acc parallel vector_length(VLENS) default(present) async(queue)
+    !$acc loop gang vector collapse(2)
+    do i = 1, mgncol
+       do k = ktop, kbot
+          dz (i,k) = ze (i,k) - ze (i,k + 1)
+          dd (i,k) = dt * vt (i,k)
+          q (i,k) = q (i,k) * dp (i,k)
+       end do
+    end do
+    !$acc end parallel
+
+    ! -----------------------------------------------------------------------
+    ! sedimentation: non - vectorizable loop
+    ! -----------------------------------------------------------------------
+
+    !$acc parallel vector_length(VLENS) default(present) async(queue)
+    !$acc loop gang vector
+    do i = 1, mgncol
+       qm (i,ktop) = q (i,ktop) / (dz (i,ktop) + dd (i,ktop))
+
+       !$acc loop seq
+       do k = ktop + 1, kbot
+          qm (i,k) = (q (i,k) + dd (i,k - 1) * qm (i,k - 1)) / (dz (i,k) + dd (i,k))
+       end do
+    end do
+    !$acc end parallel
+
+    ! -----------------------------------------------------------------------
+    ! qm is density at this stage
+    ! -----------------------------------------------------------------------
+
+    !$acc parallel vector_length(VLENS) default(present) async(queue)
+    !$acc loop gang vector collapse(2)
+    do i = 1, mgncol
+       do k = ktop, kbot
+          qm (i,k) = qm (i,k) * dz (i,k)
+       end do
+    end do
+    !$acc end parallel
+
+    ! -----------------------------------------------------------------------
+    ! output mass fluxes: non - vectorizable loop
+    ! -----------------------------------------------------------------------
+
+    !$acc parallel vector_length(VLENS) default(present) async(queue)
+    !$acc loop gang vector
+    do i = 1, mgncol
+       m1 (i,ktop) = q (i,ktop) - qm (i,ktop)
+
+       !$acc loop seq
+       do k = ktop + 1, kbot
+          m1 (i,k) = m1 (i,k - 1) + q (i,k) - qm (i,k)
+       end do
+    end do
+    !$acc end parallel
+
+    !$acc parallel vector_length(VLENS) default(present) async(queue)
+    !$acc loop gang vector
+    do i = 1, mgncol
+       precip(i) = m1 (i,kbot)
+    end do
+    !$acc end parallel
+
+    ! -----------------------------------------------------------------------
+    ! update:
+    ! -----------------------------------------------------------------------
+
+    !$acc parallel vector_length(VLENS) default(present) async(queue)
+    !$acc loop gang vector collapse(2)
+    do i = 1, mgncol
+       do k = ktop, kbot
+          q (i,k) = qm (i,k) / dp (i,k)
+       end do
+    end do
+    !$acc end parallel
+
+    !$acc exit data delete (dz,qm,dd) async(queue)
+
+end subroutine implicit_fall
+
+
+end module micro_pumas_v1

--- a/TAU_ML_microphysics/src/module_neural_net.F90
+++ b/TAU_ML_microphysics/src/module_neural_net.F90
@@ -1,0 +1,577 @@
+module module_neural_net
+    use netcdf
+    use pumas_kinds, only: r8=>kind_r8
+
+    implicit none
+    type Dense
+        integer :: input_size
+        integer :: output_size
+        integer :: batch_size
+        integer :: activation
+        real(kind=r8), allocatable :: weights(:, :)
+        real(kind=r8), allocatable :: bias(:)
+    end type Dense
+
+    type DenseData
+        real(kind=r8), allocatable :: input(:, :)
+        real(kind=r8), allocatable :: output(:, :)
+    end type DenseData
+
+contains
+
+    subroutine apply_dense(input, layer, output)
+        ! Description: Pass a set of input data through a single dense layer and nonlinear activation function
+        !
+        ! Inputs:
+        ! layer (input): a single Dense object
+        ! input (input): a 2D array where the rows are different examples and
+        !   the columns are different model inputs
+        !
+        ! Output:
+        ! output: output of the dense layer as a 2D array with shape (number of inputs, number of neurons)
+        real(kind=r8), dimension(:, :), intent(in) :: input
+        type(Dense), intent(in) :: layer
+        real(kind=r8), dimension(size(input, 1), layer%output_size), intent(out) :: output
+        real(kind=r8), dimension(size(input, 1), layer%output_size) :: dense_output
+        integer :: i, j, num_examples
+        real(kind=r8) :: alpha, beta
+        external :: dgemm
+        alpha = 1_r8
+        beta = 1_r8
+        dense_output = 0_r8
+        output = 0_r8
+        num_examples = size(input, 1)
+        call dgemm('n', 'n', num_examples, layer%output_size, layer%input_size, &
+            alpha, input, num_examples, layer%weights, layer%input_size, beta, dense_output, num_examples)
+        do i=1, num_examples
+            do j=1, layer%output_size
+                dense_output(i, j) = dense_output(i, j) + layer%bias(j)
+            end do
+        end do
+        call apply_activation(dense_output, layer%activation, output)
+    end subroutine apply_dense
+
+    subroutine apply_activation(input, activation_type, output)
+        ! Description: Apply a nonlinear activation function to a given array of input values.
+        !
+        ! Inputs:
+        ! input: A 2D array
+        ! activation_type: string describing which activation is being applied. If the activation
+        !       type does not match any of the available options, the linear activation is applied.
+        !       Currently supported activations are:
+        !           relu
+        !           elu
+        !           selu
+        !           sigmoid
+        !           tanh
+        !           softmax
+        !           linear
+        ! Output:
+        ! output: Array of the same dimensions as input with the nonlinear activation applied.
+        real(kind=r8), dimension(:, :), intent(in) :: input
+        integer, intent(in) :: activation_type
+        real(kind=r8), dimension(size(input, 1), size(input, 2)), intent(out) :: output
+
+        real(kind=r8), dimension(size(input, 1)) :: softmax_sum
+        real(kind=r8), parameter :: selu_alpha = 1.6732_r8
+        real(kind=r8), parameter :: selu_lambda = 1.0507_r8
+        real(kind=r8), parameter :: zero = 0.0_r8
+        integer :: i, j
+        select case (activation_type)
+            case (0)
+                output = input
+            case (1)
+                do i=1,size(input, 1)
+                    do j=1, size(input,2)
+                        output(i, j) = dmax1(input(i, j), zero)
+                    end do
+                end do
+            case (2)
+                output = 1.0_r8 / (1.0_r8 + dexp(-input))
+            case (3)
+                do i=1,size(input, 1)
+                    do j=1, size(input,2)
+                        if (input(i, j) >= 0) then
+                            output(i, j) = input(i, j)
+                        else
+                            output(i, j) = dexp(input(i, j))-1.0_r8
+                        end if
+                    end do
+                end do
+            case (4)
+                do i=1,size(input, 1)
+                    do j=1, size(input,2)
+                        if (input(i, j) >= 0) then
+                            output(i, j) = input(i, j)
+                        else
+                            output(i, j) = selu_lambda * ( selu_alpha * dexp(input(i, j)) - selu_alpha)
+                        end if
+                    end do
+                end do
+            case (5)
+                output = tanh(input)
+            case (6)
+                softmax_sum = sum(dexp(input), dim=2)
+                do i=1, size(input, 1)
+                    do j=1, size(input, 2)
+                        output(i, j) = dexp(input(i, j)) / softmax_sum(i)
+                    end do
+                end do
+            case default
+                output = input
+        end select
+    end subroutine apply_activation
+
+    subroutine init_neural_net(filename, batch_size, neural_net_model, iulog, errstring)
+        ! init_neuralnet
+        ! Description: Loads dense neural network weights from a netCDF file and builds an array of
+        ! Dense types from the weights and activations.
+        !
+        ! Input:
+        ! filename: Full path to the netCDF file
+        ! batch_size: number of items in single batch. Used to set intermediate array sizes.
+        !
+        ! Output:
+        ! neural_net_model (output): array of Dense layers composing a densely connected neural network
+        !
+        character(len=*), intent(in) :: filename
+        integer, intent(in) :: batch_size
+        type(Dense), allocatable, intent(out) :: neural_net_model(:)
+        integer,          intent(in)  :: iulog
+        character(128),   intent(out) :: errstring  ! output status (non-blank for error return)
+
+        integer :: ncid, num_layers_id, num_layers
+        integer :: layer_names_var_id, i, layer_in_dimid, layer_out_dimid
+        integer :: layer_in_dim, layer_out_dim
+        integer :: layer_weight_var_id
+        integer :: layer_bias_var_id
+
+        character (len=8), allocatable :: layer_names(:)
+        character (len=10) :: num_layers_dim_name = "num_layers"
+        character (len=11) :: layer_name_var = "layer_names"
+        character (len=11) :: layer_in_dim_name
+        character (len=12) :: layer_out_dim_name
+        character (len=10) :: activation_name
+        real (kind=r8), allocatable :: temp_weights(:, :)
+
+        errstring = ''
+
+        ! Open netCDF file
+        call check(nf90_open(filename, nf90_nowrite, ncid),errstring)
+        if (trim(errstring) /= '') return
+        ! Get the number of layers in the neural network
+        call check(nf90_inq_dimid(ncid, num_layers_dim_name, num_layers_id),errstring)
+        if (trim(errstring) /= '') return
+        call check(nf90_inquire_dimension(ncid, num_layers_id, &
+                                          num_layers_dim_name, num_layers),errstring)
+        if (trim(errstring) /= '') return
+        call check(nf90_inq_varid(ncid, layer_name_var, layer_names_var_id),errstring)
+        if (trim(errstring) /= '') return
+        allocate(layer_names(num_layers))
+        call check(nf90_get_var(ncid, layer_names_var_id, layer_names),errstring)
+        if (trim(errstring) /= '') return
+        write(iulog,*) "load neural network " // filename
+        allocate(neural_net_model(1:num_layers))
+        ! Loop through each layer and load the weights, bias term, and activation function
+        do i=1, num_layers
+            layer_in_dim_name = trim(layer_names(i)) // "_in"
+            layer_out_dim_name = trim(layer_names(i)) // "_out"
+            layer_in_dimid = -1
+            ! Get layer input and output dimensions
+            call check(nf90_inq_dimid(ncid, trim(layer_in_dim_name), layer_in_dimid),errstring)
+            if (trim(errstring) /= '') return
+            call check(nf90_inquire_dimension(ncid, layer_in_dimid, layer_in_dim_name, layer_in_dim),errstring)
+            if (trim(errstring) /= '') return
+            call check(nf90_inq_dimid(ncid, trim(layer_out_dim_name), layer_out_dimid),errstring)
+            if (trim(errstring) /= '') return
+            call check(nf90_inquire_dimension(ncid, layer_out_dimid, layer_out_dim_name, layer_out_dim),errstring)
+            if (trim(errstring) /= '') return
+            call check(nf90_inq_varid(ncid, trim(layer_names(i)) // "_weights", &
+                                      layer_weight_var_id),errstring)
+            if (trim(errstring) /= '') return
+            call check(nf90_inq_varid(ncid, trim(layer_names(i)) // "_bias", &
+                                      layer_bias_var_id),errstring)
+            if (trim(errstring) /= '') return
+            neural_net_model(i)%input_size = layer_in_dim
+            neural_net_model(i)%output_size = layer_out_dim
+            neural_net_model(i)%batch_size = batch_size
+            ! Fortran loads 2D arrays in the opposite order from Python/C, so I
+            ! first load the data into a temporary array and then apply the
+            ! transpose operation to copy the weights into the Dense layer
+            allocate(neural_net_model(i)%weights(layer_in_dim, layer_out_dim))
+            allocate(temp_weights(layer_out_dim, layer_in_dim))
+
+            call check(nf90_get_var(ncid, layer_weight_var_id, &
+                                    temp_weights),errstring)
+            if (trim(errstring) /= '') return
+            neural_net_model(i)%weights = transpose(temp_weights)
+            deallocate(temp_weights)
+            ! Load the bias weights
+            allocate(neural_net_model(i)%bias(layer_out_dim))
+            call check(nf90_get_var(ncid, layer_bias_var_id, &
+                                    neural_net_model(i)%bias),errstring)
+            if (trim(errstring) /= '') return
+            ! Get the name of the activation function, which is stored as an attribute of the weights variable
+            call check(nf90_get_att(ncid, layer_weight_var_id, "activation", &
+                                    activation_name),errstring)
+            if (trim(errstring) /= '') return
+            select case (trim(activation_name))
+                case ("linear")
+                    neural_net_model(i)%activation = 0
+                case ("relu")
+                    neural_net_model(i)%activation = 1
+                case ("sigmoid")
+                    neural_net_model(i)%activation = 2
+                case ("elu")
+                    neural_net_model(i)%activation = 3
+                case ("selu")
+                    neural_net_model(i)%activation = 4
+                case ("tanh")
+                    neural_net_model(i)%activation = 5
+                case ("softmax")
+                    neural_net_model(i)%activation = 6
+                case default
+                    neural_net_model(i)%activation = 7
+            end select
+        end do
+        call check(nf90_close(ncid),errstring)
+        if (trim(errstring) /= '') return
+
+    end subroutine init_neural_net
+
+    subroutine load_quantile_scale_values(filename, scale_values, iulog, errstring)
+        character(len = *), intent(in) :: filename
+        real(kind = r8), allocatable, intent(out) :: scale_values(:, :)
+        integer,          intent(in)  :: iulog
+        character(128),   intent(out) :: errstring  ! output status (non-blank for error return)
+
+        real(kind = r8), allocatable :: temp_scale_values(:, :)
+        character(len=8) :: quantile_dim_name = "quantile"
+        character(len=7) :: column_dim_name = "column"
+        character(len=9) :: ref_var_name = "reference"
+        character(len=9) :: quant_var_name = "quantiles"
+        integer :: ncid, quantile_id, column_id, quantile_dim, column_dim, ref_var_id, quant_var_id
+
+        errstring = ''
+
+        call check(nf90_open(filename, nf90_nowrite, ncid),errstring)
+        if (trim(errstring) /= '') return
+        call check(nf90_inq_dimid(ncid, quantile_dim_name, quantile_id),errstring)
+        if (trim(errstring) /= '') return
+        call check(nf90_inq_dimid(ncid, column_dim_name, column_id),errstring)
+        if (trim(errstring) /= '') return
+        call check(nf90_inquire_dimension(ncid, quantile_id, &
+                quantile_dim_name, quantile_dim),errstring)
+        if (trim(errstring) /= '') return
+        call check(nf90_inquire_dimension(ncid, column_id, &
+                column_dim_name, column_dim),errstring)
+        if (trim(errstring) /= '') return
+        allocate(scale_values(quantile_dim, column_dim + 1))
+        allocate(temp_scale_values(column_dim + 1, quantile_dim))
+        call check(nf90_inq_varid(ncid, ref_var_name, ref_var_id),errstring)
+        if (trim(errstring) /= '') return
+        write(iulog,*) "load ref var"
+        call check(nf90_get_var(ncid, ref_var_id, temp_scale_values(1, :)),errstring)
+        if (trim(errstring) /= '') return
+        call check(nf90_inq_varid(ncid, quant_var_name, quant_var_id),errstring)
+        if (trim(errstring) /= '') return
+        write(iulog,*) "load quant var"
+        call check(nf90_get_var(ncid, quant_var_id, temp_scale_values(2:column_dim + 1, :)),errstring)
+        if (trim(errstring) /= '') return
+        scale_values = transpose(temp_scale_values)
+        call check(nf90_close(ncid),errstring)
+        if (trim(errstring) /= '') return
+    end subroutine load_quantile_scale_values
+
+    subroutine linear_interp_forward(x_in, xs, ys, y_in)
+        real(kind = r8), dimension(:), intent(in) :: x_in
+        real(kind = r8), dimension(:), intent(in) :: xs
+        real(kind = r8), dimension(:), intent(in) :: ys
+        real(kind = r8), dimension(size(x_in, 1)), intent(out) :: y_in
+        integer :: i, j, jl, jr, x_in_size, xs_size, x_pos
+        real(kind = r8) :: slope
+        x_in_size = size(x_in)
+        xs_size = size(xs)
+        do i = 1, x_in_size
+            call binary_search_left(xs, x_in(i), jl)
+            call binary_search_right(xs, x_in(i), jr)
+            j = (jl + jr) / 2
+            if ((j == 1) .or. (j == xs_size) .or. (xs(j + 1) - xs(j) == 0)) then
+                y_in(i) = ys(j)
+            else
+                slope = (ys(j + 1) - ys(j)) / (xs(j + 1) - xs(j))
+                y_in(i) = slope * (x_in(i) - xs(j)) + ys(j)
+            end if
+        end do
+    end subroutine linear_interp_forward
+
+    subroutine linear_interp_inverse(x_in, xs, ys, y_in)
+        real(kind = r8), dimension(:), intent(in) :: x_in
+        real(kind = r8), dimension(:), intent(in) :: xs
+        real(kind = r8), dimension(:), intent(in) :: ys
+        real(kind = r8), dimension(size(x_in, 1)), intent(out) :: y_in
+        integer :: i, j, x_in_size, xs_size, x_pos
+        real(kind = r8) :: slope
+        x_in_size = size(x_in)
+        xs_size = size(xs)
+        do i = 1, x_in_size
+            call binary_search_left(xs, x_in(i), j)
+            if ((j == 1) .or. (j == xs_size) .or. (xs(j + 1) - xs(j) == 0)) then
+                y_in(i) = ys(j)
+            else
+                slope = (ys(j + 1) - ys(j)) / (xs(j + 1) - xs(j))
+                y_in(i) = slope * (x_in(i) - xs(j)) + ys(j)
+            end if
+        end do
+    end subroutine linear_interp_inverse
+
+    subroutine binary_search_left(x, target_val, val_index)
+        ! binary_search_left finds the leftmost index to insert
+        ! the target value in a sorted array x and returns
+        ! that index in val_index.
+        real(kind = r8), dimension(:), intent(in) :: x
+        real(kind = r8), intent(in) :: target_val
+        integer, intent(out) :: val_index
+        integer :: min_idx, max_idx, mid_idx
+        real(kind = r8) :: mid_val
+        min_idx = 1
+        max_idx = size(x)
+        mid_val = 1
+        mid_idx = 1
+        if (target_val <= x(min_idx)) then
+            max_idx = min_idx
+        end if
+        do while (min_idx < max_idx)
+            mid_idx = min_idx + (max_idx - min_idx) / 2
+            mid_val = x(mid_idx)
+            if (mid_val < target_val) then
+                min_idx = mid_idx + 1
+            else if (mid_val >= target_val) then
+                max_idx = mid_idx - 1
+            end if
+        end do
+        val_index = min_idx
+    end subroutine binary_search_left
+
+    subroutine binary_search_right(x, target_val, val_index)
+        ! binary_search_right finds the rightmost index to insert
+        ! the target value in a sorted array x and returns
+        ! that index in val_index.
+        real(kind = r8), dimension(:), intent(in) :: x
+        real(kind = r8), intent(in) :: target_val
+        integer, intent(out) :: val_index
+        integer :: min_idx, max_idx, mid_idx
+        real(kind = r8) :: mid_val
+        min_idx = 1
+        max_idx = size(x)
+        mid_idx = 1
+        if (target_val >= x(max_idx)) then
+            min_idx = max_idx
+        end if
+        do while (min_idx < max_idx)
+            mid_idx = min_idx + (max_idx - min_idx) / 2
+            mid_val = x(mid_idx)
+            if (mid_val <= target_val) then
+                min_idx = mid_idx + 1
+            else if (mid_val > target_val) then
+                max_idx = mid_idx - 1
+            end if
+        end do
+        val_index = max_idx
+    end subroutine binary_search_right
+
+    subroutine quantile_transform(x_inputs, scale_values, x_transformed)
+        real(kind = r8), dimension(:, :), intent(in) :: x_inputs
+        real(kind = r8), dimension(:, :), intent(in) :: scale_values
+        real(kind = r8), dimension(size(x_inputs, 1), size(x_inputs, 2)), intent(out) :: x_transformed
+        integer :: j, x_size, scale_size
+        x_size = size(x_inputs, 1)
+        scale_size = size(scale_values, 1)
+        do j = 1, size(x_inputs, 2)
+            call linear_interp_forward(x_inputs(:, j), scale_values(:, j + 1), &
+                    scale_values(:, 1), x_transformed(:, j))
+        end do
+    end subroutine quantile_transform
+
+    subroutine quantile_inv_transform(x_inputs, scale_values, x_transformed)
+        real(kind = r8), dimension(:, :), intent(in) :: x_inputs
+        real(kind = r8), dimension(:, :), intent(in) :: scale_values
+        real(kind = r8), dimension(size(x_inputs, 1), size(x_inputs, 2)), intent(out) :: x_transformed
+        integer :: j, x_size, scale_size
+        x_size = size(x_inputs, 1)
+        scale_size = size(scale_values, 1)
+        do j = 1, size(x_inputs, 2)
+            call linear_interp_inverse(x_inputs(:, j), scale_values(:, 1), scale_values(:, j + 1), x_transformed(:, j))
+        end do
+    end subroutine quantile_inv_transform
+
+    subroutine neural_net_predict(input, neural_net_model, prediction)
+        ! neural_net_predict
+        ! Description: generate prediction from neural network model for an arbitrary set of input values
+        !
+        ! Args:
+        ! input (input): 2D array of input values. Each row is a separate instance and each column is a model input.
+        ! neural_net_model (input): Array of type(Dense) objects
+        ! prediction (output): The prediction of the neural network as a 2D array of dimension (examples, outputs)
+        real(kind=r8), intent(in) :: input(:, :)
+        type(Dense), intent(in) :: neural_net_model(:)
+        real(kind=r8), intent(out) :: prediction(size(input, 1), neural_net_model(size(neural_net_model))%output_size)
+        integer :: bi, i, j, num_layers
+        integer :: batch_size
+        integer :: input_size
+        integer :: batch_index_size
+        integer, allocatable :: batch_indices(:)
+        type(DenseData) :: neural_net_data(size(neural_net_model))
+        input_size = size(input, 1)
+        num_layers = size(neural_net_model)
+        batch_size = neural_net_model(1)%batch_size
+        batch_index_size = input_size / batch_size
+        allocate(batch_indices(batch_index_size))
+        i = 1
+        do bi=batch_size, input_size, batch_size
+            batch_indices(i) = bi
+            i = i + 1
+        end do
+        do j=1, num_layers
+            allocate(neural_net_data(j)%input(batch_size, neural_net_model(j)%input_size))
+            allocate(neural_net_data(j)%output(batch_size, neural_net_model(j)%output_size))
+        end do
+        batch_indices(batch_index_size) = input_size
+        do bi=1, batch_index_size
+            neural_net_data(1)%input = input(batch_indices(bi)-batch_size+1:batch_indices(bi), :)
+            do i=1, num_layers - 1
+                call apply_dense(neural_net_data(i)%input, neural_net_model(i), neural_net_data(i)%output)
+                neural_net_data(i + 1)%input = neural_net_data(i)%output
+            end do
+            call apply_dense(neural_net_data(num_layers)%input, neural_net_model(num_layers), &
+                             neural_net_data(num_layers)%output)
+            prediction(batch_indices(bi)-batch_size + 1:batch_indices(bi), :) = &
+                    neural_net_data(num_layers)%output
+        end do
+        do j=1, num_layers
+            deallocate(neural_net_data(j)%input)
+            deallocate(neural_net_data(j)%output)
+        end do
+        deallocate(batch_indices)
+    end subroutine neural_net_predict
+
+    subroutine standard_scaler_transform(input_data, scale_values, transformed_data, errstring)
+        ! Perform z-score normalization of input_data table. Equivalent to scikit-learn StandardScaler.
+        !
+        ! Inputs:
+        !   input_data: 2D array where rows are examples and columns are variables
+        !   scale_values: 2D array where rows are the input variables and columns are mean and standard deviation
+        ! Output:
+        !   transformed_data: 2D array with the same shape as input_data containing the transformed values.
+        real(r8), intent(in) :: input_data(:, :)
+        real(r8), intent(in) :: scale_values(:, :)
+        real(r8), intent(out) :: transformed_data(size(input_data, 1), size(input_data, 2))
+        character(128),   intent(out) :: errstring  ! output status (non-blank for error return)
+        integer :: i
+
+        errstring = ''
+        if (size(input_data, 2) /= size(scale_values, 1)) then
+            write(errstring,*) "Size mismatch between input data and scale values", size(input_data, 2), size(scale_values, 1)
+            return
+        end if
+        do i=1, size(input_data, 2)
+            transformed_data(:, i) = (input_data(:, i) - scale_values(i, 1)) / scale_values(i, 2)
+        end do
+    end subroutine standard_scaler_transform
+
+    subroutine load_scale_values(filename, num_inputs, scale_values)
+        character(len=*), intent(in) :: filename
+        integer, intent(in) :: num_inputs
+        real(r8), intent(out) :: scale_values(num_inputs, 2)
+        character(len=40) :: row_name
+        integer :: isu, i
+        isu = 2
+        open(isu, file=filename, access="sequential", form="formatted")
+        read(isu, "(A)")
+        do i=1, num_inputs
+            read(isu, *) row_name, scale_values(i, 1), scale_values(i, 2)
+        end do
+        close(isu)
+    end subroutine load_scale_values
+
+
+    subroutine standard_scaler_inverse_transform(input_data, scale_values, transformed_data, errstring)
+        ! Perform inverse z-score normalization of input_data table. Equivalent to scikit-learn StandardScaler.
+        !
+        ! Inputs:
+        !   input_data: 2D array where rows are examples and columns are variables
+        !   scale_values: 2D array where rows are the input variables and columns are mean and standard deviation
+        ! Output:
+        !   transformed_data: 2D array with the same shape as input_data containing the transformed values.
+        real(r8), intent(in) :: input_data(:, :)
+        real(r8), intent(in) :: scale_values(:, :)
+        real(r8), intent(out) :: transformed_data(size(input_data, 1), size(input_data, 2))
+        character(128),   intent(out) :: errstring  ! output status (non-blank for error return)
+        integer :: i
+        if (size(input_data, 2) /= size(scale_values, 1)) then
+            write(errstring,*) "Size mismatch between input data and scale values", size(input_data, 2), size(scale_values, 1)
+            return
+        end if
+        do i=1, size(input_data, 2)
+            transformed_data(:, i) = input_data(:, i) * scale_values(i, 2) + scale_values(i, 1)
+        end do
+    end subroutine standard_scaler_inverse_transform
+
+    subroutine minmax_scaler_transform(input_data, scale_values, transformed_data, errstring)
+        ! Perform min-max scaling of input_data table. Equivalent to scikit-learn MinMaxScaler.
+        !
+        ! Inputs:
+        !   input_data: 2D array where rows are examples and columns are variables
+        !   scale_values: 2D array where rows are the input variables and columns are min and max.
+        ! Output:
+        !   transformed_data: 2D array with the same shape as input_data containing the transformed values.
+        real(r8), intent(in) :: input_data(:, :)
+        real(r8), intent(in) :: scale_values(:, :)
+        real(r8), intent(out) :: transformed_data(size(input_data, 1), size(input_data, 2))
+        character(128),   intent(out) :: errstring  ! output status (non-blank for error return)
+
+        integer :: i
+        if (size(input_data, 2) /= size(scale_values, 1)) then
+            write(errstring,*) "Size mismatch between input data and scale values", size(input_data, 2), size(scale_values, 1)
+            return
+        end if
+        do i=1, size(input_data, 2)
+            transformed_data(:, i) = (input_data(:, i) - scale_values(i, 1)) / (scale_values(i, 2) - scale_values(i ,1))
+        end do
+    end subroutine minmax_scaler_transform
+
+    subroutine minmax_scaler_inverse_transform(input_data, scale_values, transformed_data, errstring)
+        ! Perform inverse min-max scaling of input_data table. Equivalent to scikit-learn MinMaxScaler.
+        !
+        ! Inputs:
+        !   input_data: 2D array where rows are examples and columns are variables
+        !   scale_values: 2D array where rows are the input variables and columns are min and max.
+        ! Output:
+        !   transformed_data: 2D array with the same shape as input_data containing the transformed values.
+        real(r8), intent(in) :: input_data(:, :)
+        real(r8), intent(in) :: scale_values(:, :)
+        real(r8), intent(out) :: transformed_data(size(input_data, 1), size(input_data, 2))
+        character(128),   intent(out) :: errstring  ! output status (non-blank for error return)
+
+        integer :: i
+        if (size(input_data, 2) /= size(scale_values, 1)) then
+            write(errstring,*) "Size mismatch between input data and scale values", size(input_data, 2), size(scale_values, 1)
+            return
+        end if
+        do i=1, size(input_data, 2)
+            transformed_data(:, i) = input_data(:, i) * (scale_values(i, 2) - scale_values(i ,1)) + scale_values(i, 1)
+        end do
+    end subroutine minmax_scaler_inverse_transform
+
+    subroutine check(status, errstring)
+        ! Check for netCDF errors
+        integer, intent ( in) :: status
+        character(128),   intent(out) :: errstring  ! output status (non-blank for error return)
+
+        errstring = ''
+        if(status /= nf90_noerr) then
+          errstring = trim(nf90_strerror(status))
+        end if
+    end subroutine check
+
+end module module_neural_net

--- a/TAU_ML_microphysics/src/tau_neural_net_quantile.F90
+++ b/TAU_ML_microphysics/src/tau_neural_net_quantile.F90
@@ -1,0 +1,115 @@
+module tau_neural_net_quantile
+
+    use pumas_kinds,   only: r8=>kind_r8
+
+    use module_neural_net, only : Dense, init_neural_net, load_quantile_scale_values
+    use module_neural_net, only : quantile_transform, quantile_inv_transform, neural_net_predict
+    use tester, only : write_test_values
+
+    implicit none
+    integer, parameter, public :: i8 = selected_int_kind(18)
+    integer, parameter :: num_inputs = 9
+    integer, parameter :: num_outputs = 3
+    integer, parameter :: batch_size = 1
+
+    ! Neural networks and scale values saved within the scope of the module.
+    ! Need to call initialize_tau_emulators to load weights and tables from disk.
+    type(Dense), allocatable, save :: q_all(:)
+    real(r8), dimension(:, :), allocatable, save :: input_scale_values
+    real(r8), dimension(:, :), allocatable, save :: output_scale_values
+contains
+
+
+    subroutine initialize_tau_emulators( stochastic_emulated_filename_quantile, stochastic_emulated_filename_input_scale, &
+                                         stochastic_emulated_filename_output_scale, iulog, errstring)
+
+    ! Load neural network netCDF files and scaling values. Values are placed in to emulators,
+    ! input_scale_values, and output_scale_values.
+    character(len=*), intent(in) ::  stochastic_emulated_filename_quantile, stochastic_emulated_filename_input_scale, &
+                                     stochastic_emulated_filename_output_scale
+    integer,          intent(in)  :: iulog
+    character(128),   intent(out) :: errstring  ! output status (non-blank for error return)
+
+        errstring = ''
+
+        write(iulog,*) "Begin loading neural nets"
+        write(iulog,*) "emulated filepath is ", stochastic_emulated_filename_quantile
+        write(iulog,*) "input filepath is ", stochastic_emulated_filename_input_scale
+        write(iulog,*) "output filepath is ", stochastic_emulated_filename_output_scale
+        call init_neural_net(trim(stochastic_emulated_filename_quantile), batch_size, q_all, iulog, errstring)
+        if (trim(errstring) /= '') return
+        write(iulog,*) "End loading neural nets"
+        ! Load the scale values from a csv file.
+        call load_quantile_scale_values(trim(stochastic_emulated_filename_input_scale), input_scale_values, iulog, errstring)
+        call load_quantile_scale_values(trim(stochastic_emulated_filename_output_scale), output_scale_values, iulog, errstring)
+        write(iulog,*) "Loaded neural nets scaling values"
+
+    end subroutine initialize_tau_emulators
+
+
+    subroutine tau_emulated_cloud_rain_interactions(qc, nc, qr, nr, pgam, lamc, lamr, n0r, rho, lcldm, &
+            precip_frac, mgncol, q_small, qc_tend, qr_tend, nc_tend, nr_tend)
+        ! Calculates emulated tau microphysics tendencies from neural networks.
+        !
+        ! Input args:
+        !   qc: cloud water mixing ratio in kg kg-1
+        !   nc: cloud water number concentration in particles m-3
+        !   qr: rain water mixing ratio in kg kg-1
+        !   nr: rain water number concentration in particles m-3
+        !   pgam: cloud liquid droplet size parameter
+        !   lamc: cloud liquid size distribution parameter (slope)
+        !   n0r: rain size parameter (intercept)
+        !   lamr: rain size parameter (slope)
+        !   rho: density of air in kg m-3
+        !   q_small: minimum cloud water mixing ratio value for running the microphysics
+        !   mgncol: MG number of grid cells in vertical column
+        ! Output args:
+        !    qc_tend: qc tendency
+        !    qr_tend: qr tendency
+        !    nc_tend: nc tendency
+        !    nr_tend: nr tendency
+        !
+        integer, intent(in) :: mgncol
+        real(r8), dimension(mgncol), intent(in) :: qc, qr, nc, nr, pgam, lamc, n0r, lamr, rho, lcldm, precip_frac
+        real(r8), intent(in) :: q_small
+        real(r8), dimension(mgncol), intent(out) :: qc_tend, qr_tend, nc_tend, nr_tend
+        integer(i8) :: i, j
+        real(r8), dimension(batch_size, num_inputs) :: nn_inputs, nn_quantile_inputs
+        real(r8), dimension(batch_size, num_outputs) :: nn_quantile_outputs, nn_outputs
+        real(r8), parameter :: dt = 1800.0
+        character(len=128) :: filename
+
+        do i = 1, mgncol
+            if (qc(i) >= q_small) then
+                nn_inputs(1, 1) = qc(i)
+                nn_inputs(1, 2) = qr(i)
+                nn_inputs(1, 3) = nc(i)
+                nn_inputs(1, 4) = nr(i)
+                nn_inputs(1, 5) = pgam(i)
+                nn_inputs(1, 6) = lamc(i)
+                nn_inputs(1, 7) = lamr(i)
+                nn_inputs(1, 8) = n0r(i)
+                nn_inputs(1, 9) = rho(i)
+                ! nn_inputs(1, 6) = precip_frac(i)
+                ! nn_inputs(1, 7) = lcldm(i)
+
+                call quantile_transform(nn_inputs, input_scale_values, nn_quantile_inputs)
+
+                call neural_net_predict(nn_quantile_inputs, q_all, nn_quantile_outputs)
+
+                call quantile_inv_transform(nn_quantile_outputs, output_scale_values, nn_outputs)
+
+                qc_tend(i) = nn_outputs(1, 1)
+                qr_tend(i) = -qc_tend(i)
+                nc_tend(i) = nn_outputs(1, 2)
+                nr_tend(i) = nn_outputs(1, 3)
+            else
+                qc_tend(i) = 0._r8
+                qr_tend(i) = 0._r8
+                nc_tend(i) = 0._r8
+                nr_tend(i) = 0._r8
+            end if
+        end do
+
+    end subroutine tau_emulated_cloud_rain_interactions
+end module tau_neural_net_quantile

--- a/TAU_ML_microphysics/src/tester.F90
+++ b/TAU_ML_microphysics/src/tester.F90
@@ -1,0 +1,25 @@
+module tester
+    use pumas_kinds, only: r8=>kind_r8
+    implicit none
+    integer, parameter, public :: i8 = selected_int_kind(18)
+
+contains
+    subroutine write_test_values(filename, num_variables, nn_variables, batch_size)
+        character(len=128), intent(in) :: filename
+        integer(i8), intent(in) :: num_variables
+        integer(i8), intent(in) :: batch_size
+        real(r8), dimension(batch_size, num_variables), intent(in) :: nn_variables
+        logical :: itexists
+
+        inquire(file=filename, exist=itexists)
+        if (itexists) then
+            open(12, file=filename, status="old", position="append", action="write")
+                write(12, *) nn_variables
+            close(12)
+        else
+            open(12, file=filename, status="new", position="append", action="write")
+                write(12, *) nn_variables
+            close(12)
+        endif
+    end subroutine write_test_values
+end module tester


### PR DESCRIPTION
## Summary
- New topic folder documenting a neural-network emulator of PUMAS's TAU bin-resolved warm-rain microphysics, ported from the wkchuang/PUMAS fork (branch 1nn_tau_emulator) onto the CCPP-ized pumas_cam-release_v1.39 baseline in cesm3_0_alpha09e
- 9 NN inputs (adds cloud/rain size-distribution shape parameters pgam/lamc/lamr/n0r) vs. the 7-input version already upstream, dual forward/inverse quantile interpolation, in-cloud/in-precip inputs with lcldm/precip_frac rescaling applied afterward
- No FTorch/PyTorch dependency -- pure Fortran + netCDF
- **Critical gotcha documented up front:** this scheme (micro_mg_warm_rain) only exists in the CAM7 physics driver, not CAM6 -- a CAM6 compset (e.g. F2000climo) fails at startup with an unrecognized-namelist-variable error. Requires a CAM7 compset (e.g. F2000dev).

## Test plan
- [x] Built cleanly on Derecho (F2000dev/f09_f09_mg17, --run-unsupported since this compset/resolution pairing isn't yet validated)
- [x] 1-day smoke test run completed with micro_mg_warm_rain='emulated' -- NN weights load, scheme runs, no crash